### PR TITLE
feat(query): YdbQueryBuilder (issue #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,27 @@ await user.loadRelations(['roles']);
 
 `QueryOptions`: `trx`, `timeout` (мс), `signal` (AbortSignal), `limit` (по умолчанию 100, макс 1000), `offset`.
 
+## QueryBuilder
+
+Цепочный builder поверх Active Record (`src/query/`):
+
+```ts
+const photos = await PhotoEntity.query()
+  .where({ is_public: true })
+  .andWhere({ author_email: 'a@b.c' }) // encrypted + blind index — как в find
+  .orderBy('rating', 'DESC')
+  .addOrderBy('title')
+  .limit(20)
+  .offset(10)
+  .getMany();
+
+await PhotoEntity.query().where({ is_public: true }).getOne();   // первая или null
+await PhotoEntity.query().where({ is_public: true }).getCount(); // COUNT(*)
+const { sql, values } = await PhotoEntity.query().where({ is_public: true }).toYql(); // без выполнения
+```
+
+Условия — только равенство (AND). Поля в WHERE/ORDER BY валидируются по метаданным сущности.
+
 ## Декораторы
 
 - `@YdbEntity('table')` — имя таблицы; класс попадает в глобальный реестр сущностей (используется schema sync).

--- a/src/core/mapper.spec.ts
+++ b/src/core/mapper.spec.ts
@@ -1,0 +1,123 @@
+import { Uuid, Utf8, Int32, Int64, Bool, Double } from '@ydbjs/value/primitive';
+import { Optional } from '@ydbjs/value/optional';
+import { mapToYdb } from './mapper.js';
+
+describe('mapToYdb', () => {
+  describe('Uuid', () => {
+    it('wraps a UUID string into Uuid value', () => {
+      const val = mapToYdb('Uuid', '5ad91505-d4f6-4a81-ab65-9dbc68cf4ed5');
+      expect(val).toBeInstanceOf(Uuid);
+      expect(String(val)).toBe('5ad91505-d4f6-4a81-ab65-9dbc68cf4ed5');
+    });
+
+    it('returns Optional<Uuid> for null', () => {
+      const val = mapToYdb('Uuid', null);
+      expect(val).toBeInstanceOf(Optional);
+    });
+  });
+
+  describe('Utf8', () => {
+    it('wraps a string into Utf8 value', () => {
+      const val = mapToYdb('Utf8', 'hello');
+      expect(val).toBeInstanceOf(Utf8);
+      expect((val as any).value).toBe('hello');
+    });
+
+    it('handles unicode and emoji', () => {
+      const val = mapToYdb('Utf8', 'Привет 🌍');
+      expect((val as any).value).toBe('Привет 🌍');
+    });
+
+    it('returns Optional<Utf8> for null', () => {
+      const val = mapToYdb('Utf8', null);
+      expect(val).toBeInstanceOf(Optional);
+    });
+  });
+
+  describe('Int32', () => {
+    it('wraps an integer into Int32 value', () => {
+      const val = mapToYdb('Int32', 42);
+      expect(val).toBeInstanceOf(Int32);
+    });
+
+    it('handles zero', () => {
+      const val = mapToYdb('Int32', 0);
+      expect(val).toBeInstanceOf(Int32);
+    });
+
+    it('handles negative values', () => {
+      const val = mapToYdb('Int32', -100);
+      expect(val).toBeInstanceOf(Int32);
+    });
+
+    it('returns Optional<Int32> for null', () => {
+      const val = mapToYdb('Int32', null);
+      expect(val).toBeInstanceOf(Optional);
+    });
+  });
+
+  describe('Int64', () => {
+    it('wraps a BigInt into Int64 value', () => {
+      const val = mapToYdb('Int64', 9007199254740991n);
+      expect(val).toBeInstanceOf(Int64);
+    });
+
+    it('wraps a number into Int64 value', () => {
+      const val = mapToYdb('Int64', 123);
+      expect(val).toBeInstanceOf(Int64);
+    });
+
+    it('wraps a string into Int64 value', () => {
+      const val = mapToYdb('Int64', '9999999999999');
+      expect(val).toBeInstanceOf(Int64);
+    });
+
+    it('returns Optional<Int64> for null', () => {
+      const val = mapToYdb('Int64', null);
+      expect(val).toBeInstanceOf(Optional);
+    });
+  });
+
+  describe('Bool', () => {
+    it('wraps true into Bool value', () => {
+      const val = mapToYdb('Bool', true);
+      expect(val).toBeInstanceOf(Bool);
+    });
+
+    it('wraps false into Bool value', () => {
+      const val = mapToYdb('Bool', false);
+      expect(val).toBeInstanceOf(Bool);
+    });
+
+    it('returns Optional<Bool> for null', () => {
+      const val = mapToYdb('Bool', null);
+      expect(val).toBeInstanceOf(Optional);
+    });
+  });
+
+  describe('Double', () => {
+    it('wraps a number into Double value', () => {
+      const val = mapToYdb('Double', 3.14);
+      expect(val).toBeInstanceOf(Double);
+    });
+
+    it('returns Optional<Double> for null', () => {
+      const val = mapToYdb('Double', null);
+      expect(val).toBeInstanceOf(Optional);
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws on undefined value', () => {
+      expect(() => mapToYdb('Uuid', undefined)).toThrow(
+        /Undefined passed to YDB/,
+      );
+    });
+
+    it('throws on unsupported type', () => {
+      expect(() => mapToYdb('Foo' as any, 'bar')).toThrow(
+        /Unsupported YDB type/,
+      );
+    });
+  });
+});

--- a/src/core/sql-utils.spec.ts
+++ b/src/core/sql-utils.spec.ts
@@ -1,0 +1,49 @@
+import { quoteIdentifier, validateIdentifier } from './sql-utils.js';
+
+describe('quoteIdentifier', () => {
+  it('wraps a valid identifier in backticks', () => {
+    expect(quoteIdentifier('users')).toBe('`users`');
+  });
+
+  it('handles snake_case identifiers', () => {
+    expect(quoteIdentifier('email_encrypted')).toBe('`email_encrypted`');
+  });
+
+  it('handles identifiers starting with underscore', () => {
+    expect(quoteIdentifier('_bi')).toBe('`_bi`');
+  });
+
+  it('handles single-char identifiers', () => {
+    expect(quoteIdentifier('a')).toBe('`a`');
+  });
+
+  it('throws on identifier with spaces', () => {
+    expect(() => quoteIdentifier('my table')).toThrow(/Invalid SQL identifier/);
+  });
+
+  it('throws on identifier with special characters', () => {
+    expect(() => quoteIdentifier('col-name')).toThrow(/Invalid SQL identifier/);
+  });
+
+  it('throws on identifier starting with digit', () => {
+    expect(() => quoteIdentifier('1col')).toThrow(/Invalid SQL identifier/);
+  });
+
+  it('throws on empty string', () => {
+    expect(() => quoteIdentifier('')).toThrow(/Invalid SQL identifier/);
+  });
+});
+
+describe('validateIdentifier', () => {
+  it('does not throw for valid identifiers', () => {
+    expect(() => validateIdentifier('users', 'table')).not.toThrow();
+    expect(() => validateIdentifier('_private', 'column')).not.toThrow();
+    expect(() => validateIdentifier('col123', 'field')).not.toThrow();
+  });
+
+  it('throws for invalid identifiers with context message', () => {
+    expect(() => validateIdentifier('1bad', 'column')).toThrow(
+      /Invalid SQL identifier for column/,
+    );
+  });
+});

--- a/src/encryption/base64-test-encryption.provider.spec.ts
+++ b/src/encryption/base64-test-encryption.provider.spec.ts
@@ -1,0 +1,79 @@
+import { Base64TestEncryptionProvider } from './base64-test-encryption.provider.js';
+import type { YdbEncryptionContext } from './ydb-encryption-provider.interface.js';
+
+const context: YdbEncryptionContext = {
+  entityName: 'TestEntity',
+  tableName: 'test',
+  fieldName: 'email',
+  primaryKeyValue: 'some-uuid',
+  aadFields: {},
+};
+
+describe('Base64TestEncryptionProvider', () => {
+  const provider = new Base64TestEncryptionProvider();
+
+  describe('encrypt', () => {
+    it('encodes plaintext to base64', async () => {
+      const result = await provider.encrypt('hello world', '', context);
+      expect(result).toBe(Buffer.from('hello world').toString('base64'));
+    });
+
+    it('handles empty string', async () => {
+      const result = await provider.encrypt('', '', context);
+      expect(result).toBe('');
+    });
+
+    it('handles unicode', async () => {
+      const result = await provider.encrypt('Привет 🌍', '', context);
+      expect(result).toBe(Buffer.from('Привет 🌍').toString('base64'));
+    });
+  });
+
+  describe('decrypt', () => {
+    it('decodes base64 ciphertext to plaintext', async () => {
+      const ciphertext = Buffer.from('hello world').toString('base64');
+      const result = await provider.decrypt(ciphertext, '', context);
+      expect(result).toBe('hello world');
+    });
+
+    it('roundtrips unicode', async () => {
+      const plaintext = 'Привет 🌍';
+      const ciphertext = await provider.encrypt(plaintext, '', context);
+      const decrypted = await provider.decrypt(ciphertext, '', context);
+      expect(decrypted).toBe(plaintext);
+    });
+
+    it('handles empty ciphertext', async () => {
+      const result = await provider.decrypt('', '', context);
+      expect(result).toBe('');
+    });
+  });
+
+  describe('hash (blind index)', () => {
+    it('produces a deterministic hash from plaintext', async () => {
+      const h1 = await provider.hash('test@example.com', context);
+      const h2 = await provider.hash('test@example.com', context);
+      expect(h1).toBe(h2);
+      expect(typeof h1).toBe('string');
+      expect(h1.length).toBeGreaterThan(0);
+    });
+
+    it('produces different hashes for different inputs', async () => {
+      const h1 = await provider.hash('a@test.com', context);
+      const h2 = await provider.hash('b@test.com', context);
+      expect(h1).not.toBe(h2);
+    });
+
+    it('is deterministic regardless of context', async () => {
+      const ctx2: YdbEncryptionContext = {
+        entityName: 'Other',
+        tableName: 'other',
+        fieldName: 'other',
+        aadFields: {},
+      };
+      const h1 = await provider.hash('value', context);
+      const h2 = await provider.hash('value', ctx2);
+      expect(h1).toBe(h2);
+    });
+  });
+});

--- a/src/entity/base-entity.ts
+++ b/src/entity/base-entity.ts
@@ -20,6 +20,7 @@ import type {
   YdbEntityMetadata,
 } from '../metadata/entity-metadata.js';
 import { getEntityRuntime } from './entity-runtime.js';
+import { YdbQueryBuilder } from '../query/query-builder.js';
 
 export class YdbBaseEntity {
   static setExecutor(db: YdbExecutor): void {
@@ -636,6 +637,80 @@ export class YdbBaseEntity {
     );
     const sql = `SELECT COUNT(*) AS cnt FROM ${quoteIdentifier(meta.tableName)} ${whereClause}`;
 
+    const query = exec([sql] as unknown as TemplateStringsArray);
+    this.bindParams(query, values, keys, dbSchema);
+
+    const rows = await this.executeQuery<Record<string, any>[][]>(
+      query,
+      options,
+    );
+    return Number(rows[0]?.[0]?.cnt ?? 0);
+  }
+
+  /**
+   * Цепочный query builder: Entity.query().where(...).orderBy(...).getMany().
+   */
+  static query<T extends YdbBaseEntity>(
+    this: { new (): T } & typeof YdbBaseEntity,
+  ): YdbQueryBuilder<T> {
+    return new YdbQueryBuilder<T>(this);
+  }
+
+  /**
+   * @internal Мост для YdbQueryBuilder: собрать WHERE по метаданным сущности.
+   * Не является частью публичного API.
+   */
+  static _buildWhereClause(
+    this: typeof YdbBaseEntity,
+    where: Record<string, any>,
+  ) {
+    return this.buildWhere(where, this.getMeta());
+  }
+
+  /**
+   * @internal Мост для YdbQueryBuilder: выполнить SELECT и вернуть сущности
+   * (дешифровка + инстанцирование + eager relations).
+   */
+  static async _executeSelect<T extends YdbBaseEntity>(
+    this: { new (): T } & typeof YdbBaseEntity,
+    sql: string,
+    values: Record<string, any>,
+    keys: string[],
+    dbSchema: Record<string, YdbPrimitive>,
+    options?: QueryOptions,
+  ): Promise<T[]> {
+    const exec = this.getExecutor(options?.trx);
+    const query = exec([sql] as unknown as TemplateStringsArray);
+    this.bindParams(query, values, keys, dbSchema);
+
+    const rows = await this.executeQuery<Record<string, any>[][]>(
+      query,
+      options,
+    );
+    const raw = rows[0] ?? [];
+
+    const meta = this.getMeta();
+    await this.decryptResult(raw, meta);
+
+    const result = raw.map((r) => this.instantiate(r) as T);
+    if (result.length) {
+      await this.loadEagerRelations(result, options);
+    }
+    return result;
+  }
+
+  /**
+   * @internal Мост для YdbQueryBuilder: выполнить COUNT-запрос.
+   */
+  static async _executeCount(
+    this: typeof YdbBaseEntity,
+    sql: string,
+    values: Record<string, any>,
+    keys: string[],
+    dbSchema: Record<string, YdbPrimitive>,
+    options?: QueryOptions,
+  ): Promise<number> {
+    const exec = this.getExecutor(options?.trx);
     const query = exec([sql] as unknown as TemplateStringsArray);
     this.bindParams(query, values, keys, dbSchema);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,8 @@ export { EagerLoad } from './decorators/eager.decorator.js';
 
 // Active Record
 export { YdbBaseEntity } from './entity/base-entity.js';
+export { YdbQueryBuilder } from './query/query-builder.js';
+export type { BuiltQuery, OrderDirection } from './query/query-builder.js';
 
 // Шифрование
 export type {

--- a/src/metadata/entity-metadata.spec.ts
+++ b/src/metadata/entity-metadata.spec.ts
@@ -1,0 +1,97 @@
+import 'reflect-metadata';
+import { getYdbEntityMetadata } from './entity-metadata.js';
+import { YdbEntity } from '../decorators/entity.decorator.js';
+import { YdbColumn, YdbPrimaryColumn } from '../decorators/column.decorator.js';
+import {
+  YdbEncrypted,
+  YdbSecurityAAD,
+} from '../decorators/encryption.decorator.js';
+
+@YdbEntity('test_metadata')
+class TestEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid!: string;
+
+  @YdbColumn('Utf8')
+  name!: string;
+
+  @YdbColumn('Int32')
+  count!: number;
+
+  @YdbEncrypted({ blindIndex: true })
+  @YdbColumn('Utf8')
+  secret!: string;
+
+  @YdbEncrypted()
+  @YdbColumn('Utf8')
+  secret_no_blind!: string;
+
+  @YdbSecurityAAD()
+  @YdbColumn('Utf8')
+  tenant_id!: string;
+}
+
+@YdbEntity('test_no_cols')
+class EmptyEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid!: string;
+}
+
+class UndecoratedEntity {}
+
+describe('getYdbEntityMetadata', () => {
+  it('returns metadata for a decorated entity', () => {
+    const meta = getYdbEntityMetadata(TestEntity);
+    expect(meta).toBeDefined();
+    expect(meta!.tableName).toBe('test_metadata');
+    expect(meta!.schema).toEqual({
+      uuid: 'Uuid',
+      name: 'Utf8',
+      count: 'Int32',
+      secret: 'Utf8',
+      secret_no_blind: 'Utf8',
+      tenant_id: 'Utf8',
+    });
+    expect(meta!.primaryKeys).toEqual(['uuid']);
+  });
+
+  it('collects encrypted fields with blind index flag', () => {
+    const meta = getYdbEntityMetadata(TestEntity)!;
+    expect(meta.encryptedFields).toHaveLength(2);
+    expect(meta.encryptedFields).toContainEqual(
+      expect.objectContaining({
+        propertyKey: 'secret',
+        blindIndex: true,
+      }),
+    );
+    expect(meta.encryptedFields).toContainEqual(
+      expect.objectContaining({
+        propertyKey: 'secret_no_blind',
+        blindIndex: true,
+      }),
+    );
+  });
+
+  it('collects AAD fields sorted lexicographically', () => {
+    const meta = getYdbEntityMetadata(TestEntity)!;
+    expect(meta.aadFields).toEqual(['tenant_id']);
+  });
+
+  it('returns metadata for entity with no encrypted fields', () => {
+    const meta = getYdbEntityMetadata(EmptyEntity);
+    expect(meta).toBeDefined();
+    expect(meta!.encryptedFields).toEqual([]);
+    expect(meta!.aadFields).toEqual([]);
+  });
+
+  it('returns undefined for an undecorated class', () => {
+    const meta = getYdbEntityMetadata(UndecoratedEntity);
+    expect(meta).toBeUndefined();
+  });
+
+  it('caches metadata across calls', () => {
+    const meta1 = getYdbEntityMetadata(TestEntity);
+    const meta2 = getYdbEntityMetadata(TestEntity);
+    expect(meta1).toBe(meta2);
+  });
+});

--- a/src/query/query-builder.spec.ts
+++ b/src/query/query-builder.spec.ts
@@ -1,0 +1,127 @@
+import 'reflect-metadata';
+import { YdbEntity } from '../decorators/entity.decorator.js';
+import { YdbColumn, YdbPrimaryColumn } from '../decorators/column.decorator.js';
+import { YdbBaseEntity } from '../entity/base-entity.js';
+import { getEntityRuntime } from '../entity/entity-runtime.js';
+import { createMockExecutor } from '../../test/helpers/mock-executor.js';
+
+@YdbEntity('qb_photos')
+class QbPhotoEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @YdbColumn('Utf8')
+  title: string;
+
+  @YdbColumn('Bool')
+  is_public: boolean;
+
+  @YdbColumn('Double')
+  rating: number;
+}
+
+function mockRuntime(rows: any[][] = [[]]) {
+  const mock = createMockExecutor(rows);
+  getEntityRuntime(QbPhotoEntity).executor = mock.executor;
+  return mock;
+}
+
+describe('YdbQueryBuilder', () => {
+  it('builds SELECT with WHERE, ORDER BY, LIMIT/OFFSET', async () => {
+    mockRuntime();
+    const { sql, values } = await QbPhotoEntity.query()
+      .where({ is_public: true })
+      .andWhere({ title: 'Sunset' })
+      .orderBy('rating', 'DESC')
+      .addOrderBy('title')
+      .limit(20)
+      .offset(10)
+      .toYql();
+
+    expect(sql).toBe(
+      'SELECT * FROM `qb_photos` ' +
+        'WHERE `is_public` = $is_public AND `title` = $title ' +
+        'ORDER BY `rating` DESC, `title` ASC LIMIT 20 OFFSET 10',
+    );
+    expect(values).toEqual({ is_public: true, title: 'Sunset' });
+  });
+
+  it('builds SELECT without WHERE', async () => {
+    mockRuntime();
+    const { sql } = await QbPhotoEntity.query().toYql();
+    expect(sql).toBe('SELECT * FROM `qb_photos` LIMIT 100 OFFSET 0');
+  });
+
+  it('throws on unknown ORDER BY field', async () => {
+    mockRuntime();
+    await expect(QbPhotoEntity.query().orderBy('nope').toYql()).rejects.toThrow(
+      /Unknown field in ORDER BY: nope/,
+    );
+  });
+
+  it('throws on unknown WHERE field', async () => {
+    mockRuntime();
+    await expect(
+      QbPhotoEntity.query().where({ nope: 1 }).toYql(),
+    ).rejects.toThrow(/Unknown field in WHERE: nope/);
+  });
+
+  it('getMany executes through executor and returns entities', async () => {
+    const row = {
+      uuid: '5ad91505-d4f6-4a81-ab65-9dbc68cf4ed5',
+      title: 'Sunset',
+      is_public: true,
+      rating: 4.5,
+    };
+    const mock = mockRuntime([[row]]);
+
+    const result = await QbPhotoEntity.query()
+      .where({ is_public: true })
+      .getMany();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBeInstanceOf(QbPhotoEntity);
+    expect(result[0].title).toBe('Sunset');
+    expect(mock.queries[0].sql).toContain('WHERE `is_public` = $is_public');
+  });
+
+  it('getOne limits to 1 and returns first entity or null', async () => {
+    const mock = mockRuntime([
+      [
+        {
+          uuid: '5ad91505-d4f6-4a81-ab65-9dbc68cf4ed5',
+          title: 'Sunset',
+          is_public: true,
+          rating: 4.5,
+        },
+      ],
+    ]);
+
+    const one = await QbPhotoEntity.query().getOne();
+    expect(one?.title).toBe('Sunset');
+    expect(mock.queries[0].sql).toContain('LIMIT 1 OFFSET 0');
+
+    mockRuntime([[]]);
+    const none = await QbPhotoEntity.query().getOne();
+    expect(none).toBeNull();
+  });
+
+  it('getCount builds COUNT query without LIMIT', async () => {
+    const mock = mockRuntime([[{ cnt: 7 }]]);
+
+    const count = await QbPhotoEntity.query()
+      .where({ is_public: true })
+      .getCount();
+
+    expect(count).toBe(7);
+    expect(mock.queries[0].sql).toBe(
+      'SELECT COUNT(*) AS cnt FROM `qb_photos` WHERE `is_public` = $is_public',
+    );
+  });
+
+  it('clamps limit to 1000 and floor-offsets', async () => {
+    mockRuntime();
+    const { sql } = await QbPhotoEntity.query().limit(5000).offset(-5).toYql();
+    expect(sql).toContain('LIMIT 1000 OFFSET 0');
+  });
+});

--- a/src/query/query-builder.ts
+++ b/src/query/query-builder.ts
@@ -1,0 +1,182 @@
+import type { YdbBaseEntity } from '../entity/base-entity.js';
+import { getYdbEntityMetadata } from '../metadata/entity-metadata.js';
+import { quoteIdentifier } from '../core/sql-utils.js';
+import type { QueryOptions } from '../core/query-options.js';
+import type { YdbPrimitive } from '../core/types.js';
+
+export type OrderDirection = 'ASC' | 'DESC';
+
+/** Результат toYql(): собранный SQL и значения параметров (до маппинга в типы YDB). */
+export interface BuiltQuery {
+  sql: string;
+  values: Record<string, any>;
+}
+
+interface CompiledQuery extends BuiltQuery {
+  keys: string[];
+  dbSchema: Record<string, YdbPrimitive>;
+}
+
+type EntityClass<T extends YdbBaseEntity> = {
+  new (): T;
+} & typeof YdbBaseEntity;
+
+/**
+ * Цепочный query builder поверх Active Record сущности.
+ * Условия where/andWhere — только равенство, объединяются через AND
+ * (повторное поле в andWhere перезаписывает предыдущее).
+ * Зашифрованные поля с blind index поддерживаются так же, как в find/findAll.
+ *
+ * @example
+ *   const photos = await PhotoEntity.query()
+ *     .where({ is_public: true })
+ *     .orderBy('rating', 'DESC')
+ *     .limit(20)
+ *     .getMany();
+ */
+export class YdbQueryBuilder<T extends YdbBaseEntity> {
+  private whereValues: Record<string, any> = {};
+  private orderClauses: { field: string; direction: OrderDirection }[] = [];
+  private limitValue?: number;
+  private offsetValue?: number;
+  private queryOptions?: QueryOptions;
+
+  constructor(private readonly entity: EntityClass<T>) {}
+
+  /** Добавить условия равенства (AND). Повторный вызов дополняет условия. */
+  where(criteria: Record<string, any>): this {
+    this.whereValues = { ...this.whereValues, ...criteria };
+    return this;
+  }
+
+  /** Синоним where() для читаемости цепочек. */
+  andWhere(criteria: Record<string, any>): this {
+    return this.where(criteria);
+  }
+
+  orderBy(field: string, direction: OrderDirection = 'ASC'): this {
+    this.orderClauses = [{ field, direction }];
+    return this;
+  }
+
+  addOrderBy(field: string, direction: OrderDirection = 'ASC'): this {
+    this.orderClauses.push({ field, direction });
+    return this;
+  }
+
+  limit(limit: number): this {
+    this.limitValue = limit;
+    return this;
+  }
+
+  offset(offset: number): this {
+    this.offsetValue = offset;
+    return this;
+  }
+
+  /** QueryOptions: trx, signal, timeout. limit/offset из билдера приоритетнее. */
+  options(options: QueryOptions): this {
+    this.queryOptions = options;
+    return this;
+  }
+
+  /** Собирает SQL и значения параметров без выполнения. */
+  async toYql(): Promise<BuiltQuery> {
+    const { sql, values } = await this.build();
+    return { sql, values };
+  }
+
+  /** Выполняет запрос и возвращает сущности (с eager relations). */
+  async getMany(): Promise<T[]> {
+    const { sql, values, keys, dbSchema } = await this.build();
+    const rows = await this.entity._executeSelect(
+      sql,
+      values,
+      keys,
+      dbSchema,
+      this.queryOptions,
+    );
+    return rows as T[];
+  }
+
+  /** Алиас getMany(). */
+  execute(): Promise<T[]> {
+    return this.getMany();
+  }
+
+  /** Первая запись или null. */
+  async getOne(): Promise<T | null> {
+    const result = await this.limit(1).getMany();
+    return result[0] ?? null;
+  }
+
+  /** COUNT(*) по тем же условиям (без limit/offset/order). */
+  async getCount(): Promise<number> {
+    const meta = this.getMeta();
+    const { whereClause, values, keys, dbSchema } =
+      await this.entity._buildWhereClause(this.whereValues);
+    const sql =
+      `SELECT COUNT(*) AS cnt FROM ${quoteIdentifier(meta.tableName)}` +
+      `${whereClause ? ` ${whereClause}` : ''}`;
+    return this.entity._executeCount(
+      sql,
+      values,
+      keys,
+      dbSchema,
+      this.queryOptions,
+    );
+  }
+
+  private async build(): Promise<CompiledQuery> {
+    const meta = this.getMeta();
+    const { whereClause, values, keys, dbSchema } =
+      await this.entity._buildWhereClause(this.whereValues);
+    this.validateOrderFields(dbSchema);
+
+    const orderClause = this.orderClauses.length
+      ? ' ORDER BY ' +
+        this.orderClauses
+          .map((o) => `${quoteIdentifier(o.field)} ${o.direction}`)
+          .join(', ')
+      : '';
+
+    const sql =
+      `SELECT * FROM ${quoteIdentifier(meta.tableName)}` +
+      `${whereClause ? ` ${whereClause}` : ''}${orderClause}` +
+      ` LIMIT ${this.resolveLimit()} OFFSET ${this.resolveOffset()}`;
+
+    return { sql, values, keys, dbSchema };
+  }
+
+  private getMeta() {
+    const meta = getYdbEntityMetadata(this.entity);
+    if (!meta) {
+      throw new Error(
+        `Class ${this.entity.name} is not decorated with @YdbEntity`,
+      );
+    }
+    return meta;
+  }
+
+  private validateOrderFields(dbSchema: Record<string, YdbPrimitive>): void {
+    for (const { field } of this.orderClauses) {
+      if (!dbSchema[field]) {
+        throw new Error(
+          `Unknown field in ORDER BY: ${field} (entity ${this.entity.name})`,
+        );
+      }
+    }
+  }
+
+  private resolveLimit(): number {
+    const value = this.limitValue ?? this.queryOptions?.limit;
+    const num = Number.isFinite(value) ? Math.floor(value as number) : 100;
+    return Math.max(1, Math.min(num, 1000));
+  }
+
+  private resolveOffset(): number {
+    const value = this.offsetValue ?? this.queryOptions?.offset;
+    const num = Number.isFinite(value) ? Math.floor(value as number) : 0;
+    return Math.max(0, num);
+  }
+}

--- a/test/base-entity-crud.spec.ts
+++ b/test/base-entity-crud.spec.ts
@@ -1,0 +1,428 @@
+import 'reflect-metadata';
+import { Uuid } from '@ydbjs/value/primitive';
+import { UserEntity } from './fixtures/user/user.entity.js';
+import { UserRoleEntity } from './fixtures/user_role/user_role.entity.js';
+import { PhotoEntity } from './fixtures/photo/photo.entity.js';
+import { createMockExecutor } from './helpers/mock-executor.js';
+import { Base64TestEncryptionProvider } from '../src/encryption/base64-test-encryption.provider.js';
+
+const userRow = {
+  uuid: '5ad91505-d4f6-4a81-ab65-9dbc68cf4ed5',
+  email_encrypted: 'enc',
+  full_name: 'Ivan',
+};
+
+describe('BaseEntity CRUD (mock executor)', () => {
+  afterEach(() => {
+    // Сброс executor/providers у всех тестовых сущностей
+    UserEntity.setExecutor(undefined as any);
+    UserEntity.setEncryptionProvider(undefined as any);
+    UserEntity.setBlindIndexProvider(undefined as any);
+    UserRoleEntity.setExecutor(undefined as any);
+    UserRoleEntity.setEncryptionProvider(undefined as any);
+    UserRoleEntity.setBlindIndexProvider(undefined as any);
+    PhotoEntity.setExecutor(undefined as any);
+    PhotoEntity.setEncryptionProvider(undefined as any);
+    PhotoEntity.setBlindIndexProvider(undefined as any);
+  });
+
+  describe('find()', () => {
+    it('returns an entity instance when row exists', async () => {
+      const mock = createMockExecutor([[userRow]]);
+      UserEntity.setExecutor(mock.executor);
+
+      const user = await UserEntity.find({ uuid: userRow.uuid });
+
+      expect(user).toBeInstanceOf(UserEntity);
+      expect(user?.uuid).toBe(userRow.uuid);
+      expect(user?.full_name).toBe('Ivan');
+
+      const [q] = mock.queries;
+      expect(q.sql).toContain('SELECT * FROM `users`');
+      expect(q.sql).toContain('WHERE `uuid` = $uuid');
+      expect(q.sql).toContain('LIMIT 1');
+      expect(q.params.uuid).toBeInstanceOf(Uuid);
+    });
+
+    it('returns null when no row matches', async () => {
+      const mock = createMockExecutor([[]]);
+      UserEntity.setExecutor(mock.executor);
+
+      const user = await UserEntity.find({ uuid: userRow.uuid });
+      expect(user).toBeNull();
+    });
+
+    it('throws when called without conditions', async () => {
+      const mock = createMockExecutor([[]]);
+      UserEntity.setExecutor(mock.executor);
+
+      await expect(UserEntity.find({})).rejects.toThrow(
+        /requires at least one condition/,
+      );
+    });
+
+    it('passes multiple WHERE conditions', async () => {
+      const roleRow = {
+        user_uuid: '5ad91505-d4f6-4a81-ab65-9dbc68cf4ed5',
+        role_uuid: '00000000-0000-0000-0000-000000000002',
+        organization_uuid: '00000000-0000-0000-0000-000000000003',
+        is_global: true,
+      };
+      const mock = createMockExecutor([[roleRow]]);
+      UserRoleEntity.setExecutor(mock.executor);
+
+      await UserRoleEntity.find({
+        user_uuid: roleRow.user_uuid,
+        role_uuid: roleRow.role_uuid,
+      });
+
+      const [q] = mock.queries;
+      expect(q.sql).toContain('`user_uuid` = $user_uuid');
+      expect(q.sql).toContain('`role_uuid` = $role_uuid');
+      expect(q.sql).toContain('AND');
+    });
+
+    it('throws for unknown field in WHERE', async () => {
+      const mock = createMockExecutor([[]]);
+      UserEntity.setExecutor(mock.executor);
+
+      await expect(
+        UserEntity.find({ uuid: userRow.uuid, no_such_field: 'x' }),
+      ).rejects.toThrow(/Unknown field in WHERE/);
+    });
+
+    it('passes options to executor', async () => {
+      const mock = createMockExecutor([[userRow]]);
+      UserEntity.setExecutor(mock.executor);
+
+      const signal = AbortSignal.timeout(5000);
+      await UserEntity.find({ uuid: userRow.uuid }, { timeout: 100, signal });
+
+      const [q] = mock.queries;
+      expect(q.sql).toContain('SELECT *');
+    });
+  });
+
+  describe('findAll()', () => {
+    it('returns multiple entities', async () => {
+      const mock = createMockExecutor([
+        [
+          userRow,
+          {
+            ...userRow,
+            uuid: '00000000-0000-0000-0000-000000000002',
+            full_name: 'Petr',
+          },
+        ],
+      ]);
+      UserEntity.setExecutor(mock.executor);
+
+      const users = await UserEntity.findAll();
+      expect(users).toHaveLength(2);
+      expect(users[0]).toBeInstanceOf(UserEntity);
+      expect(users[1]).toBeInstanceOf(UserEntity);
+    });
+
+    it('returns empty array when no rows', async () => {
+      const mock = createMockExecutor([[]]);
+      UserEntity.setExecutor(mock.executor);
+
+      const users = await UserEntity.findAll();
+      expect(users).toEqual([]);
+    });
+
+    it('applies LIMIT and OFFSET', async () => {
+      const mock = createMockExecutor([[]]);
+      UserEntity.setExecutor(mock.executor);
+
+      await UserEntity.findAll({}, { limit: 50, offset: 20 });
+
+      const [q] = mock.queries;
+      expect(q.sql).toContain('LIMIT 50');
+      expect(q.sql).toContain('OFFSET 20');
+    });
+
+    it('clamps limit to 1-1000 range', async () => {
+      const mock = createMockExecutor([[]]);
+      UserEntity.setExecutor(mock.executor);
+
+      await UserEntity.findAll({}, { limit: 9999 });
+      expect(mock.queries[0].sql).toContain('LIMIT 1000');
+
+      await UserEntity.findAll({}, { limit: -1 });
+      expect(mock.queries[1].sql).toContain('LIMIT 1');
+    });
+
+    it('uses default limit 100 and offset 0', async () => {
+      const mock = createMockExecutor([[]]);
+      UserEntity.setExecutor(mock.executor);
+
+      await UserEntity.findAll();
+      const [q] = mock.queries;
+      expect(q.sql).toContain('LIMIT 100');
+      expect(q.sql).toContain('OFFSET 0');
+    });
+
+    it('applies WHERE conditions', async () => {
+      const mock = createMockExecutor([[]]);
+      UserEntity.setExecutor(mock.executor);
+
+      await UserEntity.findAll({ uuid: userRow.uuid });
+
+      const [q] = mock.queries;
+      expect(q.sql).toContain('WHERE `uuid` = $uuid');
+    });
+  });
+
+  describe('count()', () => {
+    it('returns count from result', async () => {
+      const mock = createMockExecutor([[{ cnt: 42 }]]);
+      UserEntity.setExecutor(mock.executor);
+
+      const count = await UserEntity.count();
+      expect(count).toBe(42);
+
+      const [q] = mock.queries;
+      expect(q.sql).toContain('SELECT COUNT(*) AS cnt');
+    });
+
+    it('returns 0 when cnt is missing', async () => {
+      const mock = createMockExecutor([[{}]]);
+      UserEntity.setExecutor(mock.executor);
+
+      const count = await UserEntity.count();
+      expect(count).toBe(0);
+    });
+
+    it('passes WHERE conditions', async () => {
+      const mock = createMockExecutor([[{ cnt: 5 }]]);
+      UserEntity.setExecutor(mock.executor);
+
+      const count = await UserEntity.count({ uuid: userRow.uuid });
+      expect(count).toBe(5);
+
+      const [q] = mock.queries;
+      expect(q.sql).toContain('WHERE `uuid` = $uuid');
+    });
+  });
+
+  describe('save() — insert', () => {
+    it('generates uuid and runs UPSERT when entity has no uuid', async () => {
+      const provider = new Base64TestEncryptionProvider();
+      UserEntity.setEncryptionProvider(provider);
+      UserEntity.setBlindIndexProvider(provider);
+      const mock = createMockExecutor([[]]);
+      UserEntity.setExecutor(mock.executor);
+
+      const user = new UserEntity();
+      user.email_encrypted = 'test@test.com';
+      user.full_name = 'New User';
+
+      const saved = await UserEntity.save(user);
+
+      expect(saved).toBe(user);
+      expect(saved.uuid).toBeDefined();
+      expect(typeof saved.uuid).toBe('string');
+      expect(saved.uuid.length).toBe(36);
+
+      const [q] = mock.queries;
+      expect(q.sql).toContain('UPSERT INTO `users`');
+      expect(q.sql).toContain('`uuid`');
+      expect(q.sql).toContain('`email_encrypted`');
+      expect(q.sql).toContain('`full_name`');
+    });
+
+    it('skips undefined fields in UPSERT', async () => {
+      const provider = new Base64TestEncryptionProvider();
+      UserEntity.setEncryptionProvider(provider);
+      UserEntity.setBlindIndexProvider(provider);
+      const mock = createMockExecutor([[]]);
+      UserEntity.setExecutor(mock.executor);
+
+      const user = new UserEntity();
+      user.full_name = 'Only Name';
+
+      await UserEntity.save(user);
+
+      const [q] = mock.queries;
+      expect(q.sql).not.toContain('`email_encrypted`');
+    });
+  });
+
+  describe('save() — update', () => {
+    it('runs UPDATE RETURNING * when entity has uuid', async () => {
+      const provider = new Base64TestEncryptionProvider();
+      UserEntity.setEncryptionProvider(provider);
+      UserEntity.setBlindIndexProvider(provider);
+      const updatedRow = {
+        ...userRow,
+        email_encrypted: Buffer.from('enc').toString('base64'),
+        full_name: Buffer.from('Updated').toString('base64'),
+      };
+      const mock = createMockExecutor([[updatedRow]]);
+      UserEntity.setExecutor(mock.executor);
+
+      const user = new UserEntity();
+      user.uuid = userRow.uuid;
+      user.full_name = 'Updated';
+
+      const saved = await UserEntity.save(user);
+
+      expect(saved.full_name).toBe('Updated');
+
+      const [q] = mock.queries;
+      expect(q.sql).toContain('UPDATE `users`');
+      expect(q.sql).toContain('SET');
+      expect(q.sql).toContain('WHERE `uuid` = $uuid');
+      expect(q.sql).toContain('RETURNING *');
+    });
+
+    it('throws when updating non-existent entity', async () => {
+      const provider = new Base64TestEncryptionProvider();
+      UserEntity.setEncryptionProvider(provider);
+      UserEntity.setBlindIndexProvider(provider);
+      const mock = createMockExecutor([[]]);
+      UserEntity.setExecutor(mock.executor);
+
+      const user = new UserEntity();
+      user.uuid = userRow.uuid;
+      user.full_name = 'Ghost';
+
+      await expect(UserEntity.save(user)).rejects.toThrow(
+        /not found — nothing to update/,
+      );
+    });
+
+    it('excludes uuid from SET clause', async () => {
+      const provider = new Base64TestEncryptionProvider();
+      UserEntity.setEncryptionProvider(provider);
+      UserEntity.setBlindIndexProvider(provider);
+      const mock = createMockExecutor([[userRow]]);
+      UserEntity.setExecutor(mock.executor);
+
+      const user = new UserEntity();
+      user.uuid = userRow.uuid;
+      user.full_name = 'Test';
+
+      await UserEntity.save(user);
+
+      const [q] = mock.queries;
+      const setClause = q.sql.split('SET')[1]?.split('WHERE')[0] ?? '';
+      expect(setClause).not.toContain('`uuid` =');
+    });
+  });
+
+  describe('delete()', () => {
+    it('returns deleted entity when it exists', async () => {
+      const mock = createMockExecutor([[userRow]]);
+      UserEntity.setExecutor(mock.executor);
+
+      const deleted = await UserEntity.delete(userRow.uuid);
+
+      expect(deleted).toBeInstanceOf(UserEntity);
+      expect(deleted?.uuid).toBe(userRow.uuid);
+
+      const [q] = mock.queries;
+      expect(q.sql).toContain('DELETE FROM `users`');
+      expect(q.sql).toContain('WHERE `uuid` = $pk');
+      expect(q.sql).toContain('RETURNING *');
+    });
+
+    it('returns null when no entity matches', async () => {
+      const mock = createMockExecutor([[]]);
+      UserEntity.setExecutor(mock.executor);
+
+      const deleted = await UserEntity.delete(userRow.uuid);
+      expect(deleted).toBeNull();
+    });
+  });
+
+  describe('insertMany()', () => {
+    it('batches entities and runs UPSERT', async () => {
+      const mock = createMockExecutor([[]]);
+      UserRoleEntity.setExecutor(mock.executor);
+
+      const roles = Array.from({ length: 3 }, () => new UserRoleEntity());
+      await UserRoleEntity.insertMany(roles);
+
+      const [q] = mock.queries;
+      expect(q.sql).toContain('UPSERT INTO `user_roles`');
+      expect(q.sql).toContain('`user_uuid`');
+      expect(q.sql).toContain('`role_uuid`');
+      expect(q.sql).toContain('`organization_uuid`');
+      expect(q.sql).toContain('`is_global`');
+    });
+
+    it('returns empty array for empty input', async () => {
+      const mock = createMockExecutor([[]]);
+      UserEntity.setExecutor(mock.executor);
+
+      const result = await UserEntity.insertMany([]);
+      expect(result).toEqual([]);
+      expect(mock.queries).toHaveLength(0);
+    });
+
+    it('splits into batches of 100', async () => {
+      const provider = new Base64TestEncryptionProvider();
+      PhotoEntity.setEncryptionProvider(provider);
+      PhotoEntity.setBlindIndexProvider(provider);
+      const mock = createMockExecutor([[]]);
+      PhotoEntity.setExecutor(mock.executor);
+
+      const photos = Array.from({ length: 150 }, () => {
+        const p = new PhotoEntity();
+        p.title = 'test';
+        return p;
+      });
+      await PhotoEntity.insertMany(photos);
+
+      expect(mock.queries).toHaveLength(2);
+      expect(mock.queries[0].sql).toContain('UPSERT INTO `photos`');
+      expect(mock.queries[1].sql).toContain('UPSERT INTO `photos`');
+    });
+  });
+
+  describe('executor not set', () => {
+    it('throws when executor is not configured', async () => {
+      // PhotoEntity has no executor set
+      await expect(PhotoEntity.findAll()).rejects.toThrow(
+        /YDB executor not set/,
+      );
+    });
+  });
+
+  describe('encrypt / decrypt pipeline', () => {
+    it('encrypts on save and decrypts on find', async () => {
+      const provider = new Base64TestEncryptionProvider();
+      UserEntity.setEncryptionProvider(provider);
+      UserEntity.setBlindIndexProvider(provider);
+
+      const mock = createMockExecutor([[]]);
+      UserEntity.setExecutor(mock.executor);
+
+      // Save: should encrypt email_encrypted
+      const user = new UserEntity();
+      user.email_encrypted = 'plain@example.com';
+      user.full_name = 'Enc Test';
+      await UserEntity.save(user);
+
+      const saveQ = mock.queries[0];
+      const emailParam = saveQ.params.email_encrypted;
+      // Should be base64-encoded
+      expect(String((emailParam as any).value)).toBe(
+        Buffer.from('plain@example.com').toString('base64'),
+      );
+
+      // Find: should decrypt
+      const encryptedEmail =
+        Buffer.from('plain@example.com').toString('base64');
+      const mock2 = createMockExecutor([
+        [{ ...userRow, email_encrypted: encryptedEmail }],
+      ]);
+      UserEntity.setExecutor(mock2.executor);
+
+      const found = await UserEntity.find({ uuid: userRow.uuid });
+      expect(found?.email_encrypted).toBe('plain@example.com');
+    });
+  });
+});


### PR DESCRIPTION
## QueryBuilder

Цепочный builder поверх Active Record, `src/query/query-builder.ts`:

```ts
await PhotoEntity.query()
  .where({ is_public: true })
  .orderBy('rating', 'DESC')
  .limit(20)
  .getMany();
```

- `where/andWhere` (равенство, AND; encrypted + blind index — та же логика, что в `find`), `orderBy/addOrderBy`, `limit/offset` (clamp 1..1000), `options({trx, signal, timeout})`
- `toYql()` — SQL + параметры без выполнения; `getMany()` / `execute()` / `getOne()` / `getCount()`
- Поля WHERE/ORDER BY валидируются по метаданным сущности
- Мост к сущности — `@internal` статики `_buildWhereClause` / `_executeSelect` / `_executeCount` в `base-entity.ts`
- 8 новых unit-тестов (`src/query/query-builder.spec.ts`), всего 136/136 зелёных, lint без ошибок

Closes #1