### PR TITLE
feat(types): Float, Date, Datetime, Timestamp (issue #2)

### DIFF
--- a/src/core/mapper.spec.ts
+++ b/src/core/mapper.spec.ts
@@ -1,4 +1,15 @@
-import { Uuid, Utf8, Int32, Int64, Bool, Double } from '@ydbjs/value/primitive';
+import {
+  Uuid,
+  Utf8,
+  Int32,
+  Int64,
+  Bool,
+  Double,
+  Float,
+  Date as YdbDate,
+  Datetime,
+  Timestamp,
+} from '@ydbjs/value/primitive';
 import { Optional } from '@ydbjs/value/optional';
 import { mapToYdb } from './mapper.js';
 
@@ -104,6 +115,42 @@ describe('mapToYdb', () => {
     it('returns Optional<Double> for null', () => {
       const val = mapToYdb('Double', null);
       expect(val).toBeInstanceOf(Optional);
+    });
+  });
+
+  describe('Float', () => {
+    it('wraps a number into Float value', () => {
+      const val = mapToYdb('Float', 1.5);
+      expect(val).toBeInstanceOf(Float);
+    });
+
+    it('returns Optional<Float> for null', () => {
+      const val = mapToYdb('Float', null);
+      expect(val).toBeInstanceOf(Optional);
+    });
+  });
+
+  describe('Date / Datetime / Timestamp', () => {
+    const jsDate = new global.Date('2026-08-18T12:30:00.000Z');
+
+    it('wraps Date instance into YDB Date', () => {
+      expect(mapToYdb('Date', jsDate)).toBeInstanceOf(YdbDate);
+    });
+
+    it('wraps ISO string into Datetime', () => {
+      expect(mapToYdb('Datetime', '2026-08-18T12:30:00.000Z')).toBeInstanceOf(
+        Datetime,
+      );
+    });
+
+    it('wraps epoch ms into Timestamp', () => {
+      expect(mapToYdb('Timestamp', jsDate.getTime())).toBeInstanceOf(Timestamp);
+    });
+
+    it('returns Optional for null', () => {
+      expect(mapToYdb('Date', null)).toBeInstanceOf(Optional);
+      expect(mapToYdb('Datetime', null)).toBeInstanceOf(Optional);
+      expect(mapToYdb('Timestamp', null)).toBeInstanceOf(Optional);
     });
   });
 

--- a/src/core/mapper.ts
+++ b/src/core/mapper.ts
@@ -12,6 +12,14 @@ import {
   BoolType,
   Double,
   DoubleType,
+  Float,
+  FloatType,
+  Date as YdbDate,
+  DateType,
+  Datetime,
+  DatetimeType,
+  Timestamp,
+  TimestampType,
 } from '@ydbjs/value/primitive';
 import { Optional } from '@ydbjs/value/optional';
 
@@ -23,7 +31,16 @@ const nullTypeFactories = {
   Int64: () => new Int64Type(),
   Bool: () => new BoolType(),
   Double: () => new DoubleType(),
+  Float: () => new FloatType(),
+  Date: () => new DateType(),
+  Datetime: () => new DatetimeType(),
+  Timestamp: () => new TimestampType(),
 } satisfies Record<YdbPrimitive, () => unknown>;
+
+/** Нормализация JS-даты: принимает Date, число (мс) или ISO-строку. */
+function toJsDate(value: Date | number | string): Date {
+  return value instanceof Date ? value : new Date(value);
+}
 
 /** Обёртки JS-значений в YDB-значения. */
 const valueMappers: Record<YdbPrimitive, (value: any) => unknown> = {
@@ -33,6 +50,10 @@ const valueMappers: Record<YdbPrimitive, (value: any) => unknown> = {
   Int64: (value: bigint | number | string) => new Int64(BigInt(value)),
   Bool: (value: boolean) => new Bool(value),
   Double: (value: number) => new Double(value),
+  Float: (value: number) => new Float(value),
+  Date: (value: Date | number | string) => new YdbDate(toJsDate(value)),
+  Datetime: (value: Date | number | string) => new Datetime(toJsDate(value)),
+  Timestamp: (value: Date | number | string) => new Timestamp(toJsDate(value)),
 };
 
 export function mapToYdb(type: YdbPrimitive, value: unknown) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,2 +1,11 @@
 export type YdbPrimitive =
-  'Uuid' | 'Utf8' | 'Int32' | 'Int64' | 'Bool' | 'Double';
+  | 'Uuid'
+  | 'Utf8'
+  | 'Int32'
+  | 'Int64'
+  | 'Bool'
+  | 'Double'
+  | 'Float'
+  | 'Date'
+  | 'Datetime'
+  | 'Timestamp';

--- a/src/schema/schema-sync.ts
+++ b/src/schema/schema-sync.ts
@@ -66,6 +66,10 @@ const PRIMITIVE_TO_TYPE_ID: Record<YdbPrimitive, Type_PrimitiveTypeId> = {
   Int64: Type_PrimitiveTypeId.INT64,
   Bool: Type_PrimitiveTypeId.BOOL,
   Double: Type_PrimitiveTypeId.DOUBLE,
+  Float: Type_PrimitiveTypeId.FLOAT,
+  Date: Type_PrimitiveTypeId.DATE,
+  Datetime: Type_PrimitiveTypeId.DATETIME,
+  Timestamp: Type_PrimitiveTypeId.TIMESTAMP,
 };
 
 const TYPE_ID_TO_PRIMITIVE = new Map<Type_PrimitiveTypeId, YdbPrimitive>(


### PR DESCRIPTION
## Новые типы в маппере TS→YDB

- `Float`, `Date`, `Datetime`, `Timestamp` добавлены в `YdbPrimitive`, `mapToYdb` и schema sync (`PRIMITIVE_TO_TYPE_ID`)
- Даты принимают `Date`, epoch ms или ISO-строку
- `Decimal`/`DyNumber` из исходного пункта TODO не добавлены: в `@ydbjs/value` таких классов нет — отдельной задачей при появлении поддержки в драйвере
- Тесты маппера расширены (136+ → всё зелёное), lint без ошибок

Closes #2