### PR TITLE
feat(metadata): валидация метаданных на старте (issue #3)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,8 @@ export { Base64TestEncryptionProvider } from './encryption/base64-test-encryptio
 
 // Метаданные и реестр сущностей
 export { getYdbEntityMetadata } from './metadata/entity-metadata.js';
+export { validateEntityMetadata } from './metadata/validate-entity.js';
+export type { EntityValidationContext } from './metadata/validate-entity.js';
 export type {
   YdbEntityMetadata,
   EncryptedFieldMeta,

--- a/src/metadata/validate-entity.spec.ts
+++ b/src/metadata/validate-entity.spec.ts
@@ -1,0 +1,230 @@
+import 'reflect-metadata';
+import { YdbEntity } from '../decorators/entity.decorator.js';
+import { YdbColumn, YdbPrimaryColumn } from '../decorators/column.decorator.js';
+import { YdbEncrypted } from '../decorators/encryption.decorator.js';
+import {
+  ManyToMany,
+  JoinTable,
+  OneToMany,
+  OneToOne,
+} from '../decorators/relation.decorators.js';
+import { YdbBaseEntity } from '../entity/base-entity.js';
+import {
+  validateEntityMetadata,
+  EntityValidationContext,
+} from './validate-entity.js';
+
+const ctx: EntityValidationContext = {
+  encryptionProviderConfigured: true,
+  blindIndexProviderConfigured: true,
+};
+
+const noProviders: EntityValidationContext = {
+  encryptionProviderConfigured: false,
+  blindIndexProviderConfigured: false,
+};
+
+@YdbEntity('v_users')
+class ValidUser extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @YdbEncrypted({ blindIndex: true })
+  @YdbColumn('Utf8')
+  email: string;
+}
+
+@YdbEntity('v_roles')
+class ValidRole extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @YdbColumn('Uuid')
+  user_uuid: string;
+}
+
+@YdbEntity('v_with_rel')
+class ValidWithRelations extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @YdbColumn('Uuid')
+  user_uuid: string;
+
+  @OneToMany(() => ValidRole, 'user_uuid')
+  roles?: ValidRole[];
+
+  @OneToOne(() => ValidUser, 'user_uuid')
+  user?: ValidUser;
+}
+
+class NotAnEntity extends YdbBaseEntity {}
+
+@YdbEntity('v_missing_pk_col')
+class MissingPkColumn extends YdbBaseEntity {
+  @YdbColumn('Utf8')
+  name: string;
+}
+
+@YdbEntity('v_enc_pk')
+class EncryptedPk extends YdbBaseEntity {
+  @YdbEncrypted()
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+}
+
+@YdbEntity('v_enc')
+class EncryptedNoColumn extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @YdbEncrypted()
+  secret: string;
+}
+
+@YdbEntity('v_bad_rel_target')
+class BadRelTarget extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @OneToMany(() => NotAnEntity, 'owner_uuid')
+  items?: NotAnEntity[];
+}
+
+@YdbEntity('v_bad_join_col')
+class BadJoinColumn extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @OneToMany(() => ValidRole, 'no_such_column')
+  roles?: ValidRole[];
+}
+
+@YdbEntity('v_jt_no_m2m')
+class JoinTableWithoutManyToMany extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @JoinTable('v_orphan_jt')
+  tags?: unknown[];
+}
+
+@YdbEntity('v_m2m_no_jt_a')
+class M2mNoJoinTableA extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @ManyToMany(() => M2mNoJoinTableB)
+  bs?: M2mNoJoinTableB[];
+}
+
+@YdbEntity('v_m2m_no_jt_b')
+class M2mNoJoinTableB extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @ManyToMany(() => M2mNoJoinTableA)
+  as?: M2mNoJoinTableA[];
+}
+
+@YdbEntity('v_m2m_two_jt_a')
+class M2mTwoJoinTablesA extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @ManyToMany(() => M2mTwoJoinTablesB)
+  @JoinTable('v_jt_a')
+  bs?: M2mTwoJoinTablesB[];
+}
+
+@YdbEntity('v_m2m_two_jt_b')
+class M2mTwoJoinTablesB extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @ManyToMany(() => M2mTwoJoinTablesA)
+  @JoinTable('v_jt_b')
+  as?: M2mTwoJoinTablesA[];
+}
+
+describe('validateEntityMetadata', () => {
+  it('accepts a valid entity', () => {
+    expect(validateEntityMetadata(ValidUser, ctx)).toEqual([]);
+  });
+
+  it('accepts valid relations', () => {
+    expect(validateEntityMetadata(ValidWithRelations, ctx)).toEqual([]);
+  });
+
+  it('rejects class without @YdbEntity', () => {
+    expect(validateEntityMetadata(NotAnEntity, ctx)).toEqual([
+      expect.stringContaining('not decorated with @YdbEntity'),
+    ]);
+  });
+
+  it('rejects entity whose fallback uuid PK column is missing', () => {
+    const issues = validateEntityMetadata(MissingPkColumn, ctx);
+    expect(issues).toEqual([
+      expect.stringContaining('primary key column "uuid" is not declared'),
+    ]);
+  });
+
+  it('rejects encrypted primary key', () => {
+    const issues = validateEntityMetadata(EncryptedPk, ctx);
+    expect(issues).toEqual([
+      expect.stringContaining('primary key "uuid" cannot be encrypted'),
+    ]);
+  });
+
+  it('rejects encrypted field without @YdbColumn', () => {
+    const issues = validateEntityMetadata(EncryptedNoColumn, ctx);
+    expect(issues).toEqual([
+      expect.stringContaining('encrypted field "secret" has no @YdbColumn'),
+    ]);
+  });
+
+  it('rejects encrypted entity without configured providers', () => {
+    const issues = validateEntityMetadata(ValidUser, noProviders);
+    expect(issues).toEqual([
+      expect.stringContaining('no encryptionProvider is configured'),
+      expect.stringContaining('no blindIndexProvider is configured'),
+    ]);
+  });
+
+  it('rejects relation to class without @YdbEntity', () => {
+    const issues = validateEntityMetadata(BadRelTarget, ctx);
+    expect(issues).toEqual([
+      expect.stringContaining('not decorated with @YdbEntity'),
+    ]);
+  });
+
+  it('rejects one-to-many with unknown join column on target', () => {
+    const issues = validateEntityMetadata(BadJoinColumn, ctx);
+    expect(issues).toEqual([
+      expect.stringContaining('join column "no_such_column" is not a column'),
+    ]);
+  });
+
+  it('rejects @JoinTable without @ManyToMany', () => {
+    const issues = validateEntityMetadata(JoinTableWithoutManyToMany, ctx);
+    expect(issues).toEqual([
+      expect.stringContaining(
+        '@JoinTable("v_orphan_jt") on "tags" without @ManyToMany',
+      ),
+    ]);
+  });
+
+  it('rejects many-to-many without @JoinTable on any side', () => {
+    const issues = validateEntityMetadata(M2mNoJoinTableA, ctx);
+    expect(issues).toEqual([
+      expect.stringContaining('requires @JoinTable on one of the sides'),
+    ]);
+  });
+
+  it('rejects many-to-many with @JoinTable on both sides', () => {
+    const issues = validateEntityMetadata(M2mTwoJoinTablesA, ctx);
+    expect(issues).toEqual([
+      expect.stringContaining('both sides have @JoinTable'),
+    ]);
+  });
+});

--- a/src/metadata/validate-entity.ts
+++ b/src/metadata/validate-entity.ts
@@ -1,0 +1,156 @@
+import {
+  getYdbJoinTableMetadata,
+  getYdbRelationsMetadata,
+  RelationMetadata,
+} from '../decorators/relation.decorators.js';
+import { getYdbEntityMetadata } from './entity-metadata.js';
+import type { YdbBaseEntity } from '../entity/base-entity.js';
+
+/** Контекст валидации: какие провайдеры настроены в модуле. */
+export interface EntityValidationContext {
+  encryptionProviderConfigured: boolean;
+  blindIndexProviderConfigured: boolean;
+}
+
+/**
+ * Валидация метаданных сущности при инициализации модуля.
+ * Возвращает список проблем (пустой, если всё в порядке) — вызывающий код
+ * решает, как бросать ошибку. Чистая функция, без сети.
+ */
+export function validateEntityMetadata(
+  entity: typeof YdbBaseEntity,
+  ctx: EntityValidationContext,
+): string[] {
+  const issues: string[] = [];
+  const meta = getYdbEntityMetadata(entity);
+
+  if (!meta) {
+    return [`Class ${entity.name} is not decorated with @YdbEntity`];
+  }
+
+  const pkFields = meta.primaryKeys.length ? meta.primaryKeys : ['uuid'];
+  for (const pk of pkFields) {
+    if (!meta.schema[pk]) {
+      issues.push(
+        `primary key column "${pk}" is not declared via @YdbColumn/@YdbPrimaryColumn`,
+      );
+    }
+  }
+
+  for (const ef of meta.encryptedFields) {
+    if (!meta.schema[ef.propertyKey]) {
+      issues.push(`encrypted field "${ef.propertyKey}" has no @YdbColumn`);
+    }
+    if (pkFields.includes(ef.propertyKey)) {
+      issues.push(
+        `primary key "${ef.propertyKey}" cannot be encrypted (@YdbEncrypted)`,
+      );
+    }
+  }
+
+  if (meta.encryptedFields.length && !ctx.encryptionProviderConfigured) {
+    issues.push(
+      `entity has @YdbEncrypted fields, but no encryptionProvider is configured`,
+    );
+  }
+  if (
+    meta.encryptedFields.some((ef) => ef.blindIndex) &&
+    !ctx.blindIndexProviderConfigured
+  ) {
+    issues.push(
+      `entity has blind index fields, but no blindIndexProvider is configured`,
+    );
+  }
+
+  const relations = getYdbRelationsMetadata(entity);
+  const joinTables = getYdbJoinTableMetadata(entity);
+
+  for (const jt of joinTables) {
+    const rel = relations.find(
+      (r) => r.propertyKey === jt.propertyKey && r.type === 'many-to-many',
+    );
+    if (!rel) {
+      issues.push(
+        `@JoinTable("${jt.tableName}") on "${jt.propertyKey}" without @ManyToMany`,
+      );
+    }
+  }
+
+  for (const rel of relations) {
+    issues.push(...validateRelation(entity, meta.schema, rel, ctx));
+  }
+
+  return issues;
+}
+
+function validateRelation(
+  entity: typeof YdbBaseEntity,
+  schema: Record<string, unknown>,
+  rel: RelationMetadata,
+  _ctx: EntityValidationContext,
+): string[] {
+  const issues: string[] = [];
+  const Target = rel.target();
+  const targetMeta = getYdbEntityMetadata(Target);
+
+  if (!targetMeta) {
+    issues.push(
+      `relation "${rel.propertyKey}" targets ${Target.name}, which is not decorated with @YdbEntity`,
+    );
+    return issues;
+  }
+
+  if (rel.type === 'one-to-many') {
+    const joinColumn = resolveJoinColumnName(rel);
+    if (joinColumn && !targetMeta.schema[joinColumn]) {
+      issues.push(
+        `one-to-many "${rel.propertyKey}": join column "${joinColumn}" is not a column of ${Target.name}`,
+      );
+    }
+  }
+
+  if (rel.type === 'many-to-one' || rel.type === 'one-to-one') {
+    const joinColumn = resolveJoinColumnName(rel);
+    if (joinColumn && !schema[joinColumn]) {
+      issues.push(
+        `${rel.type} "${rel.propertyKey}": join column "${joinColumn}" is not a column of ${entity.name}`,
+      );
+    }
+  }
+
+  if (rel.type === 'many-to-many') {
+    const ownJoin = getYdbJoinTableMetadata(entity).find(
+      (jt) => jt.propertyKey === rel.propertyKey,
+    );
+    const inverseRel = getYdbRelationsMetadata(Target).find(
+      (r) => r.type === 'many-to-many' && r.target() === entity,
+    );
+    const inverseJoin = inverseRel
+      ? getYdbJoinTableMetadata(Target).find(
+          (jt) => jt.propertyKey === inverseRel.propertyKey,
+        )
+      : undefined;
+
+    if (ownJoin && inverseJoin) {
+      issues.push(
+        `many-to-many "${rel.propertyKey}": both sides have @JoinTable ` +
+          `(${entity.name} and ${Target.name}) — only one owning side is allowed`,
+      );
+    } else if (!ownJoin && !inverseJoin) {
+      issues.push(
+        `many-to-many "${rel.propertyKey}" requires @JoinTable on one of the sides ` +
+          `(${entity.name} or ${Target.name})`,
+      );
+    }
+  }
+
+  return issues;
+}
+
+/** Извлекает имя колонки из строки или селектора (x) => x.field. */
+function resolveJoinColumnName(rel: RelationMetadata): string | undefined {
+  if (!rel.joinColumn) return undefined;
+  if (typeof rel.joinColumn === 'string') return rel.joinColumn;
+  const proxy = new Proxy({}, { get: (_, prop) => prop as string });
+  return rel.joinColumn(proxy);
+}

--- a/src/module/repository-factory.ts
+++ b/src/module/repository-factory.ts
@@ -10,11 +10,13 @@ import {
   YdbEncryptionProvider,
 } from '../encryption/ydb-encryption-provider.interface.js';
 import { YdbBaseEntity } from '../entity/base-entity.js';
+import { validateEntityMetadata } from '../metadata/validate-entity.js';
 
 /**
  * Провайдер, который при инициализации модуля подключает глобальный
  * executor и опциональные encryption/blind-index провайдеры к Active Record
  * сущности (см. YdbBaseEntity.setExecutor / setEncryptionProvider).
+ * Перед подключением валидирует метаданные сущности (validateEntityMetadata).
  */
 export function createActiveRecordEntityProvider(
   entityClass: typeof YdbBaseEntity,
@@ -26,6 +28,17 @@ export function createActiveRecordEntityProvider(
       encryptionProvider?: YdbEncryptionProvider,
       blindIndexProvider?: YdbBlindIndexProvider,
     ) => {
+      const issues = validateEntityMetadata(entityClass, {
+        encryptionProviderConfigured: Boolean(encryptionProvider),
+        blindIndexProviderConfigured: Boolean(blindIndexProvider),
+      });
+      if (issues.length) {
+        throw new Error(
+          `Entity ${entityClass.name} metadata validation failed:\n` +
+            issues.map((i) => `  - ${i}`).join('\n'),
+        );
+      }
+
       entityClass.setExecutor(db);
       if (encryptionProvider) {
         entityClass.setEncryptionProvider(encryptionProvider);

--- a/test/nestjs/module-wiring.spec.ts
+++ b/test/nestjs/module-wiring.spec.ts
@@ -14,6 +14,7 @@ import {
 import { UserEntity } from '../fixtures/user/user.entity.js';
 import { UserRoleEntity } from '../fixtures/user_role/user_role.entity.js';
 import { PhotoEntity } from '../fixtures/photo/photo.entity.js';
+import { Base64TestEncryptionProvider } from '../../src/encryption/base64-test-encryption.provider.js';
 import { createMockExecutor } from '../helpers/mock-executor.js';
 
 @Module({
@@ -37,6 +38,8 @@ async function createTestingModule(rows: any[][]) {
           endpoint: 'grpc://localhost:2136/local',
           auth_type: 'anonymous' as const,
           authOptions: {},
+          encryptionProvider: new Base64TestEncryptionProvider(),
+          blindIndexProvider: new Base64TestEncryptionProvider(),
           sync: false,
         }),
       }),

--- a/test/nestjs/relations.spec.ts
+++ b/test/nestjs/relations.spec.ts
@@ -10,6 +10,7 @@ import {
 import { UserProfileEntity } from '../fixtures/user_profile/user_profile.entity.js';
 import { PhotoWithTagsEntity } from '../fixtures/photo_with_tags/photo_with_tags.entity.js';
 import { TagEntity } from '../fixtures/tag/tag.entity.js';
+import { Base64TestEncryptionProvider } from '../../src/encryption/base64-test-encryption.provider.js';
 import { createMockExecutor } from '../helpers/mock-executor.js';
 
 @Module({
@@ -46,6 +47,8 @@ async function createTestingModule(rows: any[][]) {
           endpoint: 'grpc://localhost:2136/local',
           auth_type: 'anonymous' as const,
           authOptions: {},
+          encryptionProvider: new Base64TestEncryptionProvider(),
+          blindIndexProvider: new Base64TestEncryptionProvider(),
           sync: false,
         }),
       }),

--- a/test/nestjs/schema-sync.spec.ts
+++ b/test/nestjs/schema-sync.spec.ts
@@ -18,6 +18,7 @@ import {
 import { UserEntity } from '../fixtures/user/user.entity.js';
 import { UserRoleEntity } from '../fixtures/user_role/user_role.entity.js';
 import { PhotoEntity } from '../fixtures/photo/photo.entity.js';
+import { Base64TestEncryptionProvider } from '../../src/encryption/base64-test-encryption.provider.js';
 import { createMockExecutor } from '../helpers/mock-executor.js';
 
 @Module({
@@ -69,6 +70,8 @@ describe('NestJS integration: schema sync on bootstrap', () => {
             endpoint: 'grpc://localhost:2136/local',
             auth_type: 'anonymous' as const,
             authOptions: {},
+            encryptionProvider: new Base64TestEncryptionProvider(),
+            blindIndexProvider: new Base64TestEncryptionProvider(),
             sync: true,
           }),
         }),
@@ -131,6 +134,8 @@ describe('NestJS integration: schema sync on bootstrap', () => {
             endpoint: 'grpc://localhost:2136/local',
             auth_type: 'anonymous' as const,
             authOptions: {},
+            encryptionProvider: new Base64TestEncryptionProvider(),
+            blindIndexProvider: new Base64TestEncryptionProvider(),
           }),
         }),
         TestFeatureModule,


### PR DESCRIPTION
## Валидация метаданных

Новый `src/metadata/validate-entity.ts` — чистая функция `validateEntityMetadata(entity, ctx)`, вызывается при инициализации модуля (`forFeature`) и бросает понятную ошибку на старте вместо рантайм-сюрпризов.

Проверки:
- PK-колонка объявлена, PK не может быть encrypted
- encrypted-поле без `@YdbColumn`; encrypted/blind-index без настроенных провайдеров
- relation-цель без `@YdbEntity`; join-колонки one-to-many/many-to-one/one-to-one существуют
- `@JoinTable` без `@ManyToMany`; many-to-many без `@JoinTable` ни на одной стороне; две владеющие стороны

12 новых unit-тестов, 154/154 зелёных, lint 0 errors.

Closes #3