### PR TITLE
feat(entity): UUID v7 по умолчанию (issue #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ export class AppModule {}
 await UserEntity.find({ uuid });                    // одна запись или null
 await UserEntity.findAll({ name: 'Ivan' }, { limit: 50, offset: 0 });
 await UserEntity.count({ name: 'Ivan' });
-await UserEntity.save(user);                        // insert (uuid генерируется) или update по uuid
+await UserEntity.save(user);                        // insert (uuid генерируется, по умолчанию v7) или update по uuid
 await UserEntity.insertMany([u1, u2]);              // батчи по 100
 await user.loadRelations(['roles']);
 ```

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -26,6 +26,11 @@ export interface YdbModuleOptions {
   encryptionProvider?: YdbEncryptionProvider;
   blindIndexProvider?: YdbBlindIndexProvider;
   /**
+   * Версия генерируемых UUID для первичных ключей: v7 (по умолчанию,
+   * время-сортируемые) или v4 (случайные, для переходного периода).
+   */
+  uuidVersion?: 'v4' | 'v7';
+  /**
    * Как в TypeORM synchronize: при старте приложения подстроить схему БД
    * под метаданные всех сущностей (создать недостающие таблицы и колонки).
    * Только для dev-стендов — в проде используйте миграции.

--- a/src/entity/base-entity.ts
+++ b/src/entity/base-entity.ts
@@ -1,7 +1,7 @@
 import { YdbExecutor, YdbQuery } from '../core/interfaces.js';
 import { getYdbEntityMetadata } from '../metadata/entity-metadata.js';
 import { mapToYdb } from '../core/mapper.js';
-import { v4 as uuidv4 } from 'uuid';
+import { v7 as uuidv7 } from 'uuid';
 import { QueryOptions } from '../core/query-options.js';
 import { quoteIdentifier } from '../core/sql-utils.js';
 import {
@@ -51,6 +51,11 @@ export class YdbBaseEntity {
       );
     }
     return db;
+  }
+
+  /** Генератор UUID для PK: из рантайма (uuidVersion в опциях модуля), по умолчанию v7. */
+  protected static generateUuid(): string {
+    return getEntityRuntime(this).uuidGenerator?.() ?? uuidv7();
   }
 
   protected static getMeta(this: typeof YdbBaseEntity) {
@@ -783,7 +788,7 @@ export class YdbBaseEntity {
     const dbSchema = this.getDbSchema(meta);
 
     for (const e of entities) {
-      if (!(e as any).uuid) (e as any).uuid = uuidv4();
+      if (!(e as any).uuid) (e as any).uuid = this.generateUuid();
     }
 
     const dataList = await Promise.all(
@@ -835,7 +840,7 @@ export class YdbBaseEntity {
     const dbSchema = this.getDbSchema(meta);
 
     if (schema['uuid'] && !(entity as any).uuid) {
-      (entity as any).uuid = uuidv4();
+      (entity as any).uuid = this.generateUuid();
     }
     const data = await this.encryptEntity(
       { ...(entity as Record<string, any>) },

--- a/src/entity/entity-runtime.ts
+++ b/src/entity/entity-runtime.ts
@@ -9,6 +9,8 @@ export interface EntityRuntime {
   executor?: YdbExecutor;
   encryptionProvider?: YdbEncryptionProvider;
   blindIndexProvider?: YdbBlindIndexProvider;
+  /** Генератор UUID для PK (по умолчанию v7 — см. base-entity). */
+  uuidGenerator?: () => string;
 }
 
 /**

--- a/src/module/repository-factory.ts
+++ b/src/module/repository-factory.ts
@@ -1,15 +1,18 @@
 import { Provider } from '@nestjs/common';
 import {
   YDB_QUERY,
+  YDB_OPTIONS,
   YDB_ENCRYPTION_PROVIDER,
   YDB_BLIND_INDEX_PROVIDER,
 } from '../core/constants.js';
-import type { YdbExecutor } from '../core/interfaces.js';
+import type { YdbExecutor, YdbModuleOptions } from '../core/interfaces.js';
 import {
   YdbBlindIndexProvider,
   YdbEncryptionProvider,
 } from '../encryption/ydb-encryption-provider.interface.js';
 import { YdbBaseEntity } from '../entity/base-entity.js';
+import { getEntityRuntime } from '../entity/entity-runtime.js';
+import { v4 as uuidv4, v7 as uuidv7 } from 'uuid';
 import { validateEntityMetadata } from '../metadata/validate-entity.js';
 
 /**
@@ -25,6 +28,7 @@ export function createActiveRecordEntityProvider(
     provide: `${entityClass.name}_AR_INIT`,
     useFactory: (
       db: YdbExecutor,
+      opts: YdbModuleOptions,
       encryptionProvider?: YdbEncryptionProvider,
       blindIndexProvider?: YdbBlindIndexProvider,
     ) => {
@@ -39,6 +43,9 @@ export function createActiveRecordEntityProvider(
         );
       }
 
+      getEntityRuntime(entityClass).uuidGenerator =
+        opts.uuidVersion === 'v4' ? uuidv4 : uuidv7;
+
       entityClass.setExecutor(db);
       if (encryptionProvider) {
         entityClass.setEncryptionProvider(encryptionProvider);
@@ -50,6 +57,7 @@ export function createActiveRecordEntityProvider(
     },
     inject: [
       YDB_QUERY,
+      YDB_OPTIONS,
       { token: YDB_ENCRYPTION_PROVIDER, optional: true },
       { token: YDB_BLIND_INDEX_PROVIDER, optional: true },
     ],

--- a/src/module/ydb-core.module.ts
+++ b/src/module/ydb-core.module.ts
@@ -104,6 +104,7 @@ export class YdbCoreModule {
         },
       ],
       exports: [
+        YDB_OPTIONS,
         YDB_DRIVER,
         YDB_QUERY,
         YdbTransactionManager,

--- a/test/base-entity-crud.spec.ts
+++ b/test/base-entity-crud.spec.ts
@@ -5,6 +5,8 @@ import { UserRoleEntity } from './fixtures/user_role/user_role.entity.js';
 import { PhotoEntity } from './fixtures/photo/photo.entity.js';
 import { createMockExecutor } from './helpers/mock-executor.js';
 import { Base64TestEncryptionProvider } from '../src/encryption/base64-test-encryption.provider.js';
+import { getEntityRuntime } from '../src/entity/entity-runtime.js';
+import { v4 as uuidv4 } from 'uuid';
 
 const userRow = {
   uuid: '5ad91505-d4f6-4a81-ab65-9dbc68cf4ed5',
@@ -230,6 +232,38 @@ describe('BaseEntity CRUD (mock executor)', () => {
       expect(q.sql).toContain('`uuid`');
       expect(q.sql).toContain('`email_encrypted`');
       expect(q.sql).toContain('`full_name`');
+    });
+
+    it('generates UUID v7 by default and v4 when runtime generator is set', async () => {
+      const provider = new Base64TestEncryptionProvider();
+      UserEntity.setEncryptionProvider(provider);
+      UserEntity.setBlindIndexProvider(provider);
+      const mock = createMockExecutor([[]]);
+      UserEntity.setExecutor(mock.executor);
+
+      const runtime = getEntityRuntime(UserEntity);
+      const prevGenerator = runtime.uuidGenerator;
+      try {
+        // По умолчанию — v7 (время-сортируемые)
+        delete runtime.uuidGenerator;
+        const userV7 = new UserEntity();
+        userV7.full_name = 'V7';
+        await UserEntity.save(userV7);
+        expect(userV7.uuid).toMatch(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+        );
+
+        // Опция uuidVersion: 'v4' в модуле подставляет v4-генератор
+        runtime.uuidGenerator = uuidv4;
+        const userV4 = new UserEntity();
+        userV4.full_name = 'V4';
+        await UserEntity.save(userV4);
+        expect(userV4.uuid).toMatch(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+        );
+      } finally {
+        runtime.uuidGenerator = prevGenerator;
+      }
     });
 
     it('skips undefined fields in UPSERT', async () => {


### PR DESCRIPTION
## UUID v7

- `save()`/`insertMany()` генерируют PK через `generateUuid()`: по умолчанию **v7** (время-сортируемые, лучше локальность индексов)
- Опция модуля `uuidVersion: 'v4'` — вернуть случайные v4 на переходный период; генератор живёт в `EntityRuntime`
- `YDB_OPTIONS` теперь экспортируется из `YdbCoreModule` (нужен для wiring опций в forFeature)
- Тест: v7 по умолчанию, v4 при установленном генераторе — 155/155 зелёных, lint 0 errors

Closes #4