### PR TITLE
feat(schema): @YdbIndex — вторичные индексы (issue #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ const { sql, values } = await PhotoEntity.query().where({ is_public: true }).toY
 - `@YdbEncrypted({ blindIndex })` — поле шифруется перед записью и дешифруется после чтения; `blindIndex: true` (по умолчанию) добавляет synthetic колонку `{field}_bi` для поиска по хешу.
 - `@YdbSecurityAAD()` — незашифрованное поле участвует в AAD.
 - `@OneToMany` / `@ManyToOne` / `@OneToOne` / `@ManyToMany` — relations; `@EagerLoad([...])` — batch-загрузка одним `IN (...)` запросом (без N+1). `@ManyToMany` требует `@JoinTable('join_table_name')` на владеющей стороне; join-таблица попадает в schema sync и миграции автоматически.
+- `@YdbIndex({ columns, name? })` — вторичный индекс (GLOBAL SYNC); класс-декоратор, можно несколько. Имя по умолчанию `{table}__{col1}_{col2}`. Попадает в CREATE TABLE при schema sync и в `migration:generate` для новых таблиц.
 
 ```ts
 @YdbEntity('photos')

--- a/src/decorators/index.decorator.ts
+++ b/src/decorators/index.decorator.ts
@@ -1,0 +1,45 @@
+import 'reflect-metadata';
+
+export const YDB_INDEXES_KEY = 'ydb:indexes';
+
+export interface YdbIndexOptions {
+  /** Колонки индекса (порядок важен). */
+  columns: string[];
+  /** Явное имя индекса. По умолчанию: `{table}__{col1}_{col2}`. */
+  name?: string;
+}
+
+export interface YdbIndexMetadata {
+  columns: string[];
+  name?: string;
+}
+
+/**
+ * Декларативный вторичный индекс (GLOBAL SYNC). Класс-декоратор,
+ * можно вешать несколько раз. Попадает в CREATE TABLE при schema sync
+ * и в migration:generate.
+ *
+ * @example
+ *   @YdbEntity('photos')
+ *   @YdbIndex({ columns: ['author_email_bi'] })
+ *   @YdbIndex({ columns: ['is_public', 'rating'], name: 'photos__public_rating' })
+ *   class PhotoEntity extends YdbBaseEntity { ... }
+ */
+export function YdbIndex(options: YdbIndexOptions): ClassDecorator {
+  return (target) => {
+    const existing: YdbIndexMetadata[] =
+      Reflect.getMetadata(YDB_INDEXES_KEY, target) || [];
+    // Класс-декораторы применяются снизу вверх — unshift сохраняет порядок объявления.
+    const indexes: YdbIndexMetadata[] = [{ ...options }, ...existing];
+    Reflect.defineMetadata(YDB_INDEXES_KEY, indexes, target);
+  };
+}
+
+export function getYdbIndexesMetadata(target: any): YdbIndexMetadata[] {
+  return Reflect.getMetadata(YDB_INDEXES_KEY, target) || [];
+}
+
+/** Имя индекса по умолчанию: `{table}__{col1}_{col2}` — группируется сортировкой. */
+export function resolveIndexName(tableName: string, columns: string[]): string {
+  return `${tableName}__${columns.join('_')}`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,15 @@ export type {
   ManyToManyJoinTable,
 } from './decorators/relation.decorators.js';
 export { EagerLoad } from './decorators/eager.decorator.js';
+export {
+  YdbIndex,
+  getYdbIndexesMetadata,
+  resolveIndexName,
+} from './decorators/index.decorator.js';
+export type {
+  YdbIndexMetadata,
+  YdbIndexOptions,
+} from './decorators/index.decorator.js';
 
 // Active Record
 export { YdbBaseEntity } from './entity/base-entity.js';

--- a/src/metadata/validate-entity.spec.ts
+++ b/src/metadata/validate-entity.spec.ts
@@ -8,6 +8,7 @@ import {
   OneToMany,
   OneToOne,
 } from '../decorators/relation.decorators.js';
+import { YdbIndex } from '../decorators/index.decorator.js';
 import { YdbBaseEntity } from '../entity/base-entity.js';
 import {
   validateEntityMetadata,
@@ -127,6 +128,13 @@ class M2mNoJoinTableB extends YdbBaseEntity {
   as?: M2mNoJoinTableA[];
 }
 
+@YdbEntity('v_bad_idx')
+@YdbIndex({ columns: ['nope'] })
+class BadIndexColumn extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+}
+
 @YdbEntity('v_m2m_two_jt_a')
 class M2mTwoJoinTablesA extends YdbBaseEntity {
   @YdbPrimaryColumn('Uuid')
@@ -218,6 +226,13 @@ describe('validateEntityMetadata', () => {
     const issues = validateEntityMetadata(M2mNoJoinTableA, ctx);
     expect(issues).toEqual([
       expect.stringContaining('requires @JoinTable on one of the sides'),
+    ]);
+  });
+
+  it('rejects @YdbIndex with unknown column', () => {
+    const issues = validateEntityMetadata(BadIndexColumn, ctx);
+    expect(issues).toEqual([
+      expect.stringContaining('@YdbIndex references unknown column "nope"'),
     ]);
   });
 

--- a/src/metadata/validate-entity.ts
+++ b/src/metadata/validate-entity.ts
@@ -3,6 +3,7 @@ import {
   getYdbRelationsMetadata,
   RelationMetadata,
 } from '../decorators/relation.decorators.js';
+import { getYdbIndexesMetadata } from '../decorators/index.decorator.js';
 import { getYdbEntityMetadata } from './entity-metadata.js';
 import type { YdbBaseEntity } from '../entity/base-entity.js';
 
@@ -64,6 +65,23 @@ export function validateEntityMetadata(
 
   const relations = getYdbRelationsMetadata(entity);
   const joinTables = getYdbJoinTableMetadata(entity);
+
+  const allowedColumns = new Set([
+    ...Object.keys(meta.schema),
+    ...meta.encryptedFields
+      .filter((ef) => ef.blindIndex)
+      .map((ef) => `${ef.propertyKey}_bi`),
+  ]);
+  for (const idx of getYdbIndexesMetadata(entity)) {
+    if (!idx.columns.length) {
+      issues.push('@YdbIndex without columns');
+    }
+    for (const col of idx.columns) {
+      if (!allowedColumns.has(col)) {
+        issues.push(`@YdbIndex references unknown column "${col}"`);
+      }
+    }
+  }
 
   for (const jt of joinTables) {
     const rel = relations.find(

--- a/src/schema/schema-sync.spec.ts
+++ b/src/schema/schema-sync.spec.ts
@@ -24,8 +24,11 @@ import {
   JoinTable,
 } from '../decorators/relation.decorators.js';
 import { EagerLoad } from '../decorators/eager.decorator.js';
+import { YdbIndex } from '../decorators/index.decorator.js';
 
 @YdbEntity('test_users')
+@YdbIndex({ columns: ['secret_bi'] })
+@YdbIndex({ columns: ['is_active', 'name'], name: 'test_users__active_name' })
 class TestUserEntity extends YdbBaseEntity {
   @YdbPrimaryColumn('Uuid')
   uuid: string;
@@ -158,7 +161,7 @@ describe('buildExpectedSchemas', () => {
 });
 
 describe('generateCreateTableYql', () => {
-  it('generates CREATE TABLE with quoted identifiers and PRIMARY KEY', () => {
+  it('generates CREATE TABLE with quoted identifiers, INDEX clauses and PRIMARY KEY', () => {
     const yql = generateCreateTableYql(
       buildExpectedTableSchema(meta(TestUserEntity)),
     );
@@ -170,9 +173,22 @@ describe('generateCreateTableYql', () => {
         '  `secret` Utf8,\n' +
         '  `is_active` Bool,\n' +
         '  `secret_bi` Utf8,\n' +
+        '  INDEX `test_users__secret_bi` GLOBAL SYNC ON (`secret_bi`),\n' +
+        '  INDEX `test_users__active_name` GLOBAL SYNC ON (`is_active`, `name`),\n' +
         '  PRIMARY KEY (`uuid`)\n' +
         ')',
     );
+  });
+});
+
+describe('@YdbIndex metadata', () => {
+  it('resolves default index names as {table}__{cols}', () => {
+    const schema = buildExpectedTableSchema(meta(TestUserEntity));
+
+    expect(schema.indexes).toEqual([
+      { name: 'test_users__secret_bi', columns: ['secret_bi'] },
+      { name: 'test_users__active_name', columns: ['is_active', 'name'] },
+    ]);
   });
 });
 

--- a/src/schema/schema-sync.ts
+++ b/src/schema/schema-sync.ts
@@ -19,12 +19,23 @@ import {
   getManyToManyJoinTables,
   ManyToManyJoinTable,
 } from '../decorators/relation.decorators.js';
+import {
+  getYdbIndexesMetadata,
+  resolveIndexName,
+} from '../decorators/index.decorator.js';
+
+/** Ожидаемый вторичный индекс таблицы. */
+export interface ExpectedIndex {
+  name: string;
+  columns: string[];
+}
 
 /** Ожидаемая схема таблицы, построенная по метаданным сущности. */
 export interface ExpectedTableSchema {
   tableName: string;
   columns: Record<string, YdbPrimitive>;
   primaryKey: string[];
+  indexes: ExpectedIndex[];
 }
 
 /** Нормализованное описание существующей таблицы из DescribeTable. */
@@ -101,7 +112,14 @@ export function buildExpectedTableSchema(
     }
   }
 
-  return { tableName: meta.tableName, columns, primaryKey };
+  const indexes: ExpectedIndex[] = getYdbIndexesMetadata(meta.target).map(
+    (idx) => ({
+      name: idx.name ?? resolveIndexName(meta.tableName, idx.columns),
+      columns: [...idx.columns],
+    }),
+  );
+
+  return { tableName: meta.tableName, columns, primaryKey, indexes };
 }
 
 /** Ожидаемая схема join-таблицы many-to-many. */
@@ -115,6 +133,7 @@ export function buildExpectedJoinTableSchema(
       [joinTable.inverseJoinColumn]: 'Uuid',
     },
     primaryKey: [joinTable.joinColumn, joinTable.inverseJoinColumn],
+    indexes: [],
   };
 }
 
@@ -143,10 +162,16 @@ export function generateCreateTableYql(expected: ExpectedTableSchema): string {
   const columnDefs = Object.entries(expected.columns).map(
     ([name, type]) => `${quoteIdentifier(name)} ${type}`,
   );
+  const indexDefs = (expected.indexes ?? []).map(
+    (idx) =>
+      `INDEX ${quoteIdentifier(idx.name)} GLOBAL SYNC ON ` +
+      `(${idx.columns.map(quoteIdentifier).join(', ')})`,
+  );
   const pk = expected.primaryKey.map(quoteIdentifier).join(', ');
+  const body = [...columnDefs, ...indexDefs].join(',\n  ');
   return (
     `CREATE TABLE ${quoteIdentifier(expected.tableName)} (\n  ` +
-    `${columnDefs.join(',\n  ')},\n  PRIMARY KEY (${pk})\n)`
+    `${body},\n  PRIMARY KEY (${pk})\n)`
   );
 }
 


### PR DESCRIPTION
## @YdbIndex

```ts
@YdbEntity('photos')
@YdbIndex({ columns: ['author_email_bi'] })
@YdbIndex({ columns: ['is_public', 'rating'], name: 'photos__public_rating' })
class PhotoEntity extends YdbBaseEntity { ... }
```

- Класс-декоратор, несколько на класс; имя по умолчанию `{table}__{col1}_{col2}` (группируется сортировкой)
- `CREATE TABLE` теперь включает `INDEX `name` GLOBAL SYNC ON (...)` — работает и в schema sync, и в `migration:generate` для новых таблиц
- Валидация метаданных: колонки индекса должны существовать (включая synthetic `*_bi`)
- Diff/ADD INDEX на существующих таблицах — отдельный issue #7 (TODO 33)
- 157/157 тестов зелёных, lint 0 errors

Closes #6