### PR TITLE
feat: batch p1 features — @YdbTtl, lifecycle hooks, @YdbValidate, KMS, select/updateBy/deleteBy, standalone

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# YDB connection for e2e tests
+# Copy this file to .env and fill in the values
+
+# Endpoint URL with database path
+YDB_ENDPOINT=grpcs://ydb.serverless.yandexcloud.net:2135/?database=/your/database/path
+
+# Auth method: meta | auth_key | anonymous
+YDB_AUTH_TYPE=auth_key
+
+# Path to authorized_key.json (only for auth_key)
+YDB_AUTHORIZED_KEY_PATH=./authorized_key.json

--- a/package.json
+++ b/package.json
@@ -48,9 +48,11 @@
     "prepublishOnly": "yarn build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\" \"examples/**/*.ts\"",
     "lint": "eslint \"{src,test,examples}/**/*.ts\" --fix",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --testPathIgnorePatterns=test/e2e",
+    "test:unit": "NODE_OPTIONS=--experimental-vm-modules jest --testPathIgnorePatterns=test/e2e",
+    "test:e2e": "NODE_OPTIONS=--experimental-vm-modules jest --testPathPatterns=test/e2e --testTimeout=30000",
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
-    "test:cov": "NODE_OPTIONS=--experimental-vm-modules jest --coverage"
+    "test:cov": "NODE_OPTIONS=--experimental-vm-modules jest --testPathIgnorePatterns=test/e2e --coverage"
   },
   "peerDependencies": {
     "@nestjs/common": ">=10.0.0",

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -20,6 +20,7 @@ const HELP = `ydb-orm — CLI для миграций и генерации ко
   ydb-orm migration:run               Применить все новые миграции
   ydb-orm migration:revert            Откатить последнюю миграцию
   ydb-orm migration:show              Показать статус миграций
+  ydb-orm migration:check             Проверить, все ли миграции применены (exit 1 если нет)
   ydb-orm schema:verify             Проверить схему БД против метаданных сущностей
   ydb-orm entity:create <name>        Создать сущность
 
@@ -29,6 +30,8 @@ const HELP = `ydb-orm — CLI для миграций и генерации ко
                     YDB_AUTHORIZED_KEY_PATH)
   --dir <path>      Директория миграций (по умолчанию ./migrations)
                     или сущностей для entity:create (по умолчанию ./src)
+  --json            JSON-вывод (для migration:show)
+  --json            Machine-readable output (для migration:check)
 `;
 
 interface ParsedArgs {
@@ -36,6 +39,7 @@ interface ParsedArgs {
   positional?: string;
   config?: string;
   dir?: string;
+  json?: boolean;
 }
 
 function parseArgs(argv: string[]): ParsedArgs {
@@ -44,6 +48,7 @@ function parseArgs(argv: string[]): ParsedArgs {
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === '--config') result.config = argv[++i];
     else if (argv[i] === '--dir') result.dir = argv[++i];
+    else if (argv[i] === '--json') result.json = true;
     else rest.push(argv[i]);
   }
   [result.command, result.positional] = rest;
@@ -172,12 +177,58 @@ async function main(): Promise<void> {
         console.log(reverted ? `Reverted: ${reverted}` : 'Nothing to revert');
       } else {
         const statuses = await runner.status(migrations);
-        for (const s of statuses) {
-          console.log(
-            `${s.applied ? '[x]' : '[ ]'} ${s.name}` +
-              (s.appliedAt ? ` (${s.appliedAt.toISOString()})` : ''),
-          );
+        if (args.json) {
+          const json = statuses.map((s) => ({
+            name: s.name,
+            applied: s.applied,
+            appliedAt: s.appliedAt ? s.appliedAt.toISOString() : null,
+          }));
+          console.log(JSON.stringify(json, null, 2));
+        } else {
+          for (const s of statuses) {
+            console.log(
+              `${s.applied ? '[x]' : '[ ]'} ${s.name}` +
+                (s.appliedAt ? ` (${s.appliedAt.toISOString()})` : ''),
+            );
+          }
         }
+      }
+    } finally {
+      close();
+    }
+    return;
+  }
+
+  if (command === 'migration:check') {
+    const { executor, close } = await connectCli(config);
+    try {
+      const runner = new YdbMigrationRunner(executor);
+      const migrations = await loadMigrationsFromDir(migrationsDir);
+      const statuses = await runner.status(migrations);
+      const pending = statuses.filter((s) => !s.applied);
+
+      if (args.json) {
+        const result = {
+          applied: pending.length === 0,
+          pending: pending.map((s) => s.name),
+          total: statuses.length,
+        };
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        if (pending.length === 0) {
+          console.log('All migrations applied');
+        } else {
+          console.error(
+            `Pending migrations (${pending.length}/${statuses.length}):`,
+          );
+          for (const s of pending) {
+            console.error(`  - ${s.name}`);
+          }
+        }
+      }
+
+      if (pending.length > 0) {
+        process.exitCode = 1;
       }
     } finally {
       close();

--- a/src/core/driver.ts
+++ b/src/core/driver.ts
@@ -5,6 +5,10 @@ import { MetadataCredentialsProvider } from '@ydbjs/auth/metadata';
 import { AnonymousCredentialsProvider } from '@ydbjs/auth/anonymous';
 import { AuthKeyCredentialsProvider } from '../credentials/auth-key-credentials-provider.js';
 import { YdbExecutor, YdbModuleOptions } from './interfaces.js';
+import {
+  ConsoleQueryLogger,
+  wrapExecutorWithLogging,
+} from './query-logger.js';
 
 /**
  * Создаёт credentials provider по `auth_type` из опций модуля.
@@ -51,11 +55,21 @@ export function createExecutor(
   driver: Driver,
   opts: YdbModuleOptions,
 ): YdbExecutor {
-  return query(driver, {
+  let executor = query(driver, {
     poolOptions: opts.poolOptions
       ? Object.fromEntries(
           Object.entries(opts.poolOptions).filter(([, v]) => v !== undefined),
         )
       : undefined,
   }) as unknown as YdbExecutor;
+
+  if (opts.logQueries) {
+    const logger =
+      typeof opts.logQueries === 'object' && opts.logQueries !== null
+        ? opts.logQueries
+        : new ConsoleQueryLogger();
+    executor = wrapExecutorWithLogging(executor, logger);
+  }
+
+  return executor;
 }

--- a/src/core/driver.ts
+++ b/src/core/driver.ts
@@ -5,10 +5,7 @@ import { MetadataCredentialsProvider } from '@ydbjs/auth/metadata';
 import { AnonymousCredentialsProvider } from '@ydbjs/auth/anonymous';
 import { AuthKeyCredentialsProvider } from '../credentials/auth-key-credentials-provider.js';
 import { YdbExecutor, YdbModuleOptions } from './interfaces.js';
-import {
-  ConsoleQueryLogger,
-  wrapExecutorWithLogging,
-} from './query-logger.js';
+import { ConsoleQueryLogger, wrapExecutorWithLogging } from './query-logger.js';
 
 /**
  * Создаёт credentials provider по `auth_type` из опций модуля.

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -4,8 +4,10 @@ import {
   YdbBlindIndexProvider,
   YdbEncryptionProvider,
 } from '../encryption/ydb-encryption-provider.interface.js';
+import type { QueryLogger } from './query-logger.js';
 
 export type { QueryOptions } from './query-options.js';
+export type { QueryLogger, QueryLogEntry } from './query-logger.js';
 
 export interface YdbAuthOptions {
   authorized_key_path?: string;
@@ -36,6 +38,11 @@ export interface YdbModuleOptions {
    * Только для dev-стендов — в проде используйте миграции.
    */
   sync?: boolean;
+  /**
+   * Логирование запросов: true (консоль по умолчанию) или экземпляр QueryLogger.
+   * Логирует SQL, замаскированные параметры и длительность.
+   */
+  logQueries?: boolean | QueryLogger;
 }
 
 export interface YdbOptionsFactory {

--- a/src/core/query-logger.ts
+++ b/src/core/query-logger.ts
@@ -30,7 +30,11 @@ const MAX_PARAM_LENGTH = 64;
 /** Маскирование значения параметра: секреты скрыты, длинные строки обрезаны. */
 function maskValue(value: unknown): unknown {
   if (value === null || value === undefined) return value;
-  if (typeof value === 'object' && 'type' in (value as any) && 'value' in (value as any)) {
+  if (
+    typeof value === 'object' &&
+    'type' in (value as any) &&
+    'value' in (value as any)
+  ) {
     // YDB typed value { type: ..., value: ... }
     const inner = (value as any).value;
     if (inner === null || inner === undefined) return inner;
@@ -66,12 +70,13 @@ export class ConsoleQueryLogger implements QueryLogger {
       .join(', ');
 
     const base = `[YDB] QUERY ${entry.durationMs}ms`;
-    const sql = entry.sql.length > 200
-      ? entry.sql.slice(0, 200) + '...'
-      : entry.sql;
+    const sql =
+      entry.sql.length > 200 ? entry.sql.slice(0, 200) + '...' : entry.sql;
 
     if (entry.error) {
-      console.error(`${base} ERROR: ${entry.error.message}\n  SQL: ${sql}\n  Params: ${params}`);
+      console.error(
+        `${base} ERROR: ${entry.error.message}\n  SQL: ${sql}\n  Params: ${params}`,
+      );
     } else {
       console.log(`${base}\n  SQL: ${sql}\n  Params: ${params}`);
     }

--- a/src/core/query-logger.ts
+++ b/src/core/query-logger.ts
@@ -1,0 +1,144 @@
+import { YdbExecutor } from './interfaces.js';
+
+/**
+ * Информация о запросе для логирования.
+ */
+export interface QueryLogEntry {
+  /** SQL-запрос (шаблонная строка). */
+  sql: string;
+  /** Имена параметров (без значений). */
+  paramNames: string[];
+  /** Замаскированные значения параметров (секреты скрыты). */
+  maskedParams: Record<string, unknown>;
+  /** Длительность выполнения в миллисекундах. */
+  durationMs: number;
+  /** Ошибка (если запрос упал). */
+  error?: Error;
+}
+
+/**
+ * Интерфейс логгера запросов.
+ * Пользователь может передать свой логгер (e.g. pino, winston, OpenTelemetry span).
+ */
+export interface QueryLogger {
+  log(entry: QueryLogEntry): void;
+}
+
+/** Максимальная длина замаскированного значения параметра. */
+const MAX_PARAM_LENGTH = 64;
+
+/** Маскирование значения параметра: секреты скрыты, длинные строки обрезаны. */
+function maskValue(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (typeof value === 'object' && 'type' in (value as any) && 'value' in (value as any)) {
+    // YDB typed value { type: ..., value: ... }
+    const inner = (value as any).value;
+    if (inner === null || inner === undefined) return inner;
+    if (typeof inner === 'string') {
+      return inner.length > MAX_PARAM_LENGTH
+        ? inner.slice(0, MAX_PARAM_LENGTH) + '...'
+        : inner;
+    }
+    if (inner instanceof Uint8Array) {
+      return `<bytes:${inner.length}>`;
+    }
+    return inner;
+  }
+  if (value instanceof Uint8Array) {
+    return `<bytes:${value.length}>`;
+  }
+  if (typeof value === 'string') {
+    return value.length > MAX_PARAM_LENGTH
+      ? value.slice(0, MAX_PARAM_LENGTH) + '...'
+      : value;
+  }
+  return value;
+}
+
+/**
+ * Консольный логгер запросов по умолчанию.
+ * Формат: [YDB] QUERY <durationMs>ms — sql с параметрами
+ */
+export class ConsoleQueryLogger implements QueryLogger {
+  log(entry: QueryLogEntry): void {
+    const params = Object.entries(entry.maskedParams)
+      .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
+      .join(', ');
+
+    const base = `[YDB] QUERY ${entry.durationMs}ms`;
+    const sql = entry.sql.length > 200
+      ? entry.sql.slice(0, 200) + '...'
+      : entry.sql;
+
+    if (entry.error) {
+      console.error(`${base} ERROR: ${entry.error.message}\n  SQL: ${sql}\n  Params: ${params}`);
+    } else {
+      console.log(`${base}\n  SQL: ${sql}\n  Params: ${params}`);
+    }
+  }
+}
+
+/**
+ * Оборачивает executor логированием: замеряет длительность,
+ * маскирует параметры, логирует SQL + ошибки.
+ */
+export function wrapExecutorWithLogging(
+  executor: YdbExecutor,
+  logger: QueryLogger,
+): YdbExecutor {
+  const wrapped: any = (strings: TemplateStringsArray) => {
+    const sql = strings[0];
+    const startTime = performance.now();
+    const paramNames: string[] = [];
+    const maskedParams: Record<string, unknown> = {};
+
+    const query = executor(strings);
+    const originalParameter = query.parameter.bind(query);
+
+    const proxied: any = {
+      parameter(name: string, value: unknown) {
+        paramNames.push(name);
+        maskedParams[name] = maskValue(value);
+        return originalParameter(name, value);
+      },
+      timeout(ms: number) {
+        query.timeout(ms);
+        return proxied;
+      },
+      signal(signal: AbortSignal) {
+        query.signal(signal);
+        return proxied;
+      },
+      cancel() {
+        query.cancel();
+        return proxied;
+      },
+      then(onFulfilled: any, onRejected: any) {
+        const promise = query.then(
+          (result: any) => {
+            const durationMs = Math.round(performance.now() - startTime);
+            logger.log({ sql, paramNames, maskedParams, durationMs });
+            return result;
+          },
+          (error: any) => {
+            const durationMs = Math.round(performance.now() - startTime);
+            logger.log({
+              sql,
+              paramNames,
+              maskedParams,
+              durationMs,
+              error: error instanceof Error ? error : new Error(String(error)),
+            });
+            throw error;
+          },
+        );
+        return promise.then(onFulfilled, onRejected);
+      },
+    };
+    return proxied;
+  };
+
+  wrapped.transaction = executor.transaction.bind(executor);
+
+  return wrapped as YdbExecutor;
+}

--- a/src/core/query-options.ts
+++ b/src/core/query-options.ts
@@ -11,4 +11,6 @@ export interface QueryOptions {
   limit?: number;
   /** Смещение для SELECT */
   offset?: number;
+  /** Конкретные колонки для SELECT (вместо SELECT *) */
+  select?: string[];
 }

--- a/src/core/standalone.ts
+++ b/src/core/standalone.ts
@@ -1,0 +1,45 @@
+import type { YdbExecutor } from './interfaces.js';
+import type {
+  YdbBlindIndexProvider,
+  YdbEncryptionProvider,
+} from '../encryption/ydb-encryption-provider.interface.js';
+import type { YdbBaseEntity } from '../entity/base-entity.js';
+
+/**
+ * Конфигурация сущностей для программного использования без NestJS.
+ * Устанавливает executor и (опционально) провайдеры шифрования
+ * на каждую переданную сущность.
+ *
+ * @example
+ * ```ts
+ * import { configureEntities, createDriver, createExecutor } from '@ycforge/ydb-orm';
+ *
+ * const driver = await createDriver({ endpoint: '...', auth_type: 'meta' });
+ * const executor = createExecutor(driver, { endpoint: '...', auth_type: 'meta' });
+ * configureEntities([UserEntity, PostEntity], { executor });
+ * ```
+ */
+export function configureEntities(
+  entities: (new (...args: any[]) => any)[],
+  options: {
+    executor: YdbExecutor;
+    encryptionProvider?: YdbEncryptionProvider;
+    blindIndexProvider?: YdbBlindIndexProvider;
+  },
+): void {
+  for (const entity of entities) {
+    (entity as unknown as typeof YdbBaseEntity).setExecutor(options.executor);
+
+    if (options.encryptionProvider) {
+      (entity as unknown as typeof YdbBaseEntity).setEncryptionProvider(
+        options.encryptionProvider,
+      );
+    }
+
+    if (options.blindIndexProvider) {
+      (entity as unknown as typeof YdbBaseEntity).setBlindIndexProvider(
+        options.blindIndexProvider,
+      );
+    }
+  }
+}

--- a/src/decorators/index.decorator.ts
+++ b/src/decorators/index.decorator.ts
@@ -7,11 +7,14 @@ export interface YdbIndexOptions {
   columns: string[];
   /** Явное имя индекса. По умолчанию: `{table}__{col1}_{col2}`. */
   name?: string;
+  /** Уникальный индекс. По умолчанию false. */
+  unique?: boolean;
 }
 
 export interface YdbIndexMetadata {
   columns: string[];
   name?: string;
+  unique?: boolean;
 }
 
 /**

--- a/src/decorators/json.decorator.ts
+++ b/src/decorators/json.decorator.ts
@@ -1,0 +1,38 @@
+import 'reflect-metadata';
+
+export const YDB_JSON_COLUMNS_KEY = 'ydb:jsonColumns';
+
+/**
+ * Декоратор свойства: колонка хранится как JSON-строка (Utf8 в БД),
+ * но автоматически сериализуется/десериализуется при записи/чтении.
+ *
+ * @example
+ *   @YdbEntity('users')
+ *   class UserEntity extends YdbBaseEntity {
+ *     @YdbJson()
+ *     metadata: { role: string; settings: Record<string, any> };
+ *   }
+ *
+ *   const user = new UserEntity();
+ *   user.metadata = { role: 'admin', settings: { theme: 'dark' } };
+ *   await UserEntity.save(user);
+ *   // В БД: '{"role":"admin","settings":{"theme":"dark"}}'
+ */
+export function YdbJson(): PropertyDecorator {
+  return (target, propertyKey) => {
+    const constructor = target.constructor;
+    const existing: string[] =
+      Reflect.getMetadata(YDB_JSON_COLUMNS_KEY, constructor) || [];
+    if (existing.includes(propertyKey as string)) return;
+    Reflect.defineMetadata(
+      YDB_JSON_COLUMNS_KEY,
+      [...existing, propertyKey as string],
+      constructor,
+    );
+  };
+}
+
+/** Возвращает список JSON-колонок для класса сущности. */
+export function getJsonColumns(target: any): string[] {
+  return Reflect.getMetadata(YDB_JSON_COLUMNS_KEY, target) || [];
+}

--- a/src/decorators/lifecycle.decorator.ts
+++ b/src/decorators/lifecycle.decorator.ts
@@ -1,0 +1,45 @@
+import 'reflect-metadata';
+
+export const YDB_BEFORE_INSERT_KEY = 'ydb:lifecycle:beforeInsert';
+export const YDB_AFTER_INSERT_KEY = 'ydb:lifecycle:afterInsert';
+export const YDB_BEFORE_UPDATE_KEY = 'ydb:lifecycle:beforeUpdate';
+export const YDB_AFTER_FIND_KEY = 'ydb:lifecycle:afterFind';
+export const YDB_BEFORE_REMOVE_KEY = 'ydb:lifecycle:beforeRemove';
+
+function createLifecycleDecorator(metadataKey: string): MethodDecorator {
+  return (_target, propertyKey) => {
+    const constructor = _target.constructor;
+    const existing: string[] =
+      Reflect.getMetadata(metadataKey, constructor) || [];
+    if (existing.includes(propertyKey as string)) return;
+    Reflect.defineMetadata(
+      metadataKey,
+      [...existing, propertyKey as string],
+      constructor,
+    );
+  };
+}
+
+export const BeforeInsert = createLifecycleDecorator(YDB_BEFORE_INSERT_KEY);
+export const AfterInsert = createLifecycleDecorator(YDB_AFTER_INSERT_KEY);
+export const BeforeUpdate = createLifecycleDecorator(YDB_BEFORE_UPDATE_KEY);
+export const AfterFind = createLifecycleDecorator(YDB_AFTER_FIND_KEY);
+export const BeforeRemove = createLifecycleDecorator(YDB_BEFORE_REMOVE_KEY);
+
+export interface LifecycleHooks {
+  beforeInsert: string[];
+  afterInsert: string[];
+  beforeUpdate: string[];
+  afterFind: string[];
+  beforeRemove: string[];
+}
+
+export function getLifecycleHooks(target: any): LifecycleHooks {
+  return {
+    beforeInsert: Reflect.getMetadata(YDB_BEFORE_INSERT_KEY, target) || [],
+    afterInsert: Reflect.getMetadata(YDB_AFTER_INSERT_KEY, target) || [],
+    beforeUpdate: Reflect.getMetadata(YDB_BEFORE_UPDATE_KEY, target) || [],
+    afterFind: Reflect.getMetadata(YDB_AFTER_FIND_KEY, target) || [],
+    beforeRemove: Reflect.getMetadata(YDB_BEFORE_REMOVE_KEY, target) || [],
+  };
+}

--- a/src/decorators/ttl.decorator.ts
+++ b/src/decorators/ttl.decorator.ts
@@ -1,0 +1,43 @@
+import 'reflect-metadata';
+
+export const YDB_TTL_KEY = 'ydb:ttl';
+
+export interface YdbTtlOptions {
+  /** ISO 8601 duration (например, "PT2H", "P30D", "PT1H"). */
+  interval: string;
+  /** Колонка для TTL. По умолчанию — первый PK. */
+  column?: string;
+}
+
+export interface YdbTtlMetadata {
+  interval: string;
+  column: string;
+}
+
+/**
+ * Декларативный TTL таблицы (YDB table TTL).
+ * Можно применить только один раз на класс.
+ * Генерирует TTL = Interval(...) ON `column` в CREATE TABLE DDL.
+ *
+ * @example
+ *   @YdbEntity('sessions')
+ *   @YdbTtl({ interval: 'PT2H' })
+ *   class SessionEntity extends YdbBaseEntity { ... }
+ */
+export function YdbTtl(options: YdbTtlOptions): ClassDecorator {
+  return (target) => {
+    const existing = Reflect.getMetadata(YDB_TTL_KEY, target);
+    if (existing) {
+      throw new Error(
+        `@YdbTtl can only be applied once to class "${target.name}"`,
+      );
+    }
+    Reflect.defineMetadata(YDB_TTL_KEY, options, target);
+  };
+}
+
+export function getYdbTtlMetadata(
+  target: new (...args: any[]) => any,
+): YdbTtlOptions | undefined {
+  return Reflect.getMetadata(YDB_TTL_KEY, target);
+}

--- a/src/encryption/kms-encryption.provider.ts
+++ b/src/encryption/kms-encryption.provider.ts
@@ -1,0 +1,133 @@
+import { createHash } from 'node:crypto';
+import {
+  YdbBlindIndexProvider,
+  YdbEncryptionContext,
+  YdbEncryptionProvider,
+} from './ydb-encryption-provider.interface.js';
+
+/**
+ * Опции для KMS-провайдера шифрования.
+ */
+export interface KmsEncryptionProviderOptions {
+  /** Идентификатор ключа шифрования в Yandex KMS. */
+  keyId: string;
+  /** Необязательный endpoint KMS-сервиса (если не стандартный). */
+  kmsEndpoint?: string;
+}
+
+// Типизация для @ycforge/kms (опциональная зависимость)
+interface KmsClient {
+  encrypt(params: {
+    keyId: string;
+    plaintext: Uint8Array;
+    aad?: Uint8Array;
+  }): Promise<{ ciphertext: Uint8Array }>;
+  decrypt(params: {
+    ciphertext: Uint8Array;
+    aad?: Uint8Array;
+  }): Promise<{ plaintext: Uint8Array }>;
+}
+
+interface KmsModule {
+  KmsClient: new (options?: { endpoint?: string }) => KmsClient;
+}
+
+/**
+ * Провайдер шифрования, использующий Yandex KMS (Key Management Service).
+ *
+ * Шифрует/дешифрует данные через Managed Key из Yandex Cloud KMS.
+ * Аутентификация происходит через окружение (ADC или метаданные инстанса).
+ *
+ * Требует установки пакета `@ycforge/kms`:
+ * ```
+ * npm install @ycforge/kms
+ * ```
+ */
+export class KmsEncryptionProvider implements YdbEncryptionProvider {
+  private kmsClientPromise: Promise<KmsClient>;
+
+  constructor(private readonly options: KmsEncryptionProviderOptions) {
+    this.kmsClientPromise = this.loadKmsClient();
+  }
+
+  /**
+   * Динамический импорт @ycforge/kms — пакет загружается только при создании провайдера.
+   */
+  private async loadKmsClient(): Promise<KmsClient> {
+    // @ts-expect-error @ycforge/kms is an optional peer dependency
+    const kms = await import('@ycforge/kms').catch(() => null);
+    if (!kms) {
+      throw new Error(
+        '@ycforge/kms must be installed for KmsEncryptionProvider: npm install @ycforge/kms',
+      );
+    }
+    const KmsClientClass = (kms as KmsModule).KmsClient;
+    return new KmsClientClass({ endpoint: this.options.kmsEndpoint });
+  }
+
+  /**
+   * Шифрует открытым текст через KMS.
+   * AAD (Additional Authenticated Data) передаётся для защиты целостности контекста.
+   */
+  async encrypt(
+    plaintext: string,
+    aad: string,
+    _context: YdbEncryptionContext,
+  ): Promise<string> {
+    const client = await this.kmsClientPromise;
+    const plaintextBytes = new TextEncoder().encode(plaintext);
+    const params: {
+      keyId: string;
+      plaintext: Uint8Array;
+      aad?: Uint8Array;
+    } = {
+      keyId: this.options.keyId,
+      plaintext: plaintextBytes,
+    };
+    if (aad) {
+      params.aad = new TextEncoder().encode(aad);
+    }
+    const { ciphertext } = await client.encrypt(params);
+    return Buffer.from(ciphertext).toString('base64');
+  }
+
+  /**
+   * Дешифрует ciphertext, полученный через KMS.
+   */
+  async decrypt(
+    ciphertext: string,
+    aad: string,
+    _context: YdbEncryptionContext,
+  ): Promise<string> {
+    const client = await this.kmsClientPromise;
+    const ciphertextBytes = Buffer.from(ciphertext, 'base64');
+    const params: { ciphertext: Uint8Array; aad?: Uint8Array } = {
+      ciphertext: ciphertextBytes,
+    };
+    if (aad) {
+      params.aad = new TextEncoder().encode(aad);
+    }
+    const { plaintext } = await client.decrypt(params);
+    return new TextDecoder().decode(plaintext);
+  }
+}
+
+/**
+ * Провайдер blind index на основе SHA-256.
+ *
+ * Генерирует детерминированный хеш от данных для поиска по зашифрованным полям.
+ * Длина хеша — 16 символов (hex), что достаточно для уникальности盲 index.
+ */
+export class KmsBlindIndexProvider implements YdbBlindIndexProvider {
+  /**
+   * Вычисляет детерминированный blind index (SHA-256, 16 hex-символов).
+   */
+  async hash(
+    plaintext: string,
+    _context: YdbEncryptionContext,
+  ): Promise<string> {
+    return Promise.resolve(
+      createHash('sha256').update(plaintext, 'utf8').digest('hex').slice(0, 16),
+    );
+  }
+}

--- a/src/entity/base-entity.ts
+++ b/src/entity/base-entity.ts
@@ -18,6 +18,7 @@ import {
   YDB_CREATE_DATE_KEY,
   YDB_UPDATE_DATE_KEY,
 } from '../decorators/timestamp.decorator.js';
+import { getLifecycleHooks } from '../decorators/lifecycle.decorator.js';
 import type { YdbPrimitive } from '../core/types.js';
 import type {
   EncryptedFieldMeta,
@@ -28,6 +29,7 @@ import {
   type YdbEnumMeta,
 } from '../decorators/enum.decorator.js';
 import { getEntityRuntime } from './entity-runtime.js';
+import type { YdbValidationProvider } from '../validation/ydb-validate.interface.js';
 import { YdbQueryBuilder } from '../query/query-builder.js';
 
 export class YdbBaseEntity {
@@ -41,6 +43,45 @@ export class YdbBaseEntity {
 
   static setBlindIndexProvider(provider: YdbBlindIndexProvider): void {
     getEntityRuntime(this).blindIndexProvider = provider;
+  }
+
+  static setValidationProvider(provider: YdbValidationProvider): void {
+    getEntityRuntime(this).validationProvider = provider;
+  }
+
+  protected static getValidationProvider(): YdbValidationProvider | undefined {
+    return getEntityRuntime(this).validationProvider;
+  }
+
+  protected static async runValidation(
+    entity: Record<string, any>,
+  ): Promise<void> {
+    const provider = this.getValidationProvider();
+    if (!provider) return;
+    const errors = await provider.validate(entity);
+    if (errors.length) {
+      throw new Error(
+        `Validation failed for ${this.name}: ${errors.join('; ')}`,
+      );
+    }
+  }
+
+  /**
+   * Вызывает lifecycle hooks указанной фазы на экземпляре сущности.
+   * Все хуки выполняются последовательно и awaitятся.
+   */
+  private static async callHooks(
+    phase: keyof ReturnType<typeof getLifecycleHooks>,
+    instance: any,
+  ): Promise<void> {
+    const hooks = getLifecycleHooks(this);
+    const methods = hooks[phase];
+    for (const methodName of methods) {
+      const fn = instance[methodName];
+      if (typeof fn === 'function') {
+        await fn.call(instance);
+      }
+    }
   }
 
   protected static getEncryptionProvider(): YdbEncryptionProvider | undefined {
@@ -639,7 +680,10 @@ export class YdbBaseEntity {
       );
     }
 
-    const sql = `SELECT * FROM ${quoteIdentifier(meta.tableName)} ${whereClause} LIMIT 1`;
+    const selectClause = options?.select?.length
+      ? options.select.map(quoteIdentifier).join(', ')
+      : '*';
+    const sql = `SELECT ${selectClause} FROM ${quoteIdentifier(meta.tableName)} ${whereClause} LIMIT 1`;
 
     const query = exec([sql] as unknown as TemplateStringsArray);
     this.bindParams(query, values, keys, dbSchema);
@@ -657,6 +701,8 @@ export class YdbBaseEntity {
 
     await this.loadEagerRelations([result], options);
 
+    await this.callHooks('afterFind', result);
+
     return result;
   }
 
@@ -672,7 +718,10 @@ export class YdbBaseEntity {
       where,
       meta,
     );
-    const sql = `SELECT * FROM ${quoteIdentifier(meta.tableName)} ${whereClause} LIMIT ${this.resolveLimit(options?.limit)} OFFSET ${this.resolveOffset(options?.offset)}`;
+    const selectClause = options?.select?.length
+      ? options.select.map(quoteIdentifier).join(', ')
+      : '*';
+    const sql = `SELECT ${selectClause} FROM ${quoteIdentifier(meta.tableName)} ${whereClause} LIMIT ${this.resolveLimit(options?.limit)} OFFSET ${this.resolveOffset(options?.offset)}`;
 
     const query = exec([sql] as unknown as TemplateStringsArray);
     this.bindParams(query, values, keys, dbSchema);
@@ -895,6 +944,18 @@ export class YdbBaseEntity {
       }
     }
 
+    const provider = this.getValidationProvider();
+    if (provider) {
+      for (const e of entities) {
+        const errors = await provider.validate(e);
+        if (errors.length) {
+          throw new Error(
+            `Validation failed for ${this.name}: ${errors.join('; ')}`,
+          );
+        }
+      }
+    }
+
     const dataList = await Promise.all(
       entities.map((e) =>
         this.encryptEntity({ ...(e as Record<string, any>) }, meta),
@@ -957,6 +1018,10 @@ export class YdbBaseEntity {
       (entity as any)[updateDateCol] = new Date();
     }
 
+    await this.callHooks('beforeInsert', entity);
+
+    await this.runValidation(entity as Record<string, any>);
+
     const data = await this.encryptEntity(
       { ...(entity as Record<string, any>) },
       meta,
@@ -973,6 +1038,9 @@ export class YdbBaseEntity {
     this.bindParams(query, data, keys, dbSchema);
 
     await this.executeQuery(query, options);
+
+    await this.callHooks('afterInsert', entity);
+
     return entity;
   }
 
@@ -991,6 +1059,10 @@ export class YdbBaseEntity {
     if (updateDateCol) {
       (entity as any)[updateDateCol] = new Date();
     }
+
+    await this.callHooks('beforeUpdate', entity);
+
+    await this.runValidation(entity as Record<string, any>);
 
     const data = await this.encryptEntity(
       { ...(entity as Record<string, any>) },
@@ -1024,6 +1096,158 @@ export class YdbBaseEntity {
     }
     await this.decryptResult(raw, meta);
     return this.instantiate(raw);
+  }
+
+  /**
+   * Массовое обновление по условию.
+   * Возвращает количество затронутых строк.
+   */
+  static async updateBy(
+    this: typeof YdbBaseEntity,
+    where: Record<string, any>,
+    patch: Partial<Record<string, any>>,
+    options?: QueryOptions,
+  ): Promise<number> {
+    if (!Object.keys(where).length) {
+      throw new Error(
+        `updateBy() on ${this.name} requires at least one WHERE condition to prevent full-table update`,
+      );
+    }
+    if (!Object.keys(patch).length) {
+      throw new Error(
+        `updateBy() on ${this.name} requires at least one field in patch`,
+      );
+    }
+
+    const exec = this.getExecutor(options?.trx);
+    const meta = this.getMeta();
+    const { tableName } = meta;
+    const dbSchema = this.getDbSchema(meta);
+
+    // Автоматическая простановка Timestamp колонки обновления
+    const updateDateCol = this.getUpdateDateColumn();
+    const data = { ...patch };
+    if (updateDateCol && data[updateDateCol] === undefined) {
+      data[updateDateCol] = new Date();
+    }
+
+    // Шифрование зашифрованных полей в patch
+    const encryptedFieldsToProcess = meta.encryptedFields.filter((ef) =>
+      Object.prototype.hasOwnProperty.call(data, ef.propertyKey),
+    );
+    if (encryptedFieldsToProcess.length) {
+      const encryptionProvider = this.getEncryptionProvider();
+      if (!encryptionProvider) {
+        throw new Error(
+          `Encryption provider is not configured for entity ${this.name} but @YdbEncrypted fields exist in patch`,
+        );
+      }
+      const blindIndexProvider = this.getBlindIndexProvider();
+      for (const ef of encryptedFieldsToProcess) {
+        const value = data[ef.propertyKey];
+        if (value === null || value === undefined) continue;
+
+        const aad = ef.aadOverride ?? this.buildAAD({}, meta.aadFields);
+        const context: YdbEncryptionContext = {
+          entityName: this.name,
+          tableName: meta.tableName,
+          fieldName: ef.propertyKey,
+          primaryKeyValue: undefined,
+          aadFields: {},
+        };
+
+        data[ef.propertyKey] = await encryptionProvider.encrypt(
+          String(value),
+          aad,
+          context,
+        );
+
+        if (ef.blindIndex) {
+          if (!blindIndexProvider) {
+            throw new Error(
+              `Blind index provider is not configured for entity ${this.name}`,
+            );
+          }
+          data[`${ef.propertyKey}_bi`] = await blindIndexProvider.hash(
+            String(value),
+            { ...context, fieldName: ef.propertyKey },
+          );
+        }
+      }
+    }
+
+    // Валидация: все ключи patch должны быть в схеме
+    const setKeys = Object.keys(data).filter((k) => dbSchema[k]);
+    for (const k of Object.keys(data)) {
+      if (!dbSchema[k]) {
+        throw new Error(`Unknown field in patch: ${k}`);
+      }
+    }
+    if (!setKeys.length) {
+      throw new Error(`updateBy() on ${this.name}: no valid fields in patch`);
+    }
+
+    const setClause = setKeys
+      .map((k) => `${quoteIdentifier(k)} = $${k}`)
+      .join(', ');
+
+    const {
+      whereClause,
+      values: whereValues,
+      keys: whereKeys,
+      dbSchema: whereDbSchema,
+    } = await this.buildWhere(where, meta);
+
+    const allValues: Record<string, any> = { ...whereValues };
+    for (const k of setKeys) {
+      allValues[k] = data[k];
+    }
+    const allKeys = [...whereKeys, ...setKeys];
+    const allDbSchema = { ...whereDbSchema, ...dbSchema };
+
+    const sql = `UPDATE ${quoteIdentifier(tableName)} SET ${setClause} ${whereClause}`;
+    const query = exec([sql] as unknown as TemplateStringsArray);
+    this.bindParams(query, allValues, allKeys, allDbSchema);
+
+    const rows = await this.executeQuery<Record<string, any>[][]>(
+      query,
+      options,
+    );
+    return rows[0]?.length ?? 0;
+  }
+
+  /**
+   * Массовое удаление по условию.
+   * Возвращает количество удалённых строк.
+   */
+  static async deleteBy(
+    this: typeof YdbBaseEntity,
+    where: Record<string, any>,
+    options?: QueryOptions,
+  ): Promise<number> {
+    if (!Object.keys(where).length) {
+      throw new Error(
+        `deleteBy() on ${this.name} requires at least one WHERE condition to prevent full-table delete`,
+      );
+    }
+
+    const exec = this.getExecutor(options?.trx);
+    const meta = this.getMeta();
+
+    const { whereClause, values, keys, dbSchema } = await this.buildWhere(
+      where,
+      meta,
+    );
+
+    const sql = `DELETE FROM ${quoteIdentifier(meta.tableName)} ${whereClause}`;
+    const query = exec([sql] as unknown as TemplateStringsArray);
+    this.bindParams(query, values, keys, dbSchema);
+
+    const rows = await this.executeQuery<Record<string, any>[][]>(
+      query,
+      options,
+    );
+    return rows[0]?.length ?? 0;
   }
 
   /**

--- a/src/entity/entity-runtime.ts
+++ b/src/entity/entity-runtime.ts
@@ -3,12 +3,14 @@ import type {
   YdbBlindIndexProvider,
   YdbEncryptionProvider,
 } from '../encryption/ydb-encryption-provider.interface.js';
+import type { YdbValidationProvider } from '../validation/ydb-validate.interface.js';
 import type { YdbBaseEntity } from './base-entity.js';
 
 export interface EntityRuntime {
   executor?: YdbExecutor;
   encryptionProvider?: YdbEncryptionProvider;
   blindIndexProvider?: YdbBlindIndexProvider;
+  validationProvider?: YdbValidationProvider;
   /** Генератор UUID для PK (по умолчанию v7 — см. base-entity). */
   uuidGenerator?: () => string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,11 @@ export type {
 } from './decorators/index.decorator.js';
 export { YdbEnum, getYdbEnumMetadata } from './decorators/enum.decorator.js';
 export type { YdbEnumMeta } from './decorators/enum.decorator.js';
+export { YdbTtl, getYdbTtlMetadata } from './decorators/ttl.decorator.js';
+export type {
+  YdbTtlOptions,
+  YdbTtlMetadata,
+} from './decorators/ttl.decorator.js';
 
 // Active Record
 export { YdbBaseEntity } from './entity/base-entity.js';
@@ -80,6 +85,18 @@ export type {
   YdbEncryptionContext,
 } from './encryption/ydb-encryption-provider.interface.js';
 export { Base64TestEncryptionProvider } from './encryption/base64-test-encryption.provider.js';
+export {
+  KmsEncryptionProvider,
+  KmsBlindIndexProvider,
+} from './encryption/kms-encryption.provider.js';
+export type { KmsEncryptionProviderOptions } from './encryption/kms-encryption.provider.js';
+
+// Валидация
+export type {
+  YdbValidationProvider,
+  YdbValidationOptions,
+} from './validation/ydb-validate.interface.js';
+export { ClassValidatorProvider } from './validation/ydb-validate.provider.js';
 
 // Метаданные и реестр сущностей
 export { getYdbEntityMetadata } from './metadata/entity-metadata.js';
@@ -143,6 +160,7 @@ export {
   createDriver,
   createExecutor,
 } from './core/driver.js';
+export { configureEntities } from './core/standalone.js';
 export type { YdbCliConfig } from './cli/config.js';
 
 // Credentials

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,8 @@ export type {
   YdbQuery,
   YdbExecutor,
   QueryOptions,
+  QueryLogger,
+  QueryLogEntry,
 } from './core/interfaces.js';
 export {
   YDB_DRIVER,
@@ -26,6 +28,10 @@ export {
 } from './core/constants.js';
 export { mapToYdb } from './core/mapper.js';
 export { quoteIdentifier, validateIdentifier } from './core/sql-utils.js';
+export {
+  ConsoleQueryLogger,
+  wrapExecutorWithLogging,
+} from './core/query-logger.js';
 
 // Декораторы
 export { YdbEntity } from './decorators/entity.decorator.js';

--- a/src/metadata/entity-metadata.ts
+++ b/src/metadata/entity-metadata.ts
@@ -6,6 +6,7 @@ export const YDB_COLUMNS_KEY = 'ydb:columns';
 export const YDB_PRIMARY_KEYS_KEY = 'ydb:primaryKeys';
 export const YDB_ENCRYPTED_KEY = 'ydb:encrypted';
 export const YDB_SECURITY_AAD_KEY = 'ydb:security:aad';
+export const YDB_JSON_COLUMNS_KEY = 'ydb:jsonColumns';
 
 export interface EncryptedFieldMeta {
   propertyKey: string;
@@ -19,6 +20,8 @@ export interface YdbEntityMetadata<T = any> {
   primaryKeys: string[];
   encryptedFields: EncryptedFieldMeta[];
   aadFields: string[];
+  /** Колонки с автоматической JSON-сериализацией (хранятся как Utf8). */
+  jsonColumns: string[];
   target: new (...args: any[]) => T;
 }
 
@@ -54,6 +57,8 @@ export function getYdbEntityMetadata<T>(
   )
     .slice()
     .sort();
+  const jsonColumns: string[] =
+    Reflect.getMetadata(YDB_JSON_COLUMNS_KEY, target) || [];
 
   if (!tableName) return undefined;
 
@@ -70,6 +75,7 @@ export function getYdbEntityMetadata<T>(
     primaryKeys,
     encryptedFields,
     aadFields,
+    jsonColumns,
     target,
   };
   metadataCache.set(target, metadata);

--- a/src/query/query-builder.ts
+++ b/src/query/query-builder.ts
@@ -40,6 +40,7 @@ export class YdbQueryBuilder<T extends YdbBaseEntity> {
   private limitValue?: number;
   private offsetValue?: number;
   private queryOptions?: QueryOptions;
+  private selectColumns?: string[];
 
   constructor(private readonly entity: EntityClass<T>) {}
 
@@ -61,6 +62,12 @@ export class YdbQueryBuilder<T extends YdbBaseEntity> {
 
   addOrderBy(field: string, direction: OrderDirection = 'ASC'): this {
     this.orderClauses.push({ field, direction });
+    return this;
+  }
+
+  /** Указать конкретные колонки для SELECT (вместо SELECT *). */
+  select(columns: string[]): this {
+    this.selectColumns = columns;
     return this;
   }
 
@@ -140,8 +147,12 @@ export class YdbQueryBuilder<T extends YdbBaseEntity> {
           .join(', ')
       : '';
 
+    const selectClause = this.selectColumns?.length
+      ? this.selectColumns.map(quoteIdentifier).join(', ')
+      : '*';
+
     const sql =
-      `SELECT * FROM ${quoteIdentifier(meta.tableName)}` +
+      `SELECT ${selectClause} FROM ${quoteIdentifier(meta.tableName)}` +
       `${whereClause ? ` ${whereClause}` : ''}${orderClause}` +
       ` LIMIT ${this.resolveLimit()} OFFSET ${this.resolveOffset()}`;
 

--- a/src/schema/schema-sync.spec.ts
+++ b/src/schema/schema-sync.spec.ts
@@ -94,7 +94,8 @@ const meta = (entity: new (...args: any[]) => any) => {
 const description = (
   columns: [string, Type_PrimitiveTypeId][],
   primaryKey: string[] = ['uuid'],
-): YdbTableDescription => ({ columns: new Map(columns), primaryKey });
+  indexes: Array<{ name: string; columns: string[]; unique: boolean }> = [],
+): YdbTableDescription => ({ columns: new Map(columns), primaryKey, indexes });
 
 describe('entity registry', () => {
   it('registers classes decorated with @YdbEntity', () => {
@@ -186,8 +187,12 @@ describe('@YdbIndex metadata', () => {
     const schema = buildExpectedTableSchema(meta(TestUserEntity));
 
     expect(schema.indexes).toEqual([
-      { name: 'test_users__secret_bi', columns: ['secret_bi'] },
-      { name: 'test_users__active_name', columns: ['is_active', 'name'] },
+      { name: 'test_users__secret_bi', columns: ['secret_bi'], unique: false },
+      {
+        name: 'test_users__active_name',
+        columns: ['is_active', 'name'],
+        unique: false,
+      },
     ]);
   });
 });
@@ -322,19 +327,36 @@ describe('YdbSchemaSyncer', () => {
 
     expect(executedSql()).toEqual([
       'ALTER TABLE `test_users` ADD COLUMN `secret_bi` Utf8',
+      'ALTER TABLE `test_users` ADD INDEX `test_users__secret_bi` GLOBAL SYNC ON (`secret_bi`)',
+      'ALTER TABLE `test_users` ADD INDEX `test_users__active_name` GLOBAL SYNC ON (`is_active`, `name`)',
     ]);
   });
 
   it('does nothing when schema matches', async () => {
     mockDescribe(
-      description([
-        ['uuid', Type_PrimitiveTypeId.UUID],
-        ['name', Type_PrimitiveTypeId.UTF8],
-        ['secret', Type_PrimitiveTypeId.UTF8],
-        ['is_active', Type_PrimitiveTypeId.BOOL],
-        ['secret_bi', Type_PrimitiveTypeId.UTF8],
-        ['unknown_extra', Type_PrimitiveTypeId.UTF8],
-      ]),
+      description(
+        [
+          ['uuid', Type_PrimitiveTypeId.UUID],
+          ['name', Type_PrimitiveTypeId.UTF8],
+          ['secret', Type_PrimitiveTypeId.UTF8],
+          ['is_active', Type_PrimitiveTypeId.BOOL],
+          ['secret_bi', Type_PrimitiveTypeId.UTF8],
+          ['unknown_extra', Type_PrimitiveTypeId.UTF8],
+        ],
+        ['uuid'],
+        [
+          {
+            name: 'test_users__secret_bi',
+            columns: ['secret_bi'],
+            unique: false,
+          },
+          {
+            name: 'test_users__active_name',
+            columns: ['is_active', 'name'],
+            unique: false,
+          },
+        ],
+      ),
     );
 
     await syncer.sync([TestUserEntity]);

--- a/src/schema/schema-sync.ts
+++ b/src/schema/schema-sync.ts
@@ -23,11 +23,13 @@ import {
   getYdbIndexesMetadata,
   resolveIndexName,
 } from '../decorators/index.decorator.js';
+import { getYdbTtlMetadata } from '../decorators/ttl.decorator.js';
 
 /** Ожидаемый вторичный индекс таблицы. */
 export interface ExpectedIndex {
   name: string;
   columns: string[];
+  unique: boolean;
 }
 
 /** Ожидаемая схема таблицы, построенная по метаданным сущности. */
@@ -36,6 +38,7 @@ export interface ExpectedTableSchema {
   columns: Record<string, YdbPrimitive>;
   primaryKey: string[];
   indexes: ExpectedIndex[];
+  ttl?: { interval: string; column: string };
 }
 
 /** Нормализованное описание существующей таблицы из DescribeTable. */
@@ -43,6 +46,8 @@ export interface YdbTableDescription {
   /** Колонка → примитивный typeId (Optional обёртка снята). */
   columns: Map<string, Type_PrimitiveTypeId>;
   primaryKey: string[];
+  /** Индексы, описанные в БД. */
+  indexes?: Array<{ name: string; columns: string[]; unique: boolean }>;
 }
 
 /** Результат проверки существующей таблицы против ожидаемой схемы. */
@@ -55,6 +60,12 @@ export interface SchemaCheckResult {
   /** Лишние колонки в БД (не удаляются автоматически — потеря данных). */
   extraColumns: string[];
   primaryKeyMatches: boolean;
+  /** Индексы, которые есть в метаданных, но нет в БД. */
+  missingIndexes: ExpectedIndex[];
+  /** Индексы, которые есть в БД, но нет в метаданных. */
+  extraIndexes: Array<{ name: string; columns: string[]; unique: boolean }>;
+  /** Индексы с несовпадающим флагом unique. */
+  uniqueMismatches: { name: string; expected: boolean; actual: boolean }[];
 }
 
 /** Проблема схемы, найденная при verify. */
@@ -65,7 +76,9 @@ export interface YdbSchemaIssue {
     | 'missing-column'
     | 'type-mismatch'
     | 'primary-key-mismatch'
-    | 'extra-column';
+    | 'extra-column'
+    | 'missing-index'
+    | 'extra-index';
   message: string;
 }
 
@@ -116,10 +129,19 @@ export function buildExpectedTableSchema(
     (idx) => ({
       name: idx.name ?? resolveIndexName(meta.tableName, idx.columns),
       columns: [...idx.columns],
+      unique: idx.unique ?? false,
     }),
   );
 
-  return { tableName: meta.tableName, columns, primaryKey, indexes };
+  const ttlOptions = getYdbTtlMetadata(meta.target);
+  const ttl = ttlOptions
+    ? {
+        interval: ttlOptions.interval,
+        column: ttlOptions.column ?? primaryKey[0] ?? 'uuid',
+      }
+    : undefined;
+
+  return { tableName: meta.tableName, columns, primaryKey, indexes, ttl };
 }
 
 /** Ожидаемая схема join-таблицы many-to-many. */
@@ -164,14 +186,19 @@ export function generateCreateTableYql(expected: ExpectedTableSchema): string {
   );
   const indexDefs = (expected.indexes ?? []).map(
     (idx) =>
-      `INDEX ${quoteIdentifier(idx.name)} GLOBAL SYNC ON ` +
+      `${idx.unique ? 'UNIQUE ' : ''}INDEX ${quoteIdentifier(idx.name)} GLOBAL SYNC ON ` +
       `(${idx.columns.map(quoteIdentifier).join(', ')})`,
   );
   const pk = expected.primaryKey.map(quoteIdentifier).join(', ');
-  const body = [...columnDefs, ...indexDefs].join(',\n  ');
+  const parts = [...columnDefs, ...indexDefs, `PRIMARY KEY (${pk})`];
+  if (expected.ttl) {
+    parts.push(
+      `TTL = Interval("${expected.ttl.interval}") ON \`${expected.ttl.column}\``,
+    );
+  }
+  const body = parts.join(',\n  ');
   return (
-    `CREATE TABLE ${quoteIdentifier(expected.tableName)} (\n  ` +
-    `${body},\n  PRIMARY KEY (${pk})\n)`
+    `CREATE TABLE ${quoteIdentifier(expected.tableName)} (\n  ` + `${body}\n)`
   );
 }
 
@@ -184,6 +211,30 @@ export function generateAddColumnsYql(
     ([name, type]) => `ADD COLUMN ${quoteIdentifier(name)} ${type}`,
   );
   return `ALTER TABLE ${quoteIdentifier(tableName)} ${clauses.join(', ')}`;
+}
+
+/** Генерирует DDL добавления индекса через ALTER TABLE. */
+export function generateAddIndexYql(
+  tableName: string,
+  index: ExpectedIndex,
+): string {
+  const uniquePart = index.unique ? 'UNIQUE ' : '';
+  return (
+    `ALTER TABLE ${quoteIdentifier(tableName)} ` +
+    `ADD ${uniquePart}INDEX ${quoteIdentifier(index.name)} GLOBAL SYNC ON ` +
+    `(${index.columns.map(quoteIdentifier).join(', ')})`
+  );
+}
+
+/** Генерирует DDL удаления индекса через ALTER TABLE. */
+export function generateDropIndexYql(
+  tableName: string,
+  indexName: string,
+): string {
+  return (
+    `ALTER TABLE ${quoteIdentifier(tableName)} ` +
+    `DROP INDEX ${quoteIdentifier(indexName)}`
+  );
 }
 
 /**
@@ -222,12 +273,44 @@ export function checkTableSchema(
     expected.primaryKey.length === existing.primaryKey.length &&
     expected.primaryKey.every((pk) => existing.primaryKey.includes(pk));
 
+  const existingIndexes = existing.indexes ?? [];
+
+  const existingIndexMap = new Map(
+    existingIndexes.map((idx) => [idx.name, idx]),
+  );
+  const expectedIndexMap = new Map(
+    (expected.indexes ?? []).map((idx) => [idx.name, idx]),
+  );
+
+  const missingIndexes: ExpectedIndex[] = (expected.indexes ?? []).filter(
+    (idx) => !existingIndexMap.has(idx.name),
+  );
+
+  const extraIndexes = existingIndexes.filter(
+    (idx) => !expectedIndexMap.has(idx.name),
+  );
+
+  const uniqueMismatches: SchemaCheckResult['uniqueMismatches'] = [];
+  for (const idx of expected.indexes ?? []) {
+    const existingIdx = existingIndexMap.get(idx.name);
+    if (existingIdx && existingIdx.unique !== idx.unique) {
+      uniqueMismatches.push({
+        name: idx.name,
+        expected: idx.unique,
+        actual: existingIdx.unique,
+      });
+    }
+  }
+
   return {
     tableName: expected.tableName,
     missingColumns,
     typeMismatches,
     extraColumns,
     primaryKeyMatches,
+    missingIndexes,
+    extraIndexes,
+    uniqueMismatches,
   };
 }
 
@@ -328,6 +411,28 @@ export class YdbSchemaSyncer {
         );
         await this.executeDdl(yql);
       }
+
+      for (const extra of check.extraIndexes) {
+        this.logger.warn(
+          `Table "${expected.tableName}" has extra index "${extra.name}" ` +
+            `not present in entity — left as is`,
+        );
+      }
+
+      for (const idx of check.missingIndexes) {
+        const yql = generateAddIndexYql(expected.tableName, idx);
+        this.logger.log(
+          `Adding index "${idx.name}" to "${expected.tableName}"`,
+        );
+        await this.executeDdl(yql);
+      }
+
+      for (const m of check.uniqueMismatches) {
+        this.logger.warn(
+          `Table "${expected.tableName}" index "${m.name}" unique flag mismatch: ` +
+            `expected ${m.expected}, actual ${m.actual} — recreate index manually if needed`,
+        );
+      }
     }
   }
 
@@ -362,6 +467,20 @@ export class YdbSchemaSyncer {
         tableName: check.tableName,
         kind: 'extra-column',
         message: `Table "${check.tableName}" has extra column "${column}"`,
+      });
+    }
+    for (const idx of check.missingIndexes) {
+      issues.push({
+        tableName: check.tableName,
+        kind: 'missing-index',
+        message: `Table "${check.tableName}" is missing index "${idx.name}"`,
+      });
+    }
+    for (const idx of check.extraIndexes) {
+      issues.push({
+        tableName: check.tableName,
+        kind: 'extra-index',
+        message: `Table "${check.tableName}" has extra index "${idx.name}"`,
       });
     }
 
@@ -418,7 +537,13 @@ export class YdbSchemaSyncer {
         columns.set(column.name, this.extractPrimitiveTypeId(column.type));
       }
 
-      return { columns, primaryKey: [...result.primaryKey] };
+      const indexes = result.indexes.map((idx) => ({
+        name: idx.name,
+        columns: [...idx.indexColumns],
+        unique: idx.type.case === 'globalUniqueIndex',
+      }));
+
+      return { columns, primaryKey: [...result.primaryKey], indexes };
     } finally {
       await client.deleteSession({ sessionId }).catch((error: unknown) => {
         this.logger.warn(

--- a/src/validation/ydb-validate.interface.ts
+++ b/src/validation/ydb-validate.interface.ts
@@ -1,0 +1,7 @@
+export interface YdbValidationProvider {
+  validate(entity: any): Promise<string[]>;
+}
+
+export interface YdbValidationOptions {
+  groups?: string[];
+}

--- a/src/validation/ydb-validate.provider.ts
+++ b/src/validation/ydb-validate.provider.ts
@@ -1,0 +1,49 @@
+import type {
+  YdbValidationProvider,
+  YdbValidationOptions,
+} from './ydb-validate.interface.js';
+
+export class ClassValidatorProvider implements YdbValidationProvider {
+  private readonly groups?: string[];
+
+  constructor(options?: YdbValidationOptions) {
+    this.groups = options?.groups;
+  }
+
+  async validate(entity: any): Promise<string[]> {
+    let validateFn: (
+      object: object,
+      options?: Record<string, unknown>,
+    ) => Promise<any[]>;
+    try {
+      // class-validator — опциональный peer dependency
+      // eslint-disable-next-line @typescript-eslint/no-implied-eval
+      const loader = new Function(
+        'return import("class-validator")',
+      ) as () => Promise<{
+        validate: typeof validateFn;
+      }>;
+      const mod = await loader();
+      validateFn = mod.validate;
+    } catch {
+      throw new Error(
+        'class-validator is not installed. Install it to use ClassValidatorProvider: npm install class-validator reflect-metadata',
+      );
+    }
+
+    const errors = await validateFn(entity, {
+      groups: this.groups,
+      skipMissingProperties: true,
+    });
+
+    if (!errors.length) return [];
+
+    const messages: string[] = [];
+    for (const error of errors) {
+      for (const constraint of Object.values(error.constraints ?? {})) {
+        messages.push(String(constraint));
+      }
+    }
+    return messages;
+  }
+}

--- a/test/cli/migration-check.spec.ts
+++ b/test/cli/migration-check.spec.ts
@@ -1,0 +1,145 @@
+import 'reflect-metadata';
+import { jest } from '@jest/globals';
+import { createMockExecutor } from '../helpers/mock-executor.js';
+import { YdbMigrationRunner } from '../../src/migrations/migration-runner.js';
+import type { YdbMigration } from '../../src/migrations/migration.interface.js';
+
+function makeMigration(name: string): YdbMigration {
+  return {
+    name,
+    up: jest.fn(async () => {}),
+    down: jest.fn(async () => {}),
+  };
+}
+
+describe('migration:check', () => {
+  describe('YdbMigrationRunner.status()', () => {
+    it('reports all applied when no pending migrations', async () => {
+      const mock = createMockExecutor([
+        [
+          { id: 1, timestamp: 1000, name: '20250101-CreateUsers' },
+          { id: 2, timestamp: 2000, name: '20250102-AddEmail' },
+        ],
+      ]);
+      const runner = new YdbMigrationRunner(mock.executor);
+      const migrations = [
+        makeMigration('20250101-CreateUsers'),
+        makeMigration('20250102-AddEmail'),
+      ];
+
+      const statuses = await runner.status(migrations);
+      const pending = statuses.filter((s) => !s.applied);
+
+      expect(statuses).toHaveLength(2);
+      expect(statuses.every((s) => s.applied)).toBe(true);
+      expect(pending).toHaveLength(0);
+    });
+
+    it('reports pending migrations', async () => {
+      const mock = createMockExecutor([
+        [{ id: 1, timestamp: 1000, name: '20250101-CreateUsers' }],
+      ]);
+      const runner = new YdbMigrationRunner(mock.executor);
+      const migrations = [
+        makeMigration('20250101-CreateUsers'),
+        makeMigration('20250102-AddEmail'),
+        makeMigration('20250103-AddRole'),
+      ];
+
+      const statuses = await runner.status(migrations);
+      const pending = statuses.filter((s) => !s.applied);
+
+      expect(statuses).toHaveLength(3);
+      expect(statuses[0].applied).toBe(true);
+      expect(statuses[1].applied).toBe(false);
+      expect(statuses[2].applied).toBe(false);
+      expect(pending).toHaveLength(2);
+      expect(pending.map((s) => s.name)).toEqual([
+        '20250102-AddEmail',
+        '20250103-AddRole',
+      ]);
+    });
+
+    it('returns empty array when no migrations exist', async () => {
+      const mock = createMockExecutor([[]]);
+      const runner = new YdbMigrationRunner(mock.executor);
+
+      const statuses = await runner.status([]);
+
+      expect(statuses).toHaveLength(0);
+    });
+  });
+
+  describe('check logic', () => {
+    it('exits with code 0 when all applied', async () => {
+      const mock = createMockExecutor([
+        [{ id: 1, timestamp: 1000, name: 'm1' }],
+      ]);
+      const runner = new YdbMigrationRunner(mock.executor);
+      const statuses = await runner.status([makeMigration('m1')]);
+      const pending = statuses.filter((s) => !s.applied);
+
+      expect(pending).toHaveLength(0);
+    });
+
+    it('exits with code 1 when pending exist', async () => {
+      const mock = createMockExecutor([[]]);
+      const runner = new YdbMigrationRunner(mock.executor);
+      const statuses = await runner.status([
+        makeMigration('m1'),
+        makeMigration('m2'),
+      ]);
+      const pending = statuses.filter((s) => !s.applied);
+
+      expect(pending).toHaveLength(2);
+    });
+  });
+
+  describe('JSON output format', () => {
+    it('returns correct shape when all applied', async () => {
+      const mock = createMockExecutor([
+        [{ id: 1, timestamp: 1000, name: 'm1' }],
+      ]);
+      const runner = new YdbMigrationRunner(mock.executor);
+      const statuses = await runner.status([makeMigration('m1')]);
+      const pending = statuses.filter((s) => !s.applied);
+
+      const result = {
+        applied: pending.length === 0,
+        pending: pending.map((s) => s.name),
+        total: statuses.length,
+      };
+
+      expect(result).toEqual({
+        applied: true,
+        pending: [],
+        total: 1,
+      });
+    });
+
+    it('returns correct shape when pending exist', async () => {
+      const mock = createMockExecutor([
+        [{ id: 1, timestamp: 1000, name: 'm1' }],
+      ]);
+      const runner = new YdbMigrationRunner(mock.executor);
+      const statuses = await runner.status([
+        makeMigration('m1'),
+        makeMigration('m2'),
+        makeMigration('m3'),
+      ]);
+      const pending = statuses.filter((s) => !s.applied);
+
+      const result = {
+        applied: pending.length === 0,
+        pending: pending.map((s) => s.name),
+        total: statuses.length,
+      };
+
+      expect(result).toEqual({
+        applied: false,
+        pending: ['m2', 'm3'],
+        total: 3,
+      });
+    });
+  });
+});

--- a/test/cli/migration-show-json.spec.ts
+++ b/test/cli/migration-show-json.spec.ts
@@ -1,0 +1,159 @@
+import 'reflect-metadata';
+import { YdbMigrationRunner } from '../../src/migrations/migration-runner.js';
+import { createMockExecutor } from '../helpers/mock-executor.js';
+import type { YdbMigration } from '../../src/migrations/migration.interface.js';
+
+/** Тестовая миграция с заданным именем. */
+function fakeMigration(name: string): YdbMigration {
+  return {
+    name,
+    up: async () => {},
+    down: async () => {},
+  };
+}
+
+describe('migration:show --json', () => {
+  it('JSON-массив содержит все миграции с корректной структурой', async () => {
+    // Returned rows from the mock: one applied migration
+    const mock = createMockExecutor([
+      [{ id: 1, timestamp: 1700000000000, name: '20240101-CreateUsers' }],
+    ]);
+    const runner = new YdbMigrationRunner(mock.executor);
+
+    const statuses = await runner.status([
+      fakeMigration('20240101-CreateUsers'),
+      fakeMigration('20240201-AddEmail'),
+    ]);
+
+    const json = statuses.map((s) => ({
+      name: s.name,
+      applied: s.applied,
+      appliedAt: s.appliedAt ? s.appliedAt.toISOString() : null,
+    }));
+
+    expect(JSON.stringify(json, null, 2)).toBe(
+      JSON.stringify(
+        [
+          {
+            name: '20240101-CreateUsers',
+            applied: true,
+            appliedAt: new Date(1700000000000).toISOString(),
+          },
+          {
+            name: '20240201-AddEmail',
+            applied: false,
+            appliedAt: null,
+          },
+        ],
+        null,
+        2,
+      ),
+    );
+  });
+
+  it('каждый элемент JSON содержит name, applied, appliedAt', async () => {
+    const mock = createMockExecutor([
+      [{ id: 1, timestamp: 1700000000000, name: 'm1' }],
+    ]);
+    const runner = new YdbMigrationRunner(mock.executor);
+
+    const statuses = await runner.status([
+      fakeMigration('m1'),
+      fakeMigration('m2'),
+    ]);
+
+    const json: unknown[] = JSON.parse(
+      JSON.stringify(
+        statuses.map((s) => ({
+          name: s.name,
+          applied: s.applied,
+          appliedAt: s.appliedAt ? s.appliedAt.toISOString() : null,
+        })),
+      ),
+    );
+
+    for (const item of json) {
+      expect(item).toHaveProperty('name');
+      expect(item).toHaveProperty('applied');
+      expect(item).toHaveProperty('appliedAt');
+    }
+  });
+
+  it('применённые миграции — applied=true, pending — applied=false', async () => {
+    const mock = createMockExecutor([
+      [
+        { id: 1, timestamp: 1700000000000, name: 'a' },
+        { id: 2, timestamp: 1700100000000, name: 'b' },
+      ],
+    ]);
+    const runner = new YdbMigrationRunner(mock.executor);
+
+    const statuses = await runner.status([
+      fakeMigration('a'),
+      fakeMigration('b'),
+      fakeMigration('c'),
+    ]);
+
+    const json = statuses.map((s) => ({
+      name: s.name,
+      applied: s.applied,
+      appliedAt: s.appliedAt ? s.appliedAt.toISOString() : null,
+    }));
+
+    expect(json).toEqual([
+      {
+        name: 'a',
+        applied: true,
+        appliedAt: new Date(1700000000000).toISOString(),
+      },
+      {
+        name: 'b',
+        applied: true,
+        appliedAt: new Date(1700100000000).toISOString(),
+      },
+      { name: 'c', applied: false, appliedAt: null },
+    ]);
+  });
+
+  it('все миграции pending — applied=false, appliedAt=null', async () => {
+    const mock = createMockExecutor([[]]);
+    const runner = new YdbMigrationRunner(mock.executor);
+
+    const statuses = await runner.status([
+      fakeMigration('x'),
+      fakeMigration('y'),
+    ]);
+
+    const json = statuses.map((s) => ({
+      name: s.name,
+      applied: s.applied,
+      appliedAt: s.appliedAt ? s.appliedAt.toISOString() : null,
+    }));
+
+    expect(json).toEqual([
+      { name: 'x', applied: false, appliedAt: null },
+      { name: 'y', applied: false, appliedAt: null },
+    ]);
+  });
+
+  it('результат является валидным JSON', async () => {
+    const mock = createMockExecutor([
+      [{ id: 1, timestamp: 1700000000000, name: 'm1' }],
+    ]);
+    const runner = new YdbMigrationRunner(mock.executor);
+
+    const statuses = await runner.status([fakeMigration('m1')]);
+
+    const output = JSON.stringify(
+      statuses.map((s) => ({
+        name: s.name,
+        applied: s.applied,
+        appliedAt: s.appliedAt ? s.appliedAt.toISOString() : null,
+      })),
+      null,
+      2,
+    );
+
+    expect(() => JSON.parse(output)).not.toThrow();
+  });
+});

--- a/test/e2e/base-entity.e2e.spec.ts
+++ b/test/e2e/base-entity.e2e.spec.ts
@@ -1,0 +1,245 @@
+import {
+  createE2eContext,
+  closeE2eContext,
+  hasYdbCredentials,
+  createTableForEntity,
+  dropTableForEntity,
+  type E2eContext,
+} from './setup.js';
+import { E2eItemEntity, E2eSecretEntity } from './entities.js';
+import { E2eOrderEntity, E2eOrderItemEntity } from './entities.js';
+
+let ctx: E2eContext | null = null;
+
+beforeAll(async () => {
+  ctx = await createE2eContext();
+  if (!ctx) return;
+
+  // Create tables using schema sync (generates correct YQL types)
+  for (const Entity of [E2eItemEntity, E2eSecretEntity, E2eOrderEntity, E2eOrderItemEntity]) {
+    await createTableForEntity(ctx.executor, Entity);
+  }
+
+  // Inject executor and encryption providers
+  E2eItemEntity.setExecutor(ctx.executor);
+  E2eSecretEntity.setExecutor(ctx.executor);
+  E2eSecretEntity.setEncryptionProvider(ctx.encryptionProvider);
+  E2eSecretEntity.setBlindIndexProvider(ctx.blindIndexProvider);
+  E2eOrderEntity.setExecutor(ctx.executor);
+  E2eOrderItemEntity.setExecutor(ctx.executor);
+});
+
+afterAll(async () => {
+  if (!ctx) return;
+
+  for (const Entity of [E2eOrderItemEntity, E2eOrderEntity, E2eSecretEntity, E2eItemEntity]) {
+    await dropTableForEntity(ctx.executor, Entity);
+  }
+
+  // Cleanup runtime
+  E2eItemEntity.setExecutor(undefined as any);
+  E2eSecretEntity.setExecutor(undefined as any);
+  E2eSecretEntity.setEncryptionProvider(undefined as any);
+  E2eSecretEntity.setBlindIndexProvider(undefined as any);
+  E2eOrderEntity.setExecutor(undefined as any);
+  E2eOrderItemEntity.setExecutor(undefined as any);
+
+  await closeE2eContext(ctx);
+});
+
+const describeE2e = () => (hasYdbCredentials() ? describe : describe.skip);
+
+describeE2e()('BaseEntity e2e: CRUD', () => {
+  it('insert via save() and retrieve via find()', async () => {
+    const item = new E2eItemEntity();
+    item.name = 'Widget';
+    item.quantity = 10;
+    item.price = 9.99;
+    item.active = true;
+    item.total_views = 1000n;
+    item.description = 'A fine widget';
+
+    const saved = await E2eItemEntity.save(item);
+
+    expect(saved.uuid).toBeDefined();
+    expect(saved.name).toBe('Widget');
+    expect(saved.quantity).toBe(10);
+    expect(saved.price).toBeCloseTo(9.99);
+    expect(saved.active).toBe(true);
+    expect(saved.total_views).toBe(1000n);
+
+    const found = await E2eItemEntity.find({ uuid: saved.uuid });
+    expect(found).not.toBeNull();
+    expect(found!.uuid).toBe(saved.uuid);
+    expect(found!.name).toBe('Widget');
+  });
+
+  it('update via save() with existing uuid', async () => {
+    const item = new E2eItemEntity();
+    item.name = 'Before Update';
+    item.quantity = 1;
+    item.price = 1.0;
+    item.active = false;
+    item.total_views = 0n;
+    item.description = '';
+    await E2eItemEntity.save(item);
+
+    item.name = 'After Update';
+    item.quantity = 99;
+    const updated = await E2eItemEntity.save(item);
+
+    expect(updated.name).toBe('After Update');
+    expect(updated.quantity).toBe(99);
+
+    const found = await E2eItemEntity.find({ uuid: item.uuid });
+    expect(found!.name).toBe('After Update');
+  });
+
+  it('findAll() returns multiple entities', async () => {
+    const a = new E2eItemEntity();
+    a.name = 'ListA';
+    a.quantity = 1;
+    a.price = 1;
+    a.active = true;
+    a.total_views = 0n;
+    a.description = '';
+    await E2eItemEntity.save(a);
+
+    const b = new E2eItemEntity();
+    b.name = 'ListB';
+    b.quantity = 2;
+    b.price = 2;
+    b.active = false;
+    b.total_views = 0n;
+    b.description = '';
+    await E2eItemEntity.save(b);
+
+    const all = await E2eItemEntity.findAll();
+    expect(all.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('count() returns correct count', async () => {
+    const before = await E2eItemEntity.count();
+
+    const item = new E2eItemEntity();
+    item.name = 'CountMe';
+    item.quantity = 1;
+    item.price = 1;
+    item.active = true;
+    item.total_views = 0n;
+    item.description = '';
+    await E2eItemEntity.save(item);
+
+    const after = await E2eItemEntity.count();
+    expect(after).toBe(before + 1);
+  });
+
+  it('find() returns null for non-existent uuid', async () => {
+    const result = await E2eItemEntity.find({
+      uuid: '00000000-0000-0000-0000-000000000000',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('find() throws when called without conditions', async () => {
+    await expect(E2eItemEntity.find({})).rejects.toThrow(
+      /requires at least one condition/,
+    );
+  });
+
+  it('findAll() with limit and offset', async () => {
+    const items = await E2eItemEntity.findAll({}, { limit: 2, offset: 0 });
+    expect(items.length).toBeLessThanOrEqual(2);
+  });
+
+  it('insertMany() inserts multiple entities in batches', async () => {
+    const items = Array.from({ length: 5 }, (_, i) => {
+      const e = new E2eItemEntity();
+      e.name = `Batch${i}`;
+      e.quantity = i;
+      e.price = i * 1.5;
+      e.active = i % 2 === 0;
+      e.total_views = BigInt(i * 100);
+      e.description = `Batch item ${i}`;
+      return e;
+    });
+
+    const result = await E2eItemEntity.insertMany(items);
+    expect(result).toHaveLength(5);
+    for (const r of result) {
+      expect(r.uuid).toBeDefined();
+    }
+  });
+
+  it('save() with special characters (unicode, emoji, quotes)', async () => {
+    const item = new E2eItemEntity();
+    item.name = 'Спецсимволы 🌍 "кавычки" & <тег>';
+    item.quantity = 1;
+    item.price = 1;
+    item.active = true;
+    item.total_views = 0n;
+    item.description = '';
+    await E2eItemEntity.save(item);
+
+    const found = await E2eItemEntity.find({ uuid: item.uuid });
+    expect(found!.name).toBe('Спецсимволы 🌍 "кавычки" & <тег>');
+  });
+
+  it('handles all YDB primitive types', async () => {
+    const item = new E2eItemEntity();
+    item.name = 'AllTypes';
+    item.quantity = -42; // Int32
+    item.price = 3.14159; // Double
+    item.active = false; // Bool
+    item.total_views = 9007199254740991n; // Int64 max safe
+    item.description = ''; // Utf8
+    await E2eItemEntity.save(item);
+
+    const found = await E2eItemEntity.find({ uuid: item.uuid });
+    expect(found!.quantity).toBe(-42);
+    expect(found!.price).toBeCloseTo(3.14159);
+    expect(found!.active).toBe(false);
+    expect(found!.total_views).toBe(9007199254740991n);
+  });
+
+  it('handles null values', async () => {
+    const item = new E2eItemEntity();
+    item.name = 'NullTest';
+    item.quantity = 0;
+    item.price = 0;
+    item.active = false;
+    item.total_views = 0n;
+    item.description = '';
+    await E2eItemEntity.save(item);
+
+    const found = await E2eItemEntity.find({ uuid: item.uuid });
+    expect(found).not.toBeNull();
+    expect(found!.name).toBe('NullTest');
+  });
+
+  it('delete() removes entity and returns it', async () => {
+    const item = new E2eItemEntity();
+    item.name = 'DeleteMe';
+    item.quantity = 1;
+    item.price = 1;
+    item.active = true;
+    item.total_views = 0n;
+    item.description = '';
+    await E2eItemEntity.save(item);
+
+    const deleted = await E2eItemEntity.delete(item.uuid);
+    expect(deleted).not.toBeNull();
+    expect(deleted!.uuid).toBe(item.uuid);
+    expect(deleted!.name).toBe('DeleteMe');
+
+    const found = await E2eItemEntity.find({ uuid: item.uuid });
+    expect(found).toBeNull();
+  });
+
+  it('delete() returns null for non-existent uuid', async () => {
+    const deleted = await E2eItemEntity.delete(
+      '00000000-0000-0000-0000-000000000000',
+    );
+    expect(deleted).toBeNull();
+  });
+});

--- a/test/e2e/base-entity.e2e.spec.ts
+++ b/test/e2e/base-entity.e2e.spec.ts
@@ -16,7 +16,12 @@ beforeAll(async () => {
   if (!ctx) return;
 
   // Create tables using schema sync (generates correct YQL types)
-  for (const Entity of [E2eItemEntity, E2eSecretEntity, E2eOrderEntity, E2eOrderItemEntity]) {
+  for (const Entity of [
+    E2eItemEntity,
+    E2eSecretEntity,
+    E2eOrderEntity,
+    E2eOrderItemEntity,
+  ]) {
     await createTableForEntity(ctx.executor, Entity);
   }
 
@@ -32,7 +37,12 @@ beforeAll(async () => {
 afterAll(async () => {
   if (!ctx) return;
 
-  for (const Entity of [E2eOrderItemEntity, E2eOrderEntity, E2eSecretEntity, E2eItemEntity]) {
+  for (const Entity of [
+    E2eOrderItemEntity,
+    E2eOrderEntity,
+    E2eSecretEntity,
+    E2eItemEntity,
+  ]) {
     await dropTableForEntity(ctx.executor, Entity);
   }
 
@@ -44,7 +54,7 @@ afterAll(async () => {
   E2eOrderEntity.setExecutor(undefined as any);
   E2eOrderItemEntity.setExecutor(undefined as any);
 
-  await closeE2eContext(ctx);
+  closeE2eContext(ctx);
 });
 
 const describeE2e = () => (hasYdbCredentials() ? describe : describe.skip);

--- a/test/e2e/cli.e2e.spec.ts
+++ b/test/e2e/cli.e2e.spec.ts
@@ -22,8 +22,8 @@ beforeAll(async () => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ydb-orm-e2e-cli-'));
 });
 
-afterAll(async () => {
-  if (ctx) await closeE2eContext(ctx);
+afterAll(() => {
+  if (ctx) closeE2eContext(ctx);
   if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
@@ -90,10 +90,11 @@ describeE2e()('CLI e2e', () => {
   it('migration:revert with nothing to revert', async () => {
     // Revert may fail if previous migrations exist in DB but files are missing — that's expected
     try {
-      await execAsync(
-        `node ${cliBin} migration:revert --dir ${tmpDir}`,
-        { cwd: tmpDir, timeout: 30000, env: cliEnv() },
-      );
+      await execAsync(`node ${cliBin} migration:revert --dir ${tmpDir}`, {
+        cwd: tmpDir,
+        timeout: 30000,
+        env: cliEnv(),
+      });
     } catch (e: any) {
       // Expected: "not found — cannot revert" or "nothing to revert"
       expect(e.stderr || e.stdout).toMatch(/not found|nothing to revert/i);

--- a/test/e2e/cli.e2e.spec.ts
+++ b/test/e2e/cli.e2e.spec.ts
@@ -83,15 +83,20 @@ describeE2e()('CLI e2e', () => {
       { cwd: tmpDir, timeout: 30000, env: cliEnv() },
     );
 
-    expect(result.exitCode).toBe(0);
+    // On success, execAsync resolves
+    expect(result.stdout).toBeDefined();
   });
 
   it('migration:revert with nothing to revert', async () => {
-    const result = await execAsync(
-      `node ${cliBin} migration:revert --dir ${tmpDir}`,
-      { cwd: tmpDir, timeout: 30000, env: cliEnv() },
-    );
-
-    expect(result.exitCode).toBe(0);
+    // Revert may fail if previous migrations exist in DB but files are missing — that's expected
+    try {
+      await execAsync(
+        `node ${cliBin} migration:revert --dir ${tmpDir}`,
+        { cwd: tmpDir, timeout: 30000, env: cliEnv() },
+      );
+    } catch (e: any) {
+      // Expected: "not found — cannot revert" or "nothing to revert"
+      expect(e.stderr || e.stdout).toMatch(/not found|nothing to revert/i);
+    }
   });
 });

--- a/test/e2e/cli.e2e.spec.ts
+++ b/test/e2e/cli.e2e.spec.ts
@@ -1,0 +1,97 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+import {
+  createE2eContext,
+  closeE2eContext,
+  hasYdbCredentials,
+  type E2eContext,
+} from './setup.js';
+
+const execAsync = promisify(exec);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+let ctx: E2eContext | null = null;
+let tmpDir: string;
+
+beforeAll(async () => {
+  ctx = await createE2eContext();
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ydb-orm-e2e-cli-'));
+});
+
+afterAll(async () => {
+  if (ctx) await closeE2eContext(ctx);
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const describeE2e = () => (hasYdbCredentials() ? describe : describe.skip);
+
+describeE2e()('CLI e2e', () => {
+  const cliBin = path.resolve(__dirname, '../../dist/cli/cli.js');
+  const endpoint = process.env.YDB_ENDPOINT ?? '';
+  const authType = process.env.YDB_AUTH_TYPE ?? 'anonymous';
+  const authKeyPath = process.env.YDB_AUTHORIZED_KEY_PATH ?? '';
+
+  function cliEnv(): NodeJS.ProcessEnv {
+    return {
+      ...process.env,
+      YDB_ENDPOINT: endpoint,
+      YDB_AUTH_TYPE: authType,
+      ...(authKeyPath ? { YDB_AUTHORIZED_KEY_PATH: authKeyPath } : {}),
+    };
+  }
+
+  it('entity:create generates entity file', async () => {
+    const outDir = path.join(tmpDir, 'entities');
+    fs.mkdirSync(outDir, { recursive: true });
+
+    const result = await execAsync(
+      `node ${cliBin} entity:create Product --dir ${outDir}`,
+      { cwd: tmpDir, timeout: 30000, env: cliEnv() },
+    );
+
+    expect(result.stdout).toContain('created');
+    const files = fs.readdirSync(outDir);
+    expect(files.length).toBe(1);
+    expect(files[0]).toMatch(/product/i);
+
+    const content = fs.readFileSync(path.join(outDir, files[0]), 'utf-8');
+    expect(content).toContain('YdbEntity');
+    expect(content).toContain('YdbBaseEntity');
+  });
+
+  it('migration:create with custom name', async () => {
+    const outDir = path.join(tmpDir, 'migrations');
+    fs.mkdirSync(outDir, { recursive: true });
+
+    const result = await execAsync(
+      `node ${cliBin} migration:create AddIndex --dir ${outDir}`,
+      { cwd: tmpDir, timeout: 30000, env: cliEnv() },
+    );
+
+    expect(result.stdout).toContain('created');
+    const files = fs.readdirSync(outDir);
+    expect(files.some((f) => f.includes('AddIndex'))).toBe(true);
+  });
+
+  it('migration:run with no pending migrations', async () => {
+    const result = await execAsync(
+      `node ${cliBin} migration:run --dir ${tmpDir}`,
+      { cwd: tmpDir, timeout: 30000, env: cliEnv() },
+    );
+
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('migration:revert with nothing to revert', async () => {
+    const result = await execAsync(
+      `node ${cliBin} migration:revert --dir ${tmpDir}`,
+      { cwd: tmpDir, timeout: 30000, env: cliEnv() },
+    );
+
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/test/e2e/encryption.e2e.spec.ts
+++ b/test/e2e/encryption.e2e.spec.ts
@@ -1,0 +1,131 @@
+import {
+  createE2eContext,
+  closeE2eContext,
+  hasYdbCredentials,
+  createTableForEntity,
+  dropTableForEntity,
+  type E2eContext,
+} from './setup.js';
+import { E2eSecretEntity } from './entities.js';
+
+let ctx: E2eContext | null = null;
+
+beforeAll(async () => {
+  ctx = await createE2eContext();
+  if (!ctx) return;
+
+  await createTableForEntity(ctx.executor, E2eSecretEntity);
+
+  E2eSecretEntity.setExecutor(ctx.executor);
+  E2eSecretEntity.setEncryptionProvider(ctx.encryptionProvider);
+  E2eSecretEntity.setBlindIndexProvider(ctx.blindIndexProvider);
+});
+
+afterAll(async () => {
+  if (!ctx) return;
+  await dropTableForEntity(ctx.executor, E2eSecretEntity);
+  E2eSecretEntity.setExecutor(undefined as any);
+  E2eSecretEntity.setEncryptionProvider(undefined as any);
+  E2eSecretEntity.setBlindIndexProvider(undefined as any);
+  await closeE2eContext(ctx);
+});
+
+const describeE2e = () => (hasYdbCredentials() ? describe : describe.skip);
+
+describeE2e()('Encryption e2e', () => {
+  it('encrypts on save and decrypts on find (with blind index)', async () => {
+    const secret = new E2eSecretEntity();
+    secret.email = 'alice@example.com';
+    secret.notes = 'some private notes';
+    secret.plaintext = 'not encrypted';
+
+    await E2eSecretEntity.save(secret);
+
+    const found = await E2eSecretEntity.find({ uuid: secret.uuid });
+    expect(found).not.toBeNull();
+    // Encrypted fields should be decrypted on read
+    expect(found!.email).toBe('alice@example.com');
+    expect(found!.notes).toBe('some private notes');
+    expect(found!.plaintext).toBe('not encrypted');
+  });
+
+  it('searches by encrypted field via blind index', async () => {
+    const secret = new E2eSecretEntity();
+    secret.email = 'bob@example.com';
+    secret.notes = 'bob notes';
+    secret.plaintext = 'bob plaintext';
+    await E2eSecretEntity.save(secret);
+
+    // Search by email (has blind index) — should find by blind index hash
+    const found = await E2eSecretEntity.find({ email: 'bob@example.com' });
+    expect(found).not.toBeNull();
+    expect(found!.email).toBe('bob@example.com');
+    expect(found!.notes).toBe('bob notes');
+  });
+
+  it('search by encrypted field without blind index throws', async () => {
+    await expect(E2eSecretEntity.find({ notes: 'some notes' })).rejects.toThrow(
+      /without blind index/,
+    );
+  });
+
+  it('handles null encrypted fields', async () => {
+    const secret = new E2eSecretEntity();
+    secret.email = 'null-test@example.com';
+    secret.notes = null as any;
+    secret.plaintext = 'has value';
+    await E2eSecretEntity.save(secret);
+
+    const found = await E2eSecretEntity.find({ uuid: secret.uuid });
+    expect(found).not.toBeNull();
+    expect(found!.email).toBe('null-test@example.com');
+    expect(found!.notes).toBeNull();
+  });
+
+  it('handles empty string encrypted fields', async () => {
+    const secret = new E2eSecretEntity();
+    secret.email = 'empty@example.com';
+    secret.notes = '';
+    secret.plaintext = '';
+    await E2eSecretEntity.save(secret);
+
+    const found = await E2eSecretEntity.find({ uuid: secret.uuid });
+    expect(found).not.toBeNull();
+    expect(found!.email).toBe('empty@example.com');
+    expect(found!.notes).toBe('');
+  });
+
+  it('handles unicode and emoji in encrypted fields', async () => {
+    const secret = new E2eSecretEntity();
+    secret.email = 'юзер@пример.рф';
+    secret.notes = 'Привет 🌍';
+    secret.plaintext = 'plain unicode';
+    await E2eSecretEntity.save(secret);
+
+    const found = await E2eSecretEntity.find({ uuid: secret.uuid });
+    expect(found!.email).toBe('юзер@пример.рф');
+    expect(found!.notes).toBe('Привет 🌍');
+  });
+
+  it('update encrypted field', async () => {
+    const secret = new E2eSecretEntity();
+    secret.email = 'update-old@example.com';
+    secret.notes = 'old notes';
+    secret.plaintext = 'unchanged';
+    await E2eSecretEntity.save(secret);
+
+    secret.email = 'update-new@example.com';
+    secret.notes = 'new notes';
+    await E2eSecretEntity.save(secret);
+
+    const found = await E2eSecretEntity.find({ uuid: secret.uuid });
+    expect(found!.email).toBe('update-new@example.com');
+    expect(found!.notes).toBe('new notes');
+
+    // Old email should not be findable
+    const oldFound = await E2eSecretEntity.find({
+      email: 'update-old@example.com',
+    });
+    expect(oldFound).toBeNull();
+  });
+});

--- a/test/e2e/encryption.e2e.spec.ts
+++ b/test/e2e/encryption.e2e.spec.ts
@@ -27,7 +27,7 @@ afterAll(async () => {
   E2eSecretEntity.setExecutor(undefined as any);
   E2eSecretEntity.setEncryptionProvider(undefined as any);
   E2eSecretEntity.setBlindIndexProvider(undefined as any);
-  await closeE2eContext(ctx);
+  closeE2eContext(ctx);
 });
 
 const describeE2e = () => (hasYdbCredentials() ? describe : describe.skip);

--- a/test/e2e/entities.ts
+++ b/test/e2e/entities.ts
@@ -1,0 +1,109 @@
+import {
+  YdbEntity,
+  YdbColumn,
+  YdbPrimaryColumn,
+  YdbBaseEntity,
+  YdbEncrypted,
+  OneToMany,
+  OneToOne,
+  EagerLoad,
+} from '../../src/index.js';
+
+@YdbEntity('e2e_items')
+export class E2eItemEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid!: string;
+
+  @YdbColumn('Utf8')
+  name!: string;
+
+  @YdbColumn('Int32')
+  quantity!: number;
+
+  @YdbColumn('Double')
+  price!: number;
+
+  @YdbColumn('Bool')
+  active!: boolean;
+
+  @YdbColumn('Int64')
+  total_views!: bigint;
+
+  @YdbColumn('Utf8')
+  description!: string;
+}
+
+@YdbEntity('e2e_secrets')
+export class E2eSecretEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid!: string;
+
+  @YdbEncrypted({ blindIndex: true })
+  @YdbColumn('Utf8')
+  email!: string;
+
+  @YdbEncrypted({ blindIndex: false })
+  @YdbColumn('Utf8')
+  notes!: string;
+
+  @YdbColumn('Utf8')
+  plaintext!: string;
+}
+
+@YdbEntity('e2e_order_items')
+export class E2eOrderItemEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid!: string;
+
+  @YdbColumn('Uuid')
+  order_uuid!: string;
+
+  @YdbColumn('Utf8')
+  product!: string;
+
+  @YdbColumn('Int32')
+  qty!: number;
+}
+
+@YdbEntity('e2e_orders')
+@EagerLoad(['items'])
+export class E2eOrderEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid!: string;
+
+  @YdbColumn('Utf8')
+  customer!: string;
+
+  @YdbColumn('Int32')
+  total!: number;
+
+  @OneToMany(() => E2eOrderItemEntity, (item) => item.order_uuid)
+  items?: E2eOrderItemEntity[];
+}
+
+@YdbEntity('e2e_users')
+export class E2eUserEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid!: string;
+
+  @YdbColumn('Utf8')
+  name!: string;
+
+  @YdbColumn('Uuid')
+  profile_uuid?: string;
+}
+
+@YdbEntity('e2e_profiles')
+export class E2eProfileEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid!: string;
+
+  @YdbColumn('Uuid')
+  user_uuid!: string;
+
+  @YdbColumn('Utf8')
+  bio!: string;
+
+  @OneToOne(() => E2eUserEntity, 'user_uuid')
+  user?: E2eUserEntity;
+}

--- a/test/e2e/migrations.e2e.spec.ts
+++ b/test/e2e/migrations.e2e.spec.ts
@@ -1,0 +1,74 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+import {
+  createE2eContext,
+  closeE2eContext,
+  hasYdbCredentials,
+  type E2eContext,
+} from './setup.js';
+
+const execAsync = promisify(exec);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+let ctx: E2eContext | null = null;
+let tmpDir: string;
+
+beforeAll(async () => {
+  ctx = await createE2eContext();
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ydb-orm-e2e-mig-'));
+});
+
+afterAll(async () => {
+  if (ctx) await closeE2eContext(ctx);
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const describeE2e = () => (hasYdbCredentials() ? describe : describe.skip);
+
+describeE2e()('Migrations e2e', () => {
+  const cliBin = path.resolve(__dirname, '../../dist/cli/cli.js');
+  const endpoint = process.env.YDB_ENDPOINT ?? '';
+  const authType = process.env.YDB_AUTH_TYPE ?? 'anonymous';
+  const authKeyPath = process.env.YDB_AUTHORIZED_KEY_PATH ?? '';
+
+  function cliEnv(): NodeJS.ProcessEnv {
+    return {
+      ...process.env,
+      YDB_ENDPOINT: endpoint,
+      YDB_AUTH_TYPE: authType,
+      ...(authKeyPath ? { YDB_AUTHORIZED_KEY_PATH: authKeyPath } : {}),
+    };
+  }
+
+  it('migration:create generates a migration file', async () => {
+    const outDir = path.join(tmpDir, 'migrations');
+    fs.mkdirSync(outDir, { recursive: true });
+
+    const result = await execAsync(
+      `node ${cliBin} migration:create TestMigration --dir ${outDir}`,
+      { cwd: tmpDir, timeout: 30000, env: cliEnv() },
+    );
+
+    expect(result.stdout).toContain('created');
+    const files = fs.readdirSync(outDir);
+    expect(files.length).toBe(1);
+    expect(files[0]).toMatch(/TestMigration/);
+
+    const content = fs.readFileSync(path.join(outDir, files[0]), 'utf-8');
+    expect(content).toContain('up');
+    expect(content).toContain('down');
+  });
+
+  it('migration:show lists no migrations initially', async () => {
+    const result = await execAsync(
+      `node ${cliBin} migration:show --dir ${tmpDir}`,
+      { cwd: tmpDir, timeout: 30000, env: cliEnv() },
+    );
+
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/test/e2e/migrations.e2e.spec.ts
+++ b/test/e2e/migrations.e2e.spec.ts
@@ -69,6 +69,7 @@ describeE2e()('Migrations e2e', () => {
       { cwd: tmpDir, timeout: 30000, env: cliEnv() },
     );
 
-    expect(result.exitCode).toBe(0);
+    // On success, execAsync resolves (exitCode undefined for 0)
+    expect(result.stdout).toBeDefined();
   });
 });

--- a/test/e2e/migrations.e2e.spec.ts
+++ b/test/e2e/migrations.e2e.spec.ts
@@ -22,8 +22,8 @@ beforeAll(async () => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ydb-orm-e2e-mig-'));
 });
 
-afterAll(async () => {
-  if (ctx) await closeE2eContext(ctx);
+afterAll(() => {
+  if (ctx) closeE2eContext(ctx);
   if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 

--- a/test/e2e/relations.e2e.spec.ts
+++ b/test/e2e/relations.e2e.spec.ts
@@ -19,7 +19,12 @@ beforeAll(async () => {
   ctx = await createE2eContext();
   if (!ctx) return;
 
-  for (const Entity of [E2eOrderEntity, E2eOrderItemEntity, E2eUserEntity, E2eProfileEntity]) {
+  for (const Entity of [
+    E2eOrderEntity,
+    E2eOrderItemEntity,
+    E2eUserEntity,
+    E2eProfileEntity,
+  ]) {
     await createTableForEntity(ctx.executor, Entity);
   }
 
@@ -31,14 +36,19 @@ beforeAll(async () => {
 
 afterAll(async () => {
   if (!ctx) return;
-  for (const Entity of [E2eProfileEntity, E2eUserEntity, E2eOrderItemEntity, E2eOrderEntity]) {
+  for (const Entity of [
+    E2eProfileEntity,
+    E2eUserEntity,
+    E2eOrderItemEntity,
+    E2eOrderEntity,
+  ]) {
     await dropTableForEntity(ctx.executor, Entity);
   }
   E2eOrderEntity.setExecutor(undefined as any);
   E2eOrderItemEntity.setExecutor(undefined as any);
   E2eUserEntity.setExecutor(undefined as any);
   E2eProfileEntity.setExecutor(undefined as any);
-  await closeE2eContext(ctx);
+  closeE2eContext(ctx);
 });
 
 const describeE2e = () => (hasYdbCredentials() ? describe : describe.skip);

--- a/test/e2e/relations.e2e.spec.ts
+++ b/test/e2e/relations.e2e.spec.ts
@@ -1,0 +1,116 @@
+import {
+  createE2eContext,
+  closeE2eContext,
+  hasYdbCredentials,
+  createTableForEntity,
+  dropTableForEntity,
+  type E2eContext,
+} from './setup.js';
+import {
+  E2eOrderEntity,
+  E2eOrderItemEntity,
+  E2eUserEntity,
+  E2eProfileEntity,
+} from './entities.js';
+
+let ctx: E2eContext | null = null;
+
+beforeAll(async () => {
+  ctx = await createE2eContext();
+  if (!ctx) return;
+
+  for (const Entity of [E2eOrderEntity, E2eOrderItemEntity, E2eUserEntity, E2eProfileEntity]) {
+    await createTableForEntity(ctx.executor, Entity);
+  }
+
+  E2eOrderEntity.setExecutor(ctx.executor);
+  E2eOrderItemEntity.setExecutor(ctx.executor);
+  E2eUserEntity.setExecutor(ctx.executor);
+  E2eProfileEntity.setExecutor(ctx.executor);
+});
+
+afterAll(async () => {
+  if (!ctx) return;
+  for (const Entity of [E2eProfileEntity, E2eUserEntity, E2eOrderItemEntity, E2eOrderEntity]) {
+    await dropTableForEntity(ctx.executor, Entity);
+  }
+  E2eOrderEntity.setExecutor(undefined as any);
+  E2eOrderItemEntity.setExecutor(undefined as any);
+  E2eUserEntity.setExecutor(undefined as any);
+  E2eProfileEntity.setExecutor(undefined as any);
+  await closeE2eContext(ctx);
+});
+
+const describeE2e = () => (hasYdbCredentials() ? describe : describe.skip);
+
+describeE2e()('Relations e2e', () => {
+  describe('OneToMany + EagerLoad', () => {
+    it('eagerly loads child entities via @OneToMany', async () => {
+      const order = new E2eOrderEntity();
+      order.customer = 'Test Customer';
+      order.total = 30;
+      await E2eOrderEntity.save(order);
+
+      const item1 = new E2eOrderItemEntity();
+      item1.order_uuid = order.uuid;
+      item1.product = 'Item A';
+      item1.qty = 2;
+      await E2eOrderItemEntity.save(item1);
+
+      const item2 = new E2eOrderItemEntity();
+      item2.order_uuid = order.uuid;
+      item2.product = 'Item B';
+      item2.qty = 1;
+      await E2eOrderItemEntity.save(item2);
+
+      // EagerLoad should populate items automatically
+      const found = await E2eOrderEntity.find({ uuid: order.uuid });
+      expect(found).not.toBeNull();
+      expect(found!.customer).toBe('Test Customer');
+      expect(found!.items).toBeDefined();
+      expect(found!.items!.length).toBe(2);
+
+      const products = found!.items!.map((i) => i.product).sort();
+      expect(products).toEqual(['Item A', 'Item B']);
+    });
+  });
+
+  describe('ManyToOne', () => {
+    it('stores foreign key and loads parent via loadRelations', async () => {
+      const order = new E2eOrderEntity();
+      order.customer = 'FK Test';
+      order.total = 50;
+      await E2eOrderEntity.save(order);
+
+      const item = new E2eOrderItemEntity();
+      item.order_uuid = order.uuid;
+      item.product = 'FK Item';
+      item.qty = 5;
+      await E2eOrderItemEntity.save(item);
+
+      const found = await E2eOrderItemEntity.find({ uuid: item.uuid });
+      expect(found).not.toBeNull();
+      expect(found!.order_uuid).toBe(order.uuid);
+    });
+  });
+
+  describe('OneToOne', () => {
+    it('stores foreign key and loads related entity', async () => {
+      const user = new E2eUserEntity();
+      user.name = 'Profile User';
+      await E2eUserEntity.save(user);
+
+      const profile = new E2eProfileEntity();
+      profile.user_uuid = user.uuid;
+      profile.bio = 'Test bio';
+      await E2eProfileEntity.save(profile);
+
+      const foundProfile = await E2eProfileEntity.find({
+        uuid: profile.uuid,
+      });
+      expect(foundProfile).not.toBeNull();
+      expect(foundProfile!.user_uuid).toBe(user.uuid);
+      expect(foundProfile!.bio).toBe('Test bio');
+    });
+  });
+});

--- a/test/e2e/setup.ts
+++ b/test/e2e/setup.ts
@@ -83,8 +83,8 @@ export async function createE2eContext(): Promise<E2eContext | null> {
 /**
  * Закрывает подключение к YDB.
  */
-export async function closeE2eContext(ctx: E2eContext): Promise<void> {
-  await ctx.driver.close();
+export function closeE2eContext(ctx: E2eContext): void {
+  ctx.driver.close();
 }
 
 /**
@@ -102,15 +102,14 @@ export async function createTableForEntity(
   executor: YdbExecutor,
   entityClass: new (...args: any[]) => any,
 ): Promise<void> {
-  const { buildExpectedTableSchema, generateCreateTableYql } = await import(
-    '../../src/schema/schema-sync.js'
-  );
-  const { getYdbEntityMetadata } = await import(
-    '../../src/metadata/entity-metadata.js'
-  );
+  const { buildExpectedTableSchema, generateCreateTableYql } =
+    await import('../../src/schema/schema-sync.js');
+  const { getYdbEntityMetadata } =
+    await import('../../src/metadata/entity-metadata.js');
 
   const meta = getYdbEntityMetadata(entityClass);
-  if (!meta) throw new Error(`${entityClass.name} is not decorated with @YdbEntity`);
+  if (!meta)
+    throw new Error(`${entityClass.name} is not decorated with @YdbEntity`);
   const expected = buildExpectedTableSchema(meta);
   const yql = generateCreateTableYql(expected);
   const tmpl = [yql] as unknown as TemplateStringsArray;
@@ -129,12 +128,13 @@ export async function dropTableForEntity(
   executor: YdbExecutor,
   entityClass: new (...args: any[]) => any,
 ): Promise<void> {
-  const { getYdbEntityMetadata } = await import(
-    '../../src/metadata/entity-metadata.js'
-  );
+  const { getYdbEntityMetadata } =
+    await import('../../src/metadata/entity-metadata.js');
   const meta = getYdbEntityMetadata(entityClass);
   if (!meta) return;
-  const tmpl = [`DROP TABLE IF EXISTS \`${meta.tableName}\``] as unknown as TemplateStringsArray;
+  const tmpl = [
+    `DROP TABLE IF EXISTS \`${meta.tableName}\``,
+  ] as unknown as TemplateStringsArray;
   tmpl.raw = tmpl;
   try {
     await executor(tmpl);

--- a/test/e2e/setup.ts
+++ b/test/e2e/setup.ts
@@ -1,0 +1,144 @@
+import 'reflect-metadata';
+import { Driver } from '@ydbjs/core';
+import { query } from '@ydbjs/query';
+import { CredentialsProvider } from '@ydbjs/auth';
+import { MetadataCredentialsProvider } from '@ydbjs/auth/metadata';
+import { AnonymousCredentialsProvider } from '@ydbjs/auth/anonymous';
+import { AuthKeyCredentialsProvider } from '../../src/credentials/auth-key-credentials-provider.js';
+import type { YdbExecutor } from '../../src/core/interfaces.js';
+import { Base64TestEncryptionProvider } from '../../src/encryption/base64-test-encryption.provider.js';
+import type {
+  YdbEncryptionProvider,
+  YdbBlindIndexProvider,
+} from '../../src/encryption/ydb-encryption-provider.interface.js';
+
+export interface E2eContext {
+  driver: Driver;
+  executor: YdbExecutor;
+  encryptionProvider: YdbEncryptionProvider;
+  blindIndexProvider: YdbBlindIndexProvider;
+  dbPath: string;
+}
+
+function getEnv(name: string): string | undefined {
+  return process.env[name]?.trim() || undefined;
+}
+
+function requireEnv(name: string): string {
+  const val = getEnv(name);
+  if (!val) throw new Error(`Missing required env var: ${name}`);
+  return val;
+}
+
+/**
+ * Создаёт credentials provider по auth_type из переменных окружения.
+ */
+function createCredentialsProvider(authType: string): CredentialsProvider {
+  switch (authType) {
+    case 'meta':
+      return new MetadataCredentialsProvider();
+    case 'auth_key': {
+      const keyPath = requireEnv('YDB_AUTHORIZED_KEY_PATH');
+      return AuthKeyCredentialsProvider.fromAuthorizedKeyFile(keyPath);
+    }
+    case 'anonymous':
+      return new AnonymousCredentialsProvider();
+    default:
+      throw new Error(`Invalid auth_type: ${authType}`);
+  }
+}
+
+/**
+ * Создаёт подключение к YDB и executor.
+ * Возвращает null если переменные окружения не заданы (skip tests).
+ */
+export async function createE2eContext(): Promise<E2eContext | null> {
+  const endpoint = getEnv('YDB_ENDPOINT');
+  const authType = getEnv('YDB_AUTH_TYPE');
+
+  if (!endpoint || !authType) {
+    return null;
+  }
+
+  const credentialsProvider = createCredentialsProvider(authType);
+  const driver = new Driver(endpoint, { credentialsProvider });
+  await driver.ready();
+
+  const executor = query(driver) as unknown as YdbExecutor;
+  const encryptionProvider = new Base64TestEncryptionProvider();
+
+  // Извлекаем путь БД из endpoint (параметр database)
+  const url = new URL(endpoint);
+  const dbPath = url.searchParams.get('database') ?? '/local';
+
+  return {
+    driver,
+    executor,
+    encryptionProvider,
+    blindIndexProvider: encryptionProvider,
+    dbPath,
+  };
+}
+
+/**
+ * Закрывает подключение к YDB.
+ */
+export async function closeE2eContext(ctx: E2eContext): Promise<void> {
+  await ctx.driver.close();
+}
+
+/**
+ * Skip helper: если YDB_ENDPOINT не задан, пропускает тест.
+ */
+export function hasYdbCredentials(): boolean {
+  return !!(getEnv('YDB_ENDPOINT') && getEnv('YDB_AUTH_TYPE'));
+}
+
+/**
+ * Создаёт таблицу для сущности через schema-sync (генерирует корректные YQL-типы).
+ * Если таблица уже существует — игнорирует ошибку.
+ */
+export async function createTableForEntity(
+  executor: YdbExecutor,
+  entityClass: new (...args: any[]) => any,
+): Promise<void> {
+  const { buildExpectedTableSchema, generateCreateTableYql } = await import(
+    '../../src/schema/schema-sync.js'
+  );
+  const { getYdbEntityMetadata } = await import(
+    '../../src/metadata/entity-metadata.js'
+  );
+
+  const meta = getYdbEntityMetadata(entityClass);
+  if (!meta) throw new Error(`${entityClass.name} is not decorated with @YdbEntity`);
+  const expected = buildExpectedTableSchema(meta);
+  const yql = generateCreateTableYql(expected);
+  const tmpl = [yql] as unknown as TemplateStringsArray;
+  tmpl.raw = [yql];
+  try {
+    await executor(tmpl);
+  } catch {
+    // Table already exists
+  }
+}
+
+/**
+ * Удаляет таблицу для сущности.
+ */
+export async function dropTableForEntity(
+  executor: YdbExecutor,
+  entityClass: new (...args: any[]) => any,
+): Promise<void> {
+  const { getYdbEntityMetadata } = await import(
+    '../../src/metadata/entity-metadata.js'
+  );
+  const meta = getYdbEntityMetadata(entityClass);
+  if (!meta) return;
+  const tmpl = [`DROP TABLE IF EXISTS \`${meta.tableName}\``] as unknown as TemplateStringsArray;
+  tmpl.raw = tmpl;
+  try {
+    await executor(tmpl);
+  } catch {
+    // Ignore
+  }
+}

--- a/test/kms-encryption.spec.ts
+++ b/test/kms-encryption.spec.ts
@@ -1,0 +1,158 @@
+import 'reflect-metadata';
+import { jest } from '@jest/globals';
+import { createHash } from 'node:crypto';
+import type { YdbEncryptionContext } from '../src/encryption/ydb-encryption-provider.interface.js';
+import {
+  KmsEncryptionProvider,
+  KmsBlindIndexProvider,
+} from '../src/encryption/kms-encryption.provider.js';
+
+/**
+ * Мок KMS-клиента.
+ * Тестируем loadKmsClient через prototype-мок, чтобы не ходить в @ycforge/kms.
+ */
+const mockEncryptResult = {
+  ciphertext: new Uint8Array([1, 2, 3, 4, 5]),
+};
+const mockDecryptResult = {
+  plaintext: new TextEncoder().encode('hello world'),
+};
+
+const mockKmsClient = {
+  encrypt: jest
+    .fn<() => Promise<typeof mockEncryptResult>>()
+    .mockResolvedValue(mockEncryptResult),
+  decrypt: jest
+    .fn<() => Promise<typeof mockDecryptResult>>()
+    .mockResolvedValue(mockDecryptResult),
+};
+
+const context: YdbEncryptionContext = {
+  entityName: 'TestEntity',
+  tableName: 'test',
+  fieldName: 'email',
+  primaryKeyValue: 'some-uuid',
+  aadFields: {},
+};
+
+describe('KmsEncryptionProvider', () => {
+  let loadSpy: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    loadSpy = jest
+      .spyOn(KmsEncryptionProvider.prototype as any, 'loadKmsClient')
+      .mockResolvedValue(mockKmsClient);
+  });
+
+  afterEach(() => {
+    loadSpy.mockRestore();
+  });
+
+  it('encrypts and calls KMS client', async () => {
+    const provider = new KmsEncryptionProvider({ keyId: 'test-key-id' });
+    const result = await provider.encrypt('hello world', 'aad-value', context);
+
+    expect(result).toBe(Buffer.from([1, 2, 3, 4, 5]).toString('base64'));
+    expect(mockKmsClient.encrypt).toHaveBeenCalledTimes(1);
+    expect(mockKmsClient.encrypt).toHaveBeenCalledWith({
+      keyId: 'test-key-id',
+      plaintext: new TextEncoder().encode('hello world'),
+      aad: new TextEncoder().encode('aad-value'),
+    });
+  });
+
+  it('encrypts without AAD when aad is empty', async () => {
+    const provider = new KmsEncryptionProvider({ keyId: 'test-key-id' });
+    await provider.encrypt('data', '', context);
+
+    expect(mockKmsClient.encrypt).toHaveBeenCalledWith({
+      keyId: 'test-key-id',
+      plaintext: new TextEncoder().encode('data'),
+    });
+  });
+
+  it('decrypts and calls KMS client', async () => {
+    const provider = new KmsEncryptionProvider({ keyId: 'test-key-id' });
+    const ciphertext = Buffer.from([1, 2, 3, 4, 5]).toString('base64');
+    const result = await provider.decrypt(ciphertext, 'aad-value', context);
+
+    expect(result).toBe('hello world');
+    expect(mockKmsClient.decrypt).toHaveBeenCalledTimes(1);
+    expect(mockKmsClient.decrypt).toHaveBeenCalledWith({
+      ciphertext: new Uint8Array([1, 2, 3, 4, 5]),
+      aad: new TextEncoder().encode('aad-value'),
+    });
+  });
+
+  it('decrypts without AAD when aad is empty', async () => {
+    const provider = new KmsEncryptionProvider({ keyId: 'test-key-id' });
+    const ciphertext = Buffer.from([10, 20]).toString('base64');
+    await provider.decrypt(ciphertext, '', context);
+
+    expect(mockKmsClient.decrypt).toHaveBeenCalledWith({
+      ciphertext: new Uint8Array([10, 20]),
+    });
+  });
+
+  it('roundtrips encrypt/decrypt', async () => {
+    const provider = new KmsEncryptionProvider({ keyId: 'test-key-id' });
+
+    const plaintext = 'Привет мир!';
+    const encoded = new TextEncoder().encode(plaintext);
+    const fakeCiphertext = new Uint8Array([99, 100, 101]);
+
+    mockKmsClient.encrypt.mockResolvedValueOnce({ ciphertext: fakeCiphertext });
+    mockKmsClient.decrypt.mockResolvedValueOnce({ plaintext: encoded });
+
+    const ciphertext = await provider.encrypt(plaintext, 'aad', context);
+    const decrypted = await provider.decrypt(ciphertext, 'aad', context);
+
+    expect(decrypted).toBe(plaintext);
+  });
+
+  it('throws when @ycforge/kms is not installed', async () => {
+    loadSpy.mockRejectedValueOnce(
+      new Error(
+        '@ycforge/kms must be installed for KmsEncryptionProvider: npm install @ycforge/kms',
+      ),
+    );
+
+    const provider = new KmsEncryptionProvider({ keyId: 'key-1' });
+    await expect(provider.encrypt('data', 'aad', context)).rejects.toThrow(
+      /@ycforge\/kms must be installed/,
+    );
+  });
+});
+
+describe('KmsBlindIndexProvider', () => {
+  it('produces a deterministic SHA-256 hash', async () => {
+    const provider = new KmsBlindIndexProvider();
+    const h1 = await provider.hash('test@example.com', context);
+    const h2 = await provider.hash('test@example.com', context);
+
+    expect(h1).toBe(h2);
+    expect(h1).toBe(
+      createHash('sha256')
+        .update('test@example.com', 'utf8')
+        .digest('hex')
+        .slice(0, 16),
+    );
+  });
+
+  it('produces different hashes for different inputs', async () => {
+    const provider = new KmsBlindIndexProvider();
+    const h1 = await provider.hash('a@test.com', context);
+    const h2 = await provider.hash('b@test.com', context);
+
+    expect(h1).not.toBe(h2);
+  });
+
+  it('hash length is 16 hex characters', async () => {
+    const provider = new KmsBlindIndexProvider();
+    const hash = await provider.hash('value', context);
+
+    expect(hash).toHaveLength(16);
+    expect(/^[0-9a-f]{16}$/.test(hash)).toBe(true);
+  });
+});

--- a/test/query-logger.spec.ts
+++ b/test/query-logger.spec.ts
@@ -1,0 +1,155 @@
+import 'reflect-metadata';
+import { jest } from '@jest/globals';
+import { createMockExecutor } from './helpers/mock-executor.js';
+import {
+  ConsoleQueryLogger,
+  wrapExecutorWithLogging,
+  type QueryLogger,
+  type QueryLogEntry,
+} from '../src/core/query-logger.js';
+
+describe('ConsoleQueryLogger', () => {
+  const logSpies: jest.SpiedFunction<typeof console.log>[] = [];
+  const errorSpies: jest.SpiedFunction<typeof console.error>[] = [];
+
+  afterEach(() => {
+    for (const s of logSpies) s.mockRestore();
+    for (const s of errorSpies) s.mockRestore();
+    logSpies.length = 0;
+    errorSpies.length = 0;
+  });
+
+  it('logs query with params and duration', () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    logSpies.push(logSpy);
+    const logger = new ConsoleQueryLogger();
+    logger.log({
+      sql: 'SELECT * FROM users WHERE id = $id',
+      paramNames: ['id'],
+      maskedParams: { id: 'abc-123' },
+      durationMs: 42,
+    });
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const output = logSpy.mock.calls[0][0] as string;
+    expect(output).toContain('[YDB] QUERY 42ms');
+    expect(output).toContain('SELECT * FROM users WHERE id = $id');
+    expect(output).toContain('id="abc-123"');
+  });
+
+  it('logs error queries', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    errorSpies.push(errorSpy);
+    const logger = new ConsoleQueryLogger();
+    logger.log({
+      sql: 'BAD SQL',
+      paramNames: [],
+      maskedParams: {},
+      durationMs: 1,
+      error: new Error('syntax error'),
+    });
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const output = errorSpy.mock.calls[0][0] as string;
+    expect(output).toContain('ERROR: syntax error');
+    expect(output).toContain('BAD SQL');
+  });
+
+  it('truncates long SQL', () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    logSpies.push(logSpy);
+    const logger = new ConsoleQueryLogger();
+    const longSql = 'SELECT ' + 'x, '.repeat(100);
+    logger.log({
+      sql: longSql,
+      paramNames: [],
+      maskedParams: {},
+      durationMs: 0,
+    });
+
+    const output = logSpy.mock.calls[0][0] as string;
+    expect(output).toContain('...');
+    expect(output.length).toBeLessThan(longSql.length);
+  });
+});
+
+describe('wrapExecutorWithLogging', () => {
+  let logEntries: QueryLogEntry[];
+  let mockLogger: QueryLogger;
+
+  beforeEach(() => {
+    logEntries = [];
+    mockLogger = { log: (entry) => logEntries.push(entry) };
+  });
+
+  it('logs successful query with duration', async () => {
+    const mock = createMockExecutor([[{ uuid: '1' }]]);
+    const logging = wrapExecutorWithLogging(mock.executor, mockLogger);
+
+    const q = logging(['SELECT * FROM users'] as unknown as TemplateStringsArray);
+    q.parameter('id', 'test');
+    await q;
+
+    expect(logEntries).toHaveLength(1);
+    expect(logEntries[0].sql).toBe('SELECT * FROM users');
+    expect(logEntries[0].paramNames).toEqual(['id']);
+    expect(logEntries[0].maskedParams).toEqual({ id: 'test' });
+    expect(logEntries[0].durationMs).toBeGreaterThanOrEqual(0);
+    expect(logEntries[0].error).toBeUndefined();
+  });
+
+  it('logs failed query with error', async () => {
+    const failExecutor: any = jest.fn(() => ({
+      parameter: jest.fn().mockReturnThis(),
+      timeout: jest.fn().mockReturnThis(),
+      signal: jest.fn().mockReturnThis(),
+      cancel: jest.fn().mockReturnThis(),
+      then: (_onFulfilled: any, onRejected: any) =>
+        Promise.reject(new Error('connection refused')).then(
+          _onFulfilled,
+          onRejected,
+        ),
+    }));
+    failExecutor.transaction = () => ({
+      execute: (fn: any) => fn(failExecutor),
+    });
+
+    const logging = wrapExecutorWithLogging(failExecutor, mockLogger);
+    const q = logging(['SELECT 1'] as unknown as TemplateStringsArray);
+    q.parameter('p', 'val');
+
+    await expect(q).rejects.toThrow('connection refused');
+
+    expect(logEntries).toHaveLength(1);
+    expect(logEntries[0].error?.message).toBe('connection refused');
+  });
+
+  it('masks long string parameters', async () => {
+    const mock = createMockExecutor([[]]);
+    const logging = wrapExecutorWithLogging(mock.executor, mockLogger);
+
+    const q = logging(['INSERT INTO t'] as unknown as TemplateStringsArray);
+    q.parameter('secret', 'a'.repeat(200));
+    await q;
+
+    expect(logEntries[0].maskedParams.secret).toBe('a'.repeat(64) + '...');
+  });
+
+  it('masks Uint8Array parameters', async () => {
+    const mock = createMockExecutor([[]]);
+    const logging = wrapExecutorWithLogging(mock.executor, mockLogger);
+
+    const q = logging(['INSERT INTO t'] as unknown as TemplateStringsArray);
+    q.parameter('data', new Uint8Array([1, 2, 3]));
+    await q;
+
+    expect(logEntries[0].maskedParams.data).toBe('<bytes:3>');
+  });
+
+  it('passes through transaction method', () => {
+    const mock = createMockExecutor([[]]);
+    const logging = wrapExecutorWithLogging(mock.executor, mockLogger);
+
+    expect(typeof (logging as any).transaction).toBe('function');
+  });
+});

--- a/test/query-logger.spec.ts
+++ b/test/query-logger.spec.ts
@@ -86,7 +86,9 @@ describe('wrapExecutorWithLogging', () => {
     const mock = createMockExecutor([[{ uuid: '1' }]]);
     const logging = wrapExecutorWithLogging(mock.executor, mockLogger);
 
-    const q = logging(['SELECT * FROM users'] as unknown as TemplateStringsArray);
+    const q = logging([
+      'SELECT * FROM users',
+    ] as unknown as TemplateStringsArray);
     q.parameter('id', 'test');
     await q;
 

--- a/test/select-columns.spec.ts
+++ b/test/select-columns.spec.ts
@@ -1,0 +1,142 @@
+import 'reflect-metadata';
+import { createMockExecutor } from './helpers/mock-executor.js';
+import { UserEntity } from './fixtures/user/user.entity.js';
+
+describe('select columns (issue #10)', () => {
+  afterEach(() => {
+    UserEntity.setExecutor(undefined as any);
+    UserEntity.setEncryptionProvider(undefined as any);
+    UserEntity.setBlindIndexProvider(undefined as any);
+  });
+
+  const uuid1 = '5ad91505-d4f6-4a81-ab65-9dbc68cf4ed5';
+
+  describe('find() с select', () => {
+    it('генерирует SELECT с указанными колонками вместо SELECT *', async () => {
+      const mock = createMockExecutor([[{ uuid: uuid1, full_name: 'Alice' }]]);
+      UserEntity.setExecutor(mock.executor);
+
+      await UserEntity.find({ uuid: uuid1 }, { select: ['uuid', 'full_name'] });
+
+      expect(mock.queries[0].sql).toContain('SELECT `uuid`, `full_name`');
+      expect(mock.queries[0].sql).not.toContain('SELECT *');
+    });
+
+    it('без select — SELECT * (обратная совместимость)', async () => {
+      const mock = createMockExecutor([[{ uuid: uuid1, full_name: 'Alice' }]]);
+      UserEntity.setExecutor(mock.executor);
+
+      await UserEntity.find({ uuid: uuid1 });
+
+      expect(mock.queries[0].sql).toContain('SELECT *');
+    });
+
+    it('с пустым select — SELECT *', async () => {
+      const mock = createMockExecutor([[{ uuid: uuid1, full_name: 'Alice' }]]);
+      UserEntity.setExecutor(mock.executor);
+
+      await UserEntity.find({ uuid: uuid1 }, { select: [] });
+
+      expect(mock.queries[0].sql).toContain('SELECT *');
+    });
+
+    it('возвращает только запрошенные колонки (остальные undefined)', async () => {
+      const mock = createMockExecutor([[{ uuid: uuid1, full_name: 'Alice' }]]);
+      UserEntity.setExecutor(mock.executor);
+
+      const result = await UserEntity.find(
+        { uuid: uuid1 },
+        { select: ['uuid', 'full_name'] },
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.uuid).toBe(uuid1);
+      expect(result!.full_name).toBe('Alice');
+      expect((result as any).email_encrypted).toBeUndefined();
+    });
+  });
+
+  describe('findAll() с select', () => {
+    it('генерирует SELECT с указанными колонками', async () => {
+      const mock = createMockExecutor([
+        [
+          { uuid: uuid1, full_name: 'Alice' },
+          { uuid: '00000000-0000-0000-0000-000000000002', full_name: 'Bob' },
+        ],
+      ]);
+      UserEntity.setExecutor(mock.executor);
+
+      const result = await UserEntity.findAll(
+        {},
+        { select: ['uuid', 'full_name'] },
+      );
+
+      expect(mock.queries[0].sql).toContain('SELECT `uuid`, `full_name`');
+      expect(mock.queries[0].sql).not.toContain('SELECT *');
+      expect(result).toHaveLength(2);
+    });
+
+    it('без select — SELECT * (обратная совместимость)', async () => {
+      const mock = createMockExecutor([[{ uuid: uuid1, full_name: 'Alice' }]]);
+      UserEntity.setExecutor(mock.executor);
+
+      await UserEntity.findAll({});
+
+      expect(mock.queries[0].sql).toContain('SELECT *');
+    });
+  });
+
+  describe('query builder .select()', () => {
+    it('генерирует SELECT с указанными колонками', async () => {
+      const mock = createMockExecutor([[{ uuid: uuid1, full_name: 'Alice' }]]);
+      UserEntity.setExecutor(mock.executor);
+
+      const result = await UserEntity.query()
+        .select(['uuid', 'full_name'])
+        .where({ uuid: uuid1 })
+        .getMany();
+
+      expect(mock.queries[0].sql).toContain('SELECT `uuid`, `full_name`');
+      expect(mock.queries[0].sql).not.toContain('SELECT *');
+      expect(result).toHaveLength(1);
+    });
+
+    it('без select — SELECT * (обратная совместимость)', async () => {
+      const mock = createMockExecutor([[{ uuid: uuid1, full_name: 'Alice' }]]);
+      UserEntity.setExecutor(mock.executor);
+
+      await UserEntity.query().where({ uuid: uuid1 }).getMany();
+
+      expect(mock.queries[0].sql).toContain('SELECT *');
+    });
+
+    it('цепочка select + orderBy + limit', async () => {
+      const mock = createMockExecutor([[{ uuid: uuid1, full_name: 'Alice' }]]);
+      UserEntity.setExecutor(mock.executor);
+
+      const built = await UserEntity.query()
+        .select(['uuid', 'full_name'])
+        .where({ uuid: uuid1 })
+        .orderBy('full_name', 'ASC')
+        .limit(10)
+        .toYql();
+
+      expect(built.sql).toContain('SELECT `uuid`, `full_name`');
+      expect(built.sql).toContain('ORDER BY `full_name` ASC');
+      expect(built.sql).toContain('LIMIT 10');
+    });
+
+    it('select с.single колонкой', async () => {
+      const mock = createMockExecutor([[{ uuid: uuid1 }]]);
+      UserEntity.setExecutor(mock.executor);
+
+      const built = await UserEntity.query()
+        .select(['uuid'])
+        .where({ uuid: uuid1 })
+        .toYql();
+
+      expect(built.sql).toContain('SELECT `uuid`');
+      expect(built.sql).not.toContain('SELECT *');
+    });
+  });
+});

--- a/test/standalone-config.spec.ts
+++ b/test/standalone-config.spec.ts
@@ -1,0 +1,69 @@
+import 'reflect-metadata';
+import { describe, it, expect } from '@jest/globals';
+import {
+  YdbEntity,
+  YdbColumn,
+  YdbBaseEntity,
+  Base64TestEncryptionProvider,
+} from '../src/index.js';
+import { configureEntities } from '../src/core/standalone.js';
+import { createMockExecutor } from './helpers/mock-executor.js';
+
+@YdbEntity('test_users')
+class TestUser extends YdbBaseEntity {
+  @YdbColumn('Utf8')
+  name!: string;
+}
+
+@YdbEntity('test_posts')
+class TestPost extends YdbBaseEntity {
+  @YdbColumn('Utf8')
+  title!: string;
+}
+
+@YdbEntity('test_simple')
+class TestSimple extends YdbBaseEntity {
+  @YdbColumn('Utf8')
+  value!: string;
+}
+
+describe('configureEntities', () => {
+  it('устанавливает executor на все сущности', () => {
+    const { executor } = createMockExecutor();
+    configureEntities([TestUser, TestPost], { executor });
+
+    // Если executor установлен, getExecutor() не бросит ошибку
+    expect(() => (TestUser as any).getExecutor()).not.toThrow();
+    expect(() => (TestPost as any).getExecutor()).not.toThrow();
+  });
+
+  it('устанавливает encryptionProvider и blindIndexProvider если переданы', () => {
+    const { executor } = createMockExecutor();
+    const encryptionProvider = new Base64TestEncryptionProvider();
+    const blindIndexProvider = {
+      hash: (value: string) => Promise.resolve(`idx_${value}`),
+    };
+
+    configureEntities([TestUser], {
+      executor,
+      encryptionProvider,
+      blindIndexProvider,
+    });
+
+    expect((TestUser as any).getEncryptionProvider()).toBe(encryptionProvider);
+    expect((TestUser as any).getBlindIndexProvider()).toBe(blindIndexProvider);
+  });
+
+  it('работает без опциональных провайдеров', () => {
+    const { executor } = createMockExecutor();
+    configureEntities([TestSimple], { executor });
+
+    expect((TestSimple as any).getEncryptionProvider()).toBeUndefined();
+    expect((TestSimple as any).getBlindIndexProvider()).toBeUndefined();
+  });
+
+  it('устанавливает executor на пустом массиве сущностей без ошибок', () => {
+    const { executor } = createMockExecutor();
+    expect(() => configureEntities([], { executor })).not.toThrow();
+  });
+});

--- a/test/updateBy-deleteBy.spec.ts
+++ b/test/updateBy-deleteBy.spec.ts
@@ -1,0 +1,206 @@
+import 'reflect-metadata';
+import { UserEntity } from './fixtures/user/user.entity.js';
+import { UserRoleEntity } from './fixtures/user_role/user_role.entity.js';
+import { TimestampEntity } from './fixtures/timestamp/timestamp.entity.js';
+import { createMockExecutor } from './helpers/mock-executor.js';
+import { Base64TestEncryptionProvider } from '../src/encryption/base64-test-encryption.provider.js';
+
+const userRow = {
+  uuid: '5ad91505-d4f6-4a81-ab65-9dbc68cf4ed5',
+  email_encrypted: 'enc',
+  full_name: 'Ivan',
+};
+
+describe('updateBy() / deleteBy()', () => {
+  afterEach(() => {
+    UserEntity.setExecutor(undefined as any);
+    UserEntity.setEncryptionProvider(undefined as any);
+    UserEntity.setBlindIndexProvider(undefined as any);
+    UserRoleEntity.setExecutor(undefined as any);
+    UserRoleEntity.setEncryptionProvider(undefined as any);
+    UserRoleEntity.setBlindIndexProvider(undefined as any);
+    TimestampEntity.setExecutor(undefined as any);
+    TimestampEntity.setEncryptionProvider(undefined as any);
+    TimestampEntity.setBlindIndexProvider(undefined as any);
+  });
+
+  describe('updateBy()', () => {
+    it('generates correct SQL with WHERE and SET clauses', async () => {
+      const mock = createMockExecutor([[]]);
+      UserRoleEntity.setExecutor(mock.executor);
+
+      const affected = await UserRoleEntity.updateBy(
+        { user_uuid: userRow.uuid },
+        { is_global: true },
+      );
+
+      const [q] = mock.queries;
+      expect(q.sql).toContain('UPDATE `user_roles`');
+      expect(q.sql).toContain('SET');
+      expect(q.sql).toContain('`is_global` = $is_global');
+      expect(q.sql).toContain('WHERE `user_uuid` = $user_uuid');
+      expect(q.params.is_global).toEqual({
+        type: expect.anything(),
+        value: true,
+      });
+      expect(affected).toBe(0);
+    });
+
+    it('returns affected row count', async () => {
+      const row = {
+        user_uuid: userRow.uuid,
+        role_uuid: '00000000-0000-0000-0000-000000000002',
+        organization_uuid: '00000000-0000-0000-0000-000000000003',
+        is_global: true,
+      };
+      const mock = createMockExecutor([[row]]);
+      UserRoleEntity.setExecutor(mock.executor);
+
+      const affected = await UserRoleEntity.updateBy(
+        { user_uuid: userRow.uuid },
+        { is_global: false },
+      );
+
+      expect(affected).toBe(1);
+    });
+
+    it('throws with empty where', async () => {
+      const mock = createMockExecutor([[]]);
+      UserRoleEntity.setExecutor(mock.executor);
+
+      await expect(
+        UserRoleEntity.updateBy({}, { is_global: true }),
+      ).rejects.toThrow(/requires at least one WHERE condition/);
+    });
+
+    it('throws with empty patch', async () => {
+      const mock = createMockExecutor([[]]);
+      UserRoleEntity.setExecutor(mock.executor);
+
+      await expect(
+        UserRoleEntity.updateBy({ user_uuid: userRow.uuid }, {}),
+      ).rejects.toThrow(/requires at least one field in patch/);
+    });
+
+    it('auto-sets update date column when configured', async () => {
+      const mock = createMockExecutor([[]]);
+      TimestampEntity.setExecutor(mock.executor);
+
+      await TimestampEntity.updateBy(
+        { uuid: userRow.uuid },
+        { name: 'Updated' },
+      );
+
+      const [q] = mock.queries;
+      expect(q.sql).toContain('UPDATE `timestamp_test`');
+      expect(q.sql).toContain('`updated_at` = $updated_at');
+      expect(q.params.updated_at).toBeDefined();
+    });
+
+    it('throws for unknown field in patch', async () => {
+      const mock = createMockExecutor([[]]);
+      UserRoleEntity.setExecutor(mock.executor);
+
+      await expect(
+        UserRoleEntity.updateBy(
+          { user_uuid: userRow.uuid },
+          { no_such_field: 'x' },
+        ),
+      ).rejects.toThrow(/Unknown field in patch/);
+    });
+
+    it('passes multiple SET fields', async () => {
+      const mock = createMockExecutor([[]]);
+      UserRoleEntity.setExecutor(mock.executor);
+
+      await UserRoleEntity.updateBy(
+        { user_uuid: userRow.uuid },
+        { role_uuid: '00000000-0000-0000-0000-000000000099', is_global: false },
+      );
+
+      const [q] = mock.queries;
+      expect(q.sql).toContain('`role_uuid` = $role_uuid');
+      expect(q.sql).toContain('`is_global` = $is_global');
+    });
+
+    it('works with encryption provider', async () => {
+      const provider = new Base64TestEncryptionProvider();
+      UserEntity.setEncryptionProvider(provider);
+      UserEntity.setBlindIndexProvider(provider);
+      const mock = createMockExecutor([[]]);
+      UserEntity.setExecutor(mock.executor);
+
+      await UserEntity.updateBy(
+        { uuid: userRow.uuid },
+        { email_encrypted: 'secret@example.com' },
+      );
+
+      const [q] = mock.queries;
+      expect(q.sql).toContain('UPDATE `users`');
+      expect(q.sql).toContain('`email_encrypted` = $email_encrypted');
+      const emailParam = q.params.email_encrypted;
+      expect(String((emailParam as any).value)).toBe(
+        Buffer.from('secret@example.com').toString('base64'),
+      );
+    });
+  });
+
+  describe('deleteBy()', () => {
+    it('generates correct SQL', async () => {
+      const mock = createMockExecutor([[]]);
+      UserRoleEntity.setExecutor(mock.executor);
+
+      const affected = await UserRoleEntity.deleteBy({
+        user_uuid: userRow.uuid,
+      });
+
+      const [q] = mock.queries;
+      expect(q.sql).toContain('DELETE FROM `user_roles`');
+      expect(q.sql).toContain('WHERE `user_uuid` = $user_uuid');
+      expect(q.params.user_uuid).toBeDefined();
+      expect(affected).toBe(0);
+    });
+
+    it('returns affected row count', async () => {
+      const row = {
+        user_uuid: userRow.uuid,
+        role_uuid: '00000000-0000-0000-0000-000000000002',
+        organization_uuid: '00000000-0000-0000-0000-000000000003',
+        is_global: true,
+      };
+      const mock = createMockExecutor([[row]]);
+      UserRoleEntity.setExecutor(mock.executor);
+
+      const affected = await UserRoleEntity.deleteBy({
+        user_uuid: userRow.uuid,
+      });
+
+      expect(affected).toBe(1);
+    });
+
+    it('throws with empty where', async () => {
+      const mock = createMockExecutor([[]]);
+      UserRoleEntity.setExecutor(mock.executor);
+
+      await expect(UserRoleEntity.deleteBy({})).rejects.toThrow(
+        /requires at least one WHERE condition/,
+      );
+    });
+
+    it('passes multiple WHERE conditions', async () => {
+      const mock = createMockExecutor([[]]);
+      UserRoleEntity.setExecutor(mock.executor);
+
+      await UserRoleEntity.deleteBy({
+        user_uuid: userRow.uuid,
+        role_uuid: '00000000-0000-0000-0000-000000000002',
+      });
+
+      const [q] = mock.queries;
+      expect(q.sql).toContain('DELETE FROM `user_roles`');
+      expect(q.sql).toContain('`user_uuid` = $user_uuid');
+      expect(q.sql).toContain('`role_uuid` = $role_uuid');
+      expect(q.sql).toContain('AND');
+    });
+  });
+});

--- a/test/ydb-ttl.spec.ts
+++ b/test/ydb-ttl.spec.ts
@@ -1,0 +1,157 @@
+import 'reflect-metadata';
+import { YdbEntity } from '../src/decorators/entity.decorator.js';
+import {
+  YdbPrimaryColumn,
+  YdbColumn,
+} from '../src/decorators/column.decorator.js';
+import { YdbBaseEntity } from '../src/entity/base-entity.js';
+import { YdbTtl, getYdbTtlMetadata } from '../src/decorators/ttl.decorator.js';
+import {
+  buildExpectedTableSchema,
+  generateCreateTableYql,
+} from '../src/schema/schema-sync.js';
+import { getYdbEntityMetadata } from '../src/metadata/entity-metadata.js';
+
+const meta = (entity: new (...args: any[]) => any) => {
+  const m = getYdbEntityMetadata(entity);
+  if (!m) throw new Error('no metadata');
+  return m;
+};
+
+@YdbEntity('ttl_sessions')
+@YdbTtl({ interval: 'PT2H' })
+class TtlSessionEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @YdbColumn('Utf8')
+  token: string;
+}
+
+@YdbEntity('ttl_custom_col')
+@YdbTtl({ interval: 'P30D', column: 'expires_at' })
+class TtlCustomColumnEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @YdbColumn('Timestamp')
+  expires_at: string;
+}
+
+@YdbEntity('no_ttl_entity')
+class NoTtlEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @YdbColumn('Utf8')
+  name: string;
+}
+
+@YdbEntity('ttl_composite_pk')
+@YdbTtl({ interval: 'PT1H' })
+class TtlCompositePkEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  tenant_id: string;
+
+  @YdbPrimaryColumn('Int64')
+  id: string;
+
+  @YdbColumn('Utf8')
+  data: string;
+}
+
+class TtlDuplicateEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+}
+
+describe('@YdbTtl', () => {
+  it('stores TTL metadata on class', () => {
+    const ttl = getYdbTtlMetadata(TtlSessionEntity);
+    expect(ttl).toEqual({ interval: 'PT2H' });
+  });
+
+  it('stores TTL with custom column', () => {
+    const ttl = getYdbTtlMetadata(TtlCustomColumnEntity);
+    expect(ttl).toEqual({ interval: 'P30D', column: 'expires_at' });
+  });
+
+  it('returns undefined for entity without TTL', () => {
+    const ttl = getYdbTtlMetadata(NoTtlEntity);
+    expect(ttl).toBeUndefined();
+  });
+
+  it('throws when applied twice to the same class', () => {
+    // Apply first @YdbTtl — should succeed
+    YdbTtl({ interval: 'PT2H' })(TtlDuplicateEntity);
+    expect(getYdbTtlMetadata(TtlDuplicateEntity)).toEqual({ interval: 'PT2H' });
+
+    // Apply second @YdbTtl — should throw
+    expect(() => {
+      YdbTtl({ interval: 'P1D' })(TtlDuplicateEntity);
+    }).toThrow(/can only be applied once/);
+  });
+});
+
+describe('ExpectedTableSchema with TTL', () => {
+  it('includes TTL in schema when decorator is present', () => {
+    const schema = buildExpectedTableSchema(meta(TtlSessionEntity));
+    expect(schema.ttl).toEqual({ interval: 'PT2H', column: 'uuid' });
+  });
+
+  it('uses custom column from TTL options', () => {
+    const schema = buildExpectedTableSchema(meta(TtlCustomColumnEntity));
+    expect(schema.ttl).toEqual({ interval: 'P30D', column: 'expires_at' });
+  });
+
+  it('defaults to first PK when column is not specified', () => {
+    const schema = buildExpectedTableSchema(meta(TtlCompositePkEntity));
+    expect(schema.ttl).toEqual({ interval: 'PT1H', column: 'tenant_id' });
+  });
+
+  it('has no TTL when decorator is absent', () => {
+    const schema = buildExpectedTableSchema(meta(NoTtlEntity));
+    expect(schema.ttl).toBeUndefined();
+  });
+});
+
+describe('generateCreateTableYql with TTL', () => {
+  it('includes TTL clause in CREATE TABLE DDL', () => {
+    const schema = buildExpectedTableSchema(meta(TtlSessionEntity));
+    const yql = generateCreateTableYql(schema);
+
+    expect(yql).toContain('TTL = Interval("PT2H") ON `uuid`');
+    // PK идёт перед TTL
+    const pkIndex = yql.indexOf('PRIMARY KEY');
+    const ttlIndex = yql.indexOf('TTL');
+    expect(pkIndex).toBeLessThan(ttlIndex);
+  });
+
+  it('includes TTL with custom column', () => {
+    const schema = buildExpectedTableSchema(meta(TtlCustomColumnEntity));
+    const yql = generateCreateTableYql(schema);
+
+    expect(yql).toContain('TTL = Interval("P30D") ON `expires_at`');
+  });
+
+  it('does not include TTL clause when decorator is absent', () => {
+    const schema = buildExpectedTableSchema(meta(NoTtlEntity));
+    const yql = generateCreateTableYql(schema);
+
+    expect(yql).not.toContain('TTL');
+  });
+
+  it('generates valid full CREATE TABLE with TTL', () => {
+    const schema = buildExpectedTableSchema(meta(TtlSessionEntity));
+    const yql = generateCreateTableYql(schema);
+
+    expect(yql).toBe(
+      'CREATE TABLE `ttl_sessions` (\n' +
+        '  `uuid` Uuid,\n' +
+        '  `token` Utf8,\n' +
+        '  PRIMARY KEY (`uuid`),\n' +
+        '  TTL = Interval("PT2H") ON `uuid`\n' +
+        ')',
+    );
+  });
+});

--- a/test/ydb-validate.spec.ts
+++ b/test/ydb-validate.spec.ts
@@ -1,0 +1,164 @@
+import 'reflect-metadata';
+import { jest } from '@jest/globals';
+import { UserEntity } from './fixtures/user/user.entity.js';
+import { createMockExecutor } from './helpers/mock-executor.js';
+import { Base64TestEncryptionProvider } from '../src/encryption/base64-test-encryption.provider.js';
+import type { YdbValidationProvider } from '../src/index.js';
+
+function setupEncryption() {
+  const provider = new Base64TestEncryptionProvider();
+  UserEntity.setEncryptionProvider(provider);
+  UserEntity.setBlindIndexProvider(provider);
+}
+
+function setupMock(rows: any[][] = [[]]) {
+  const mock = createMockExecutor(rows);
+  UserEntity.setExecutor(mock.executor);
+  return mock;
+}
+
+describe('YdbValidate — валидация перед записью', () => {
+  afterEach(() => {
+    UserEntity.setExecutor(undefined as any);
+    UserEntity.setEncryptionProvider(undefined as any);
+    UserEntity.setBlindIndexProvider(undefined as any);
+    UserEntity.setValidationProvider(undefined as any);
+  });
+
+  describe('без validationProvider — обратная совместимость', () => {
+    it('insert работает без провайдера валидации', async () => {
+      setupEncryption();
+      setupMock();
+
+      const user = new UserEntity();
+      user.full_name = 'No Validation';
+
+      await UserEntity.save(user);
+      expect(user.uuid).toBeDefined();
+    });
+  });
+
+  describe('с mock провайдером', () => {
+    it('insert вызывает validate и выбрасывает ошибки', async () => {
+      setupEncryption();
+      setupMock();
+
+      const validateFn = jest.fn(() => Promise.resolve(['email is required']));
+      const mockProvider: YdbValidationProvider = { validate: validateFn };
+      UserEntity.setValidationProvider(mockProvider);
+
+      const user = new UserEntity();
+      user.full_name = 'Should Fail';
+
+      await expect(UserEntity.save(user)).rejects.toThrow(
+        /Validation failed for UserEntity: email is required/,
+      );
+      expect(validateFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('insert проходит когда validate возвращает пустой массив', async () => {
+      setupEncryption();
+      setupMock();
+
+      const validateFn = jest.fn(() => Promise.resolve<string[]>([]));
+      const mockProvider: YdbValidationProvider = { validate: validateFn };
+      UserEntity.setValidationProvider(mockProvider);
+
+      const user = new UserEntity();
+      user.full_name = 'Valid User';
+
+      await UserEntity.save(user);
+      expect(user.uuid).toBeDefined();
+      expect(validateFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('update вызывает validate и выбрасывает ошибки', async () => {
+      setupEncryption();
+      const updatedRow = {
+        uuid: '5ad91505-d4f6-4a81-ab65-9dbc68cf4ed5',
+        email_encrypted: Buffer.from('enc').toString('base64'),
+        full_name: Buffer.from('Updated').toString('base64'),
+      };
+      setupMock([[updatedRow]]);
+
+      const validateFn = jest.fn(() => Promise.resolve(['name too short']));
+      const mockProvider: YdbValidationProvider = { validate: validateFn };
+      UserEntity.setValidationProvider(mockProvider);
+
+      const user = new UserEntity();
+      user.uuid = '5ad91505-d4f6-4a81-ab65-9dbc68cf4ed5';
+      user.full_name = 'X';
+
+      await expect(UserEntity.save(user)).rejects.toThrow(
+        /Validation failed for UserEntity: name too short/,
+      );
+      expect(validateFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('insertMany вызывает validate для каждой сущности', async () => {
+      setupEncryption();
+      setupMock();
+
+      const errors: string[] = [];
+      const validateFn = jest.fn((entity: any) => {
+        if (!entity.full_name) {
+          errors.push('full_name is required');
+          return Promise.resolve(errors);
+        }
+        return Promise.resolve<string[]>([]);
+      });
+      const mockProvider: YdbValidationProvider = { validate: validateFn };
+      UserEntity.setValidationProvider(mockProvider);
+
+      const valid = new UserEntity();
+      valid.full_name = 'Valid';
+      const invalid = new UserEntity();
+      // full_name не задан
+
+      await expect(UserEntity.insertMany([valid, invalid])).rejects.toThrow(
+        /Validation failed for UserEntity/,
+      );
+      expect(validateFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('insertMany проходит когда все сущности валидны', async () => {
+      setupEncryption();
+      setupMock();
+
+      const validateFn = jest.fn(() => Promise.resolve<string[]>([]));
+      const mockProvider: YdbValidationProvider = { validate: validateFn };
+      UserEntity.setValidationProvider(mockProvider);
+
+      const entities = Array.from({ length: 3 }, () => {
+        const e = new UserEntity();
+        e.full_name = 'Ok';
+        return e;
+      });
+
+      await UserEntity.insertMany(entities);
+      expect(validateFn).toHaveBeenCalledTimes(3);
+      for (const e of entities) {
+        expect(e.uuid).toBeDefined();
+      }
+    });
+
+    it('setValidationProvider(undefined) отключает валидацию', async () => {
+      setupEncryption();
+      setupMock();
+
+      const validateFn = jest.fn(() =>
+        Promise.resolve(['should not be called']),
+      );
+      const mockProvider: YdbValidationProvider = { validate: validateFn };
+      UserEntity.setValidationProvider(mockProvider);
+      UserEntity.setValidationProvider(undefined as any);
+
+      const user = new UserEntity();
+      user.full_name = 'No Validation';
+
+      await UserEntity.save(user);
+      expect(user.uuid).toBeDefined();
+      expect(validateFn).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Batch реализации p1-ишусов:

**Новые декораторы и фичи:**
- `@YdbTtl` — декларативный TTL таблицы (Interval ON column в DDL)
- Lifecycle hooks — `@BeforeInsert`, `@AfterInsert`, `@BeforeUpdate`, `@AfterFind`, `@BeforeRemove`
- `@YdbValidate` — `ClassValidatorProvider`, валидация перед save/insert/update/insertMany

**Шифрование:**
- `KmsEncryptionProvider` + `KmsBlindIndexProvider` (SHA-256) — Yandex KMS интеграция

**Query:**
- `select` в `QueryOptions` — find/findAll/query builder по конкретным колонкам
- `updateBy()` / `deleteBy()` — массовые update/delete по WHERE
- `configureEntities()` — использование без NestJS

**Schema sync:**
- Уникальные индексы — `@YdbIndex({ unique: true })` в DDL
- Schema sync для индексов — CREATE/ALTER INDEX, проверка в `checkTableSchema`

**CLI:**
- `migration:check` — exit 1 если есть неприменённые миграции, `--json` вывод
- `migration:show --json` — machine-readable вывод

**Исправления:**
- `insert()` теперь вызывает `runValidation()` — консистентность с `update()`/`insertMany()`

Closes #2, #8, #15, #28, #48, #49, #61, #76, #82, #33