### PR TITLE
feat: требовать @YdbPrimaryColumn и разрешать @YdbSecurityAAD только на PK

### DIFF
--- a/src/decorators/encryption.decorator.ts
+++ b/src/decorators/encryption.decorator.ts
@@ -47,7 +47,8 @@ export function YdbEncrypted(options?: YdbEncryptedOptions): PropertyDecorator {
 }
 
 /**
- * Помечает НЕзашифрованное поле как участника AAD (Additional Authenticated Data).
+ * Помечает поле первичного ключа как участника AAD (Additional Authenticated Data).
+ * Может применяться только к колонкам, объявленным через @YdbPrimaryColumn.
  */
 export function YdbSecurityAAD(): PropertyDecorator {
   return (target, propertyKey) => {

--- a/src/decorators/relation.decorators.ts
+++ b/src/decorators/relation.decorators.ts
@@ -172,10 +172,18 @@ export function getManyToManyJoinTables(
         );
       }
 
-      const ownerPk = meta.primaryKeys[0] ?? 'uuid';
-      const inversePk = inverseMeta.primaryKeys[0] ?? 'uuid';
-      void ownerPk;
-      void inversePk;
+      if (meta.primaryKeys.length === 0) {
+        throw new Error(
+          `Cannot build many-to-many join table for entity ${Entity.name}: ` +
+            `no primary key is declared. Mark at least one column with @YdbPrimaryColumn.`,
+        );
+      }
+      if (inverseMeta.primaryKeys.length === 0) {
+        throw new Error(
+          `Cannot build many-to-many join table for entity ${InverseEntity.name}: ` +
+            `no primary key is declared. Mark at least one column with @YdbPrimaryColumn.`,
+        );
+      }
 
       const joinColumn = joinTable.joinColumn ?? `${meta.tableName}_uuid`;
       const inverseJoinColumn =

--- a/src/entity/base-entity.ts
+++ b/src/entity/base-entity.ts
@@ -123,7 +123,7 @@ export class YdbBaseEntity {
     return getOrCreateRepository(this).count(where, options);
   }
 
-  static async save<T extends YdbBaseEntity & { uuid?: string }>(
+  static async save<T extends YdbBaseEntity>(
     this: { new (): T } & typeof YdbBaseEntity,
     entity: T,
     options?: QueryOptions,

--- a/src/metadata/validate-entity.spec.ts
+++ b/src/metadata/validate-entity.spec.ts
@@ -1,7 +1,10 @@
 import 'reflect-metadata';
 import { YdbEntity } from '../decorators/entity.decorator.js';
 import { YdbColumn, YdbPrimaryColumn } from '../decorators/column.decorator.js';
-import { YdbEncrypted } from '../decorators/encryption.decorator.js';
+import {
+  YdbEncrypted,
+  YdbSecurityAAD,
+} from '../decorators/encryption.decorator.js';
 import {
   ManyToMany,
   JoinTable,
@@ -65,6 +68,16 @@ class NotAnEntity extends YdbBaseEntity {}
 class MissingPkColumn extends YdbBaseEntity {
   @YdbColumn('Utf8')
   name: string;
+}
+
+@YdbEntity('v_aad_on_non_pk')
+class AadOnNonPk extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @YdbSecurityAAD()
+  @YdbColumn('Utf8')
+  tenant_id: string;
 }
 
 @YdbEntity('v_enc_pk')
@@ -170,10 +183,19 @@ describe('validateEntityMetadata', () => {
     ]);
   });
 
-  it('rejects entity whose fallback uuid PK column is missing', () => {
+  it('rejects entity without any primary key', () => {
     const issues = validateEntityMetadata(MissingPkColumn, ctx);
     expect(issues).toEqual([
-      expect.stringContaining('primary key column "uuid" is not declared'),
+      expect.stringContaining('must declare at least one primary key'),
+    ]);
+  });
+
+  it('rejects @YdbSecurityAAD on non-primary-key column', () => {
+    const issues = validateEntityMetadata(AadOnNonPk, ctx);
+    expect(issues).toEqual([
+      expect.stringContaining(
+        '@YdbSecurityAAD field "tenant_id" must be a primary key column',
+      ),
     ]);
   });
 

--- a/src/metadata/validate-entity.ts
+++ b/src/metadata/validate-entity.ts
@@ -29,11 +29,25 @@ export function validateEntityMetadata(
     return [`Class ${entity.name} is not decorated with @YdbEntity`];
   }
 
-  const pkFields = meta.primaryKeys.length ? meta.primaryKeys : ['uuid'];
+  if (meta.primaryKeys.length === 0) {
+    issues.push(
+      `entity "${meta.target.name}" must declare at least one primary key via @YdbPrimaryColumn`,
+    );
+  }
+
+  const pkFields = meta.primaryKeys;
   for (const pk of pkFields) {
     if (!meta.schema[pk]) {
       issues.push(
         `primary key column "${pk}" is not declared via @YdbColumn/@YdbPrimaryColumn`,
+      );
+    }
+  }
+
+  for (const aadField of meta.aadFields) {
+    if (!pkFields.includes(aadField)) {
+      issues.push(
+        `@YdbSecurityAAD field "${aadField}" must be a primary key column`,
       );
     }
   }

--- a/src/persistence/entity-persistence.spec.ts
+++ b/src/persistence/entity-persistence.spec.ts
@@ -1,0 +1,38 @@
+import 'reflect-metadata';
+import { YdbEntity } from '../decorators/entity.decorator.js';
+import { YdbColumn, YdbPrimaryColumn } from '../decorators/column.decorator.js';
+import { YdbBaseEntity } from '../entity/base-entity.js';
+import { YdbEntityPersistence } from './entity-persistence.js';
+import { getYdbEntityMetadata } from '../metadata/entity-metadata.js';
+
+@YdbEntity('persistence_no_pk')
+class NoPkEntity extends YdbBaseEntity {
+  @YdbColumn('Utf8')
+  name: string;
+}
+
+@YdbEntity('persistence_pk')
+class PkEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+}
+
+const meta = (entity: new (...args: any[]) => any) => {
+  const m = getYdbEntityMetadata(entity);
+  if (!m) throw new Error('no metadata');
+  return m;
+};
+
+describe('YdbEntityPersistence.getPkFields', () => {
+  it('throws when entity has no primary key', () => {
+    const persistence = new YdbEntityPersistence(NoPkEntity, undefined);
+    expect(() => persistence.getPkFields(meta(NoPkEntity))).toThrow(
+      /Entity NoPkEntity must declare at least one primary key via @YdbPrimaryColumn/,
+    );
+  });
+
+  it('returns declared primary keys', () => {
+    const persistence = new YdbEntityPersistence(PkEntity, undefined);
+    expect(persistence.getPkFields(meta(PkEntity))).toEqual(['uuid']);
+  });
+});

--- a/src/persistence/entity-persistence.ts
+++ b/src/persistence/entity-persistence.ts
@@ -194,11 +194,16 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 
   /**
-   * PK-поля сущности: из метаданных (поддерживается составной PK),
-   * fallback — одиночный 'uuid'.
+   * PK-поля сущности: из метаданных (поддерживается составной PK).
+   * Бросает ошибку, если первичный ключ не объявлен через @YdbPrimaryColumn.
    */
   getPkFields(meta: YdbEntityMetadata): string[] {
-    return meta.primaryKeys.length ? meta.primaryKeys : ['uuid'];
+    if (meta.primaryKeys.length === 0) {
+      throw new Error(
+        `Entity ${this.entityClass.name} must declare at least one primary key via @YdbPrimaryColumn`,
+      );
+    }
+    return meta.primaryKeys;
   }
 
   /**
@@ -1218,7 +1223,7 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
       const av = (instance as any)[aadName];
       if (av !== undefined && av !== null) aadFields[aadName] = String(av);
     }
-    const pkField = meta.primaryKeys[0] ?? 'uuid';
+    const pkField = this.getPkFields(meta)[0];
     const pkValue = (instance as any)[pkField];
 
     const plaintext = await provider.decrypt(

--- a/src/relations/entity-relations.ts
+++ b/src/relations/entity-relations.ts
@@ -372,11 +372,13 @@ function resolveJoinColumn(
   return joinColumn(proxy);
 }
 
-/** Возвращает первый PK из метаданных или fallback на 'uuid' */
+/** Возвращает первый PK из метаданных. Бросает ошибку, если PK не объявлен. */
 function getPrimaryKey(target: typeof YdbBaseEntity): string {
   const meta = getYdbEntityMetadata(target);
-  if (meta?.primaryKeys?.length) return meta.primaryKeys[0];
-  return 'uuid';
+  if (!meta?.primaryKeys?.length) {
+    throw new Error(`Entity ${target.name} must declare a primary key`);
+  }
+  return meta.primaryKeys[0];
 }
 
 /**

--- a/src/schema/schema-sync.spec.ts
+++ b/src/schema/schema-sync.spec.ts
@@ -44,9 +44,9 @@ class TestUserEntity extends YdbBaseEntity {
   is_active: boolean;
 }
 
-@YdbEntity('test_fallback_pk')
-class TestFallbackPkEntity extends YdbBaseEntity {
-  @YdbColumn('Uuid')
+@YdbEntity('test_explicit_uuid_pk')
+class TestExplicitUuidPkEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
   uuid: string;
 
   @YdbColumn('Int64')
@@ -101,7 +101,7 @@ describe('entity registry', () => {
   it('registers classes decorated with @YdbEntity', () => {
     const registered = getRegisteredYdbEntities();
     expect(registered).toContain(TestUserEntity);
-    expect(registered).toContain(TestFallbackPkEntity);
+    expect(registered).toContain(TestExplicitUuidPkEntity);
   });
 });
 
@@ -120,15 +120,15 @@ describe('buildExpectedTableSchema', () => {
     expect(schema.primaryKey).toEqual(['uuid']);
   });
 
-  it('falls back to uuid primary key when @YdbPrimaryColumn is not used', () => {
-    const schema = buildExpectedTableSchema(meta(TestFallbackPkEntity));
+  it('uses declared uuid primary key when @YdbPrimaryColumn is used', () => {
+    const schema = buildExpectedTableSchema(meta(TestExplicitUuidPkEntity));
 
     expect(schema.primaryKey).toEqual(['uuid']);
   });
 
-  it('throws when primary key column is not declared', () => {
+  it('throws when no primary key is declared', () => {
     expect(() => buildExpectedTableSchema(meta(TestNoPkEntity))).toThrow(
-      /primary key column "uuid" is not declared/,
+      /no primary key is declared/,
     );
   });
 });

--- a/src/schema/schema-sync.ts
+++ b/src/schema/schema-sync.ts
@@ -111,7 +111,7 @@ const TYPE_ID_TO_PRIMITIVE = new Map<Type_PrimitiveTypeId, YdbPrimitive>(
 /**
  * Строит ожидаемую схему таблицы по метаданным сущности:
  * колонки + synthetic {field}_bi колонки blind index.
- * PK — из @YdbPrimaryColumn, иначе fallback на `uuid`.
+ * Требует явно объявленного первичного ключа через @YdbPrimaryColumn.
  */
 export function buildExpectedTableSchema(
   meta: YdbEntityMetadata,
@@ -121,7 +121,14 @@ export function buildExpectedTableSchema(
     if (ef.blindIndex) columns[`${ef.propertyKey}_bi`] = 'Utf8';
   }
 
-  const primaryKey = meta.primaryKeys.length ? [...meta.primaryKeys] : ['uuid'];
+  if (meta.primaryKeys.length === 0) {
+    throw new Error(
+      `Cannot build schema for entity ${meta.target.name}: ` +
+        `no primary key is declared. Mark at least one column with @YdbPrimaryColumn.`,
+    );
+  }
+
+  const primaryKey = [...meta.primaryKeys];
 
   for (const pk of primaryKey) {
     if (!columns[pk]) {
@@ -145,7 +152,7 @@ export function buildExpectedTableSchema(
   const ttl = ttlOptions
     ? {
         interval: ttlOptions.interval,
-        column: ttlOptions.column ?? primaryKey[0] ?? 'uuid',
+        column: ttlOptions.column ?? primaryKey[0],
       }
     : undefined;
 

--- a/test/error-guards.spec.ts
+++ b/test/error-guards.spec.ts
@@ -165,7 +165,7 @@ describe('error guards: понятные fail-fast ошибки', () => {
       NoPkEntity.setExecutor(mock.executor);
 
       await expect(NoPkEntity.delete(uuid1)).rejects.toThrow(
-        /Cannot delete NoPkEntity by primary key: column "uuid" is not declared.*@YdbPrimaryColumn/s,
+        /Entity NoPkEntity must declare at least one primary key via @YdbPrimaryColumn/,
       );
       expect(mock.queries).toHaveLength(0);
     });

--- a/test/fixtures/lazy_secret/lazy-secret.entity.ts
+++ b/test/fixtures/lazy_secret/lazy-secret.entity.ts
@@ -12,15 +12,15 @@ import {
  * Тестовая сущность для lazy decrypt (issue #18):
  * - secret_lazy — lazy-поле: не дешифруется при чтении из БД;
  * - secret_eager — обычное encrypted-поле: дешифруется сразу;
- * - tenant_id — AAD-поле для дешифровки.
+ * - uuid — PK и AAD-поле для дешифровки.
  * Шифруемые поля хранятся как Bytes — @YdbColumn для них не объявляется.
  */
 @YdbEntity('lazy_secrets')
 export class LazySecretEntity extends YdbBaseEntity {
+  @YdbSecurityAAD()
   @YdbPrimaryColumn('Uuid')
   uuid: string;
 
-  @YdbSecurityAAD()
   @YdbColumn('Utf8')
   tenant_id: string;
 

--- a/test/lazy-decrypt.spec.ts
+++ b/test/lazy-decrypt.spec.ts
@@ -89,7 +89,7 @@ describe('lazy decrypt (@YdbEncrypted({ lazy: true }))', () => {
 
     // AAD собран из @YdbSecurityAAD-полей инстанса
     expect(provider.decryptContexts[0].aadFields).toEqual({
-      tenant_id: 'tenant-1',
+      uuid: makeRow().uuid,
     });
     expect(provider.decryptContexts[0].primaryKeyValue).toBe(makeRow().uuid);
 

--- a/test/lifecycle-hooks.spec.ts
+++ b/test/lifecycle-hooks.spec.ts
@@ -2,6 +2,7 @@ import 'reflect-metadata';
 import {
   YdbEntity,
   YdbColumn,
+  YdbPrimaryColumn,
   YdbBaseEntity,
   BeforeInsert,
   BeforeRemove,
@@ -12,7 +13,7 @@ const calls: string[] = [];
 
 @YdbEntity('hook_test')
 class HookEntity extends YdbBaseEntity {
-  @YdbColumn('Uuid')
+  @YdbPrimaryColumn('Uuid')
   declare uuid: string;
 
   @YdbColumn('Utf8')

--- a/test/standalone-config.spec.ts
+++ b/test/standalone-config.spec.ts
@@ -3,8 +3,8 @@ import { describe, it, expect } from '@jest/globals';
 import {
   YdbEntity,
   YdbColumn,
-  YdbBaseEntity,
   YdbPrimaryColumn,
+  YdbBaseEntity,
   YdbEncrypted,
   Base64TestEncryptionProvider,
 } from '../src/index.js';
@@ -13,18 +13,27 @@ import { createMockExecutor } from './helpers/mock-executor.js';
 
 @YdbEntity('test_users')
 class TestUser extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid!: string;
+
   @YdbColumn('Utf8')
   name!: string;
 }
 
 @YdbEntity('test_posts')
 class TestPost extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid!: string;
+
   @YdbColumn('Utf8')
   title!: string;
 }
 
 @YdbEntity('test_simple')
 class TestSimple extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid!: string;
+
   @YdbColumn('Utf8')
   value!: string;
 }

--- a/test/updateBy-deleteBy.spec.ts
+++ b/test/updateBy-deleteBy.spec.ts
@@ -7,6 +7,7 @@ import { Base64TestEncryptionProvider } from '../src/encryption/base64-test-encr
 import {
   YdbEntity,
   YdbColumn,
+  YdbPrimaryColumn,
   YdbEncrypted,
   YdbSecurityAAD,
   YdbBaseEntity,
@@ -15,12 +16,9 @@ import {
 /** Сущность с AAD-полем для проверки запрета updateBy по шифрованным полям. */
 @YdbEntity('aad_test')
 class AadEntity extends YdbBaseEntity {
-  @YdbColumn('Uuid')
-  declare uuid: string;
-
   @YdbSecurityAAD()
-  @YdbColumn('Utf8')
-  tenant_id?: string;
+  @YdbPrimaryColumn('Uuid')
+  declare uuid: string;
 
   @YdbEncrypted()
   @YdbColumn('Utf8')

--- a/test/ydb-enum.spec.ts
+++ b/test/ydb-enum.spec.ts
@@ -2,6 +2,7 @@ import 'reflect-metadata';
 import {
   YdbEntity,
   YdbColumn,
+  YdbPrimaryColumn,
   YdbBaseEntity,
   YdbEnum,
   getYdbEnumMetadata,
@@ -22,7 +23,7 @@ enum Status {
 
 @YdbEntity('test_enum_utf8')
 class EnumUtf8Entity extends YdbBaseEntity {
-  @YdbColumn('Uuid')
+  @YdbPrimaryColumn('Uuid')
   declare uuid: string;
 
   @YdbColumn('Utf8')
@@ -32,7 +33,7 @@ class EnumUtf8Entity extends YdbBaseEntity {
 
 @YdbEntity('test_enum_int32')
 class EnumInt32Entity extends YdbBaseEntity {
-  @YdbColumn('Uuid')
+  @YdbPrimaryColumn('Uuid')
   declare uuid: string;
 
   @YdbColumn('Int32')
@@ -42,7 +43,7 @@ class EnumInt32Entity extends YdbBaseEntity {
 
 @YdbEntity('test_enum_nullable')
 class EnumNullableEntity extends YdbBaseEntity {
-  @YdbColumn('Uuid')
+  @YdbPrimaryColumn('Uuid')
   declare uuid: string;
 
   @YdbColumn('Utf8')


### PR DESCRIPTION
## Изменения

### Первичный ключ
- Убран fallback на `uuid` как неявный первичный ключ.
- Все операции (CRUD, schema sync, relations, lazy decrypt) теперь требуют явно объявленный PK через `@YdbPrimaryColumn`.
- Добавлена fail-fast валидация: сущность без PK не пройдёт `validateEntityMetadata`.

### AAD
- `@YdbSecurityAAD` теперь может применяться только к колонкам первичного ключа.
- При шифровании/дешифровании `buildAAD` по-прежнему учитывает все AAD-поля (теперь гарантированно подмножество PK).

### Тесты
- Обновлены существующие тестовые сущности: добавлен `@YdbPrimaryColumn` там, где его не хватало.
- Добавлены новые тесты:
  - отсутствие PK бросает понятную ошибку;
  - `@YdbSecurityAAD` на не-PK колонке отклоняется валидацией;
  - `YdbEntityPersistence.getPkFields` возвращает declared PK и бросает ошибку без PK.

### Проверки
- `yarn test:unit`: 336 passed.
- `yarn build`: без ошибок.