### PR TITLE
ci: автоматический AI code review на PR через DeepSeek

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -6,10 +6,10 @@ on:
       - opened
       - reopened
       - synchronize
+      - labeled
 
 permissions:
   pull-requests: write
-  models: read
 
 concurrency:
   group: ai-review-${{ github.event.pull_request.number }}
@@ -20,14 +20,30 @@ jobs:
     name: DeepSeek Code Review
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Защита от DoS и лишнего расхода токенов:
+    # 1. Не запускаем на draft-PR.
+    # 2. Автоматически запускаем только для OWNER/MEMBER/COLLABORATOR.
+    # 3. Внешние контрибьюторы могут получить ревью, только если мейнтейнер
+    #    повесит метку "ai review" (триггер labeled).
+    # 4. Ограничиваем размер diff (max-length) и исключаем lock/генерируемые файлы.
+    if: |
+      !github.event.pull_request.draft && (
+        contains(github.event.pull_request.labels.*.name, 'ai review') ||
+        github.event.pull_request.author_association == 'OWNER' ||
+        github.event.pull_request.author_association == 'MEMBER' ||
+        github.event.pull_request.author_association == 'COLLABORATOR'
+      )
     steps:
       - name: DeepSeek Code Review
         uses: hustcer/deepseek-review@v1
         with:
-          chat-token: ${{ secrets.GITHUB_TOKEN }}
-          model: 'azureml-deepseek/DeepSeek-R1'
-          base-url: 'https://models.github.ai/inference'
+          # Токен, endpoint и модель задаются через секреты/переменные репозитория,
+          # чтобы можно было подключить собственного агента/провайдера.
+          chat-token: ${{ secrets.DEEPSEEK_CHAT_TOKEN }}
+          base-url: ${{ secrets.DEEPSEEK_BASE_URL }}
+          model: ${{ vars.DEEPSEEK_MODEL || 'deepseek/deepseek-v4-flash' }}
           max-length: 12000
+          exclude-patterns: 'pnpm-lock.yaml,package-lock.json,yarn.lock,*.lock,dist/**,coverage/**,node_modules/**,*.min.js,*.min.css'
           sys-prompt: |
             You are a thorough code review assistant for a TypeScript ORM project.
             Analyze the pull request diff and provide actionable feedback:


### PR DESCRIPTION
## Что добавлено

Workflow `.github/workflows/ai-review.yml`, который запускает AI-ревью кода в PR.

### Провайдер
- Используется [hustcer/deepseek-review](https://github.com/hustcer/deepseek-review) GitHub Action.
- Токен, endpoint и модель задаются через секреты/переменные репозитория, чтобы владелец мог подключить собственного агента/провайдера.

### Настройка секретов и переменных

| Секрет / переменная | Описание | Пример |
|---|---|---|
| `secrets.DEEPSEEK_CHAT_TOKEN` | API-токен провайдера | `sk-...`, `ghp_...` |
| `secrets.DEEPSEEK_BASE_URL` | Базовый URL OpenAI-совместимого API | `https://api.deepseek.com`, `https://models.github.ai/inference`, `https://openrouter.ai/api/v1` |
| `vars.DEEPSEEK_MODEL` | Имя модели (необязательно) | `deepseek/deepseek-v4-flash`, `deepseek-chat`, `gpt-4o` |

Если `vars.DEEPSEEK_MODEL` не задана, используется `deepseek/deepseek-v4-flash`.

### Защита от DoS и лишнего расхода токенов

1. **Авторский фильтр**: автоматический запуск только для `OWNER` / `MEMBER` / `COLLABORATOR`.
2. **Метка для внешних контрибьюторов**: внешние авторы получают AI-ревью только после того, как мейнтейнер повесит метку `ai review`.
3. **Draft-PR пропускаются**.
4. **Ограничение объёма**: `max-length: 12000` и исключение lock/генерируемых файлов (`*.lock`, `dist/**`, `coverage/**`, `node_modules/**`, минимизированные ассеты).
5. **Конкурентность**: отменяем предыдущий запуск при новом push в тот же PR.

### Триггеры
- `opened`, `reopened`, `synchronize`, `labeled`.

### Права
- `pull-requests: write` — публикация review-комментариев.

### Промпт
Ревью сфокусировано на:
- багах и логических ошибках;
- проблемах безопасности (SQL, шифрование, авторизация);
- TypeScript-типизации и обработке крайних случаев;
- читаемости, поддерживаемости и покрытии тестами.

> ⚠️ Для GitHub Models дополнительно потребуется вернуть permission `models: read` в workflow.