### PR TITLE
chore: добавить @mimbol22 в OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,8 @@
+# OWNERS defines who can approve and review changes in this repository.
+# Format follows the Kubernetes OWNERS file convention.
+
+approvers:
+  - mimbol22
+
+reviewers:
+  - mimbol22


### PR DESCRIPTION
Добавляет `OWNERS`-файл в формате Kubernetes OWNERS и указывает `@mimbol22` как approver и reviewer для репозитория.