### PR TITLE
ci: починить шаг проверки критических ошибок в AI review

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -72,14 +72,15 @@ jobs:
           repo="${{ github.repository }}"
 
           echo "Fetching PR reviews..."
-          review_bodies=$(gh api "repos/${repo}/pulls/${pr_number}/reviews" --jq '.[].body' -r)
+          # gh api не поддерживает флаг -r; забираем JSON-массив тел review и ищем маркер в нём.
+          review_bodies=$(gh api "repos/${repo}/pulls/${pr_number}/reviews" --jq '[.[].body]')
 
-          if echo "$review_bodies" | grep -q '<!-- AI_REVIEW_SEVERITY: CRITICAL -->'; then
+          if echo "$review_bodies" | grep -q 'AI_REVIEW_SEVERITY: CRITICAL'; then
             echo "::error::AI review detected CRITICAL issues. Failing the workflow."
             exit 1
           fi
 
-          if echo "$review_bodies" | grep -q '<!-- AI_REVIEW_SEVERITY: OK -->'; then
+          if echo "$review_bodies" | grep -q 'AI_REVIEW_SEVERITY: OK'; then
             echo "AI review found no critical issues."
           else
             echo "::warning::Severity marker not found in AI review; cannot determine critical status. Continuing without failure."


### PR DESCRIPTION
## Проблема

Workflow AI review падает на шаге `Check for critical issues` с ошибкой:



`gh api` не поддерживает флаг `-r`, который был ошибочно использован для "raw"-вывода.

## Решение

Забираем review-боди как JSON-массив через `--jq '[.[].body]'` и ищем маркер `AI_REVIEW_SEVERITY` уже внутри JSON, без необходимости декодирования строк.

## Проверка

После мержа workflow сможет корректно определять наличие критических проблем и падать с `exit 1` только при маркере `CRITICAL`.