### PR TITLE
fix(schema): TTL в WITH (...), явная TTL-колонка и валидация метаданных (#81)

### DIFF
--- a/src/decorators/ttl.decorator.ts
+++ b/src/decorators/ttl.decorator.ts
@@ -1,27 +1,62 @@
 import 'reflect-metadata';
+import { YdbPrimitive } from '../core/types.js';
 
 export const YDB_TTL_KEY = 'ydb:ttl';
+
+/**
+ * Единица измерения числовой TTL-колонки (AS <unit> в YQL).
+ * Обязательна для целочисленных колонок, запрещена для Date/Datetime/Timestamp.
+ */
+export type YdbTtlUnit =
+  'seconds' | 'milliseconds' | 'microseconds' | 'nanoseconds';
+
+const TTL_UNITS: readonly YdbTtlUnit[] = [
+  'seconds',
+  'milliseconds',
+  'microseconds',
+  'nanoseconds',
+];
+
+/** Типы колонок, которые можно использовать как TTL без указания unit. */
+const DATE_LIKE_TTL_TYPES: readonly YdbPrimitive[] = [
+  'Date',
+  'Datetime',
+  'Timestamp',
+];
+
+/** Целочисленные типы, допустимые для TTL только с AS <unit>. */
+const NUMERIC_TTL_TYPES: readonly YdbPrimitive[] = ['Int32', 'Int64'];
+
+/** ISO 8601 duration (например, "PT2H", "P30D", "P1DT2H30M"). */
+const ISO_DURATION_RE =
+  /^P(?!$)(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+(\.\d+)?S)?)?$/;
 
 export interface YdbTtlOptions {
   /** ISO 8601 duration (например, "PT2H", "P30D", "PT1H"). */
   interval: string;
-  /** Колонка для TTL. По умолчанию — первый PK. */
-  column?: string;
+  /**
+   * Колонка для TTL — должна быть объявлена через @YdbColumn и иметь
+   * тип Date/Datetime/Timestamp либо целочисленный (тогда обязателен unit).
+   */
+  column: string;
+  /** Единица измерения числовой TTL-колонки (AS <unit>), например 'seconds'. */
+  unit?: YdbTtlUnit;
 }
 
 export interface YdbTtlMetadata {
   interval: string;
   column: string;
+  unit?: YdbTtlUnit;
 }
 
 /**
  * Декларативный TTL таблицы (YDB table TTL).
  * Можно применить только один раз на класс.
- * Генерирует TTL = Interval(...) ON `column` в CREATE TABLE DDL.
+ * Генерирует секцию WITH (TTL = Interval(...) ON column) после CREATE TABLE (...).
  *
  * @example
  *   @YdbEntity('sessions')
- *   @YdbTtl({ interval: 'PT2H' })
+ *   @YdbTtl({ interval: 'PT2H', column: 'expires_at', unit: 'seconds' })
  *   class SessionEntity extends YdbBaseEntity { ... }
  */
 export function YdbTtl(options: YdbTtlOptions): ClassDecorator {
@@ -32,12 +67,88 @@ export function YdbTtl(options: YdbTtlOptions): ClassDecorator {
         `@YdbTtl can only be applied once to class "${target.name}"`,
       );
     }
+    validateYdbTtlOptions(target.name, options);
     Reflect.defineMetadata(YDB_TTL_KEY, options, target);
   };
 }
 
 export function getYdbTtlMetadata(
   target: new (...args: any[]) => any,
-): YdbTtlOptions | undefined {
+): YdbTtlMetadata | undefined {
   return Reflect.getMetadata(YDB_TTL_KEY, target);
+}
+
+/** Проверяет опции декоратора без учёта схемы сущности (вызывается из @YdbTtl). */
+function validateYdbTtlOptions(
+  className: string,
+  options: YdbTtlOptions,
+): void {
+  if (!options?.interval || !ISO_DURATION_RE.test(options.interval)) {
+    throw new Error(
+      `@YdbTtl on class "${className}": ` +
+        `interval must be a valid ISO 8601 duration (e.g. "PT2H", "P30D"), ` +
+        `got "${options?.interval}"`,
+    );
+  }
+  if (!options.column || typeof options.column !== 'string') {
+    throw new Error(
+      `@YdbTtl on class "${className}": ` +
+        `"column" is required — specify an existing Date/Datetime/Timestamp ` +
+        `(or integer with "unit") column explicitly`,
+    );
+  }
+  if (options.unit !== undefined && !TTL_UNITS.includes(options.unit)) {
+    throw new Error(
+      `@YdbTtl on class "${className}": invalid unit "${String(options.unit)}" — ` +
+        `expected one of: ${TTL_UNITS.join(', ')}`,
+    );
+  }
+}
+
+/**
+ * Проверяет TTL-метаданные против схемы колонок сущности.
+ * Возвращает список проблем (пустой, если всё в порядке) — чистая функция,
+ * используется validateEntityMetadata и buildExpectedTableSchema.
+ */
+export function validateYdbTtlAgainstSchema(
+  entityName: string,
+  ttl: YdbTtlMetadata,
+  columns: Record<string, YdbPrimitive>,
+): string[] {
+  const issues: string[] = [];
+  const type = columns[ttl.column];
+
+  if (!type) {
+    issues.push(
+      `entity "${entityName}": @YdbTtl column "${ttl.column}" ` +
+        `is not declared via @YdbColumn`,
+    );
+    return issues;
+  }
+
+  if (DATE_LIKE_TTL_TYPES.includes(type)) {
+    if (ttl.unit !== undefined) {
+      issues.push(
+        `entity "${entityName}": @YdbTtl unit cannot be specified ` +
+          `for ${type} column "${ttl.column}"`,
+      );
+    }
+    return issues;
+  }
+
+  if (NUMERIC_TTL_TYPES.includes(type)) {
+    if (!ttl.unit) {
+      issues.push(
+        `entity "${entityName}": @YdbTtl requires "unit" ` +
+          `(e.g. { unit: 'seconds' }) for numeric column "${ttl.column}" of type ${type}`,
+      );
+    }
+    return issues;
+  }
+
+  issues.push(
+    `entity "${entityName}": @YdbTtl column "${ttl.column}" has unsupported type ` +
+      `${type} — use Date/Datetime/Timestamp or Int32/Int64 with "unit"`,
+  );
+  return issues;
 }

--- a/src/decorators/ttl.decorator.ts
+++ b/src/decorators/ttl.decorator.ts
@@ -24,8 +24,12 @@ const DATE_LIKE_TTL_TYPES: readonly YdbPrimitive[] = [
   'Timestamp',
 ];
 
-/** Целочисленные типы, допустимые для TTL только с AS <unit>. */
-const NUMERIC_TTL_TYPES: readonly YdbPrimitive[] = ['Int32', 'Int64'];
+/**
+ * Числовые типы TTL-колонок по ограничениям YDB (значение трактуется как
+ * Unix-время и требует указания unit). Только беззнаковые: знаковые
+ * Int32/Int64 YDB для TTL не принимает.
+ */
+const NUMERIC_TTL_TYPES: readonly string[] = ['Uint32', 'Uint64', 'DyNumber'];
 
 /** ISO 8601 duration (например, "PT2H", "P30D", "P1DT2H30M"). */
 const ISO_DURATION_RE =
@@ -35,11 +39,17 @@ export interface YdbTtlOptions {
   /** ISO 8601 duration (например, "PT2H", "P30D", "PT1H"). */
   interval: string;
   /**
-   * Колонка для TTL — должна быть объявлена через @YdbColumn и иметь
-   * тип Date/Datetime/Timestamp либо целочисленный (тогда обязателен unit).
+   * Колонка для TTL — должна быть объявлена через @YdbColumn.
+   * По ограничениям YDB тип колонки: Date/Datetime/Timestamp либо
+   * числовой Uint32/Uint64/DyNumber (трактуется как Unix-время,
+   * тогда обязателен unit). Знаковые Int32/Int64 YDB не допускает.
+   * Дефолтов нет: колонка указывается явно (см. issue #81).
    */
   column: string;
-  /** Единица измерения числовой TTL-колонки (AS <unit>), например 'seconds'. */
+  /**
+   * Единица измерения числовой TTL-колонки (AS <unit>), например 'seconds'.
+   * Обязательна для Uint32/Uint64/DyNumber, запрещена для дат.
+   */
   unit?: YdbTtlUnit;
 }
 
@@ -53,6 +63,12 @@ export interface YdbTtlMetadata {
  * Декларативный TTL таблицы (YDB table TTL).
  * Можно применить только один раз на класс.
  * Генерирует секцию WITH (TTL = Interval(...) ON column) после CREATE TABLE (...).
+ *
+ * Ошибки формата (interval, column, unit) бросаются сразу при декорировании.
+ * Ошибки относительно схемы сущности (неизвестная колонка, несовместимый тип,
+ * лишний/недостающий unit) обнаруживаются при инициализации модуля
+ * (validateEntityMetadata) и при построении схемы (buildExpectedTableSchema) —
+ * до генерации DDL, см. issue #81.
  *
  * @example
  *   @YdbEntity('sessions')
@@ -106,7 +122,11 @@ function validateYdbTtlOptions(
 }
 
 /**
- * Проверяет TTL-метаданные против схемы колонок сущности.
+ * Проверяет TTL-метаданные против схемы колонок сущности по ограничениям YDB:
+ * колонка должна существовать и иметь тип Date/Datetime/Timestamp (без unit)
+ * либо Uint32/Uint64/DyNumber (только с unit). Знаковые Int32/Int64 YDB
+ * для TTL не принимает.
+ *
  * Возвращает список проблем (пустой, если всё в порядке) — чистая функция,
  * используется validateEntityMetadata и buildExpectedTableSchema.
  */
@@ -148,7 +168,8 @@ export function validateYdbTtlAgainstSchema(
 
   issues.push(
     `entity "${entityName}": @YdbTtl column "${ttl.column}" has unsupported type ` +
-      `${type} — use Date/Datetime/Timestamp or Int32/Int64 with "unit"`,
+      `${type} — YDB TTL requires Date/Datetime/Timestamp or ` +
+      `numeric Uint32/Uint64/DyNumber with "unit"`,
   );
   return issues;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,7 @@ export { YdbTtl, getYdbTtlMetadata } from './decorators/ttl.decorator.js';
 export type {
   YdbTtlOptions,
   YdbTtlMetadata,
+  YdbTtlUnit,
 } from './decorators/ttl.decorator.js';
 export {
   BeforeInsert,
@@ -130,6 +131,10 @@ export { ClassValidatorProvider } from './validation/ydb-validate.provider.js';
 // Метаданные и реестр сущностей
 export { getYdbEntityMetadata } from './metadata/entity-metadata.js';
 export { validateEntityMetadata } from './metadata/validate-entity.js';
+export {
+  validateYdbTtlAgainstSchema,
+  YDB_TTL_KEY,
+} from './decorators/ttl.decorator.js';
 export type { EntityValidationContext } from './metadata/validate-entity.js';
 export type {
   YdbEntityMetadata,
@@ -149,6 +154,7 @@ export {
   YdbSchemaSyncer,
   buildExpectedTableSchema,
   generateCreateTableYql,
+  generateTtlWithClause,
   generateAddColumnsYql,
   checkTableSchema,
 } from './schema/schema-sync.js';

--- a/src/metadata/validate-entity.ts
+++ b/src/metadata/validate-entity.ts
@@ -4,6 +4,10 @@ import {
   RelationMetadata,
 } from '../decorators/relation.decorators.js';
 import { getYdbIndexesMetadata } from '../decorators/index.decorator.js';
+import {
+  getYdbTtlMetadata,
+  validateYdbTtlAgainstSchema,
+} from '../decorators/ttl.decorator.js';
 import { getYdbEntityMetadata } from './entity-metadata.js';
 import type { YdbBaseEntity } from '../entity/base-entity.js';
 
@@ -71,6 +75,13 @@ export function validateEntityMetadata(
   ) {
     issues.push(
       `entity has blind index fields, but no blindIndexProvider is configured`,
+    );
+  }
+
+  const ttl = getYdbTtlMetadata(entity);
+  if (ttl) {
+    issues.push(
+      ...validateYdbTtlAgainstSchema(meta.target.name, ttl, meta.schema),
     );
   }
 

--- a/src/schema/schema-sync.ts
+++ b/src/schema/schema-sync.ts
@@ -23,7 +23,11 @@ import {
   getYdbIndexesMetadata,
   resolveIndexName,
 } from '../decorators/index.decorator.js';
-import { getYdbTtlMetadata } from '../decorators/ttl.decorator.js';
+import {
+  getYdbTtlMetadata,
+  validateYdbTtlAgainstSchema,
+  YdbTtlMetadata,
+} from '../decorators/ttl.decorator.js';
 
 /** Ожидаемый вторичный индекс таблицы. */
 export interface ExpectedIndex {
@@ -38,7 +42,7 @@ export interface ExpectedTableSchema {
   columns: Record<string, YdbPrimitive>;
   primaryKey: string[];
   indexes: ExpectedIndex[];
-  ttl?: { interval: string; column: string };
+  ttl?: YdbTtlMetadata;
 }
 
 /** Нормализованное описание существующей таблицы из DescribeTable. */
@@ -151,14 +155,26 @@ export function buildExpectedTableSchema(
   );
 
   const ttlOptions = getYdbTtlMetadata(meta.target);
-  const ttl = ttlOptions
-    ? {
-        interval: ttlOptions.interval,
-        column: ttlOptions.column ?? primaryKey[0],
-      }
-    : undefined;
+  if (ttlOptions) {
+    const issues = validateYdbTtlAgainstSchema(
+      meta.target.name,
+      ttlOptions,
+      columns,
+    );
+    if (issues.length) {
+      throw new Error(
+        `Cannot build schema for entity ${meta.target.name}: ${issues.join('; ')}`,
+      );
+    }
+  }
 
-  return { tableName: meta.tableName, columns, primaryKey, indexes, ttl };
+  return {
+    tableName: meta.tableName,
+    columns,
+    primaryKey,
+    indexes,
+    ttl: ttlOptions,
+  };
 }
 
 /** Ожидаемая схема join-таблицы many-to-many. */
@@ -196,6 +212,20 @@ export function buildExpectedSchemas(
   return schemas;
 }
 
+/**
+ * Генерирует TTL-секцию WITH (...) для CREATE TABLE.
+ * По синтаксису YQL TTL задаётся только в WITH, а не внутри тела таблицы:
+ *   WITH (TTL = Interval("PT2H") ON `col` [AS SECONDS])
+ */
+export function generateTtlWithClause(ttl: YdbTtlMetadata): string {
+  const unitPart = ttl.unit ? ` AS ${ttl.unit.toUpperCase()}` : '';
+  return (
+    `WITH (\n` +
+    `  TTL = Interval("${ttl.interval}") ON ${quoteIdentifier(ttl.column)}` +
+    `${unitPart}\n)`
+  );
+}
+
 /** Генерирует DDL создания таблицы. */
 export function generateCreateTableYql(expected: ExpectedTableSchema): string {
   const columnDefs = Object.entries(expected.columns).map(
@@ -208,15 +238,13 @@ export function generateCreateTableYql(expected: ExpectedTableSchema): string {
   );
   const pk = expected.primaryKey.map(quoteIdentifier).join(', ');
   const parts = [...columnDefs, ...indexDefs, `PRIMARY KEY (${pk})`];
-  if (expected.ttl) {
-    parts.push(
-      `TTL = Interval("${expected.ttl.interval}") ON ${quoteIdentifier(expected.ttl.column)}`,
-    );
-  }
   const body = parts.join(',\n  ');
-  return (
-    `CREATE TABLE ${quoteIdentifier(expected.tableName)} (\n  ` + `${body}\n)`
-  );
+  let yql =
+    `CREATE TABLE ${quoteIdentifier(expected.tableName)} (\n  ` + `${body}\n)`;
+  if (expected.ttl) {
+    yql += `\n${generateTtlWithClause(expected.ttl)}`;
+  }
+  return yql;
 }
 
 /** Генерирует DDL добавления недостающих колонок (один ALTER на таблицу). */

--- a/src/schema/schema-sync.ts
+++ b/src/schema/schema-sync.ts
@@ -118,6 +118,13 @@ const TYPE_ID_TO_PRIMITIVE = new Map<Type_PrimitiveTypeId, YdbPrimitive>(
  * Строит ожидаемую схему таблицы по метаданным сущности:
  * колонки + synthetic {field}_bi колонки blind index.
  * Требует явно объявленного первичного ключа через @YdbPrimaryColumn.
+ *
+ * Бросает ошибку (fail-fast, по той же политике, что и для PK) при
+ * невалидных метаданных TTL: неизвестная колонка, несовместимый тип
+ * (YDB допускает Date/Datetime/Timestamp либо Uint32/Uint64/DyNumber
+ * с unit), unit у даты или его отсутствие у числа. Так schema sync,
+ * миграции и CLI не сгенерируют заведомо невалидный DDL; при инициализации
+ * модуля те же проблемы раньше собирает validateEntityMetadata.
  */
 export function buildExpectedTableSchema(
   meta: YdbEntityMetadata,

--- a/test/ydb-ttl.spec.ts
+++ b/test/ydb-ttl.spec.ts
@@ -14,7 +14,9 @@ import {
   buildExpectedTableSchema,
   generateCreateTableYql,
   generateTtlWithClause,
+  ExpectedTableSchema,
 } from '../src/schema/schema-sync.js';
+import { YdbPrimitive } from '../src/core/types.js';
 import { validateEntityMetadata } from '../src/metadata/validate-entity.js';
 import { getYdbEntityMetadata } from '../src/metadata/entity-metadata.js';
 
@@ -29,6 +31,13 @@ const validationCtx = {
   blindIndexProviderConfigured: true,
 };
 
+/**
+ * Uint32/Uint64/DyNumber пока не входят в YdbPrimitive (отдельная задача),
+ * поэтому для тестов числовых TTL-колонок схема колонок приводится напрямую.
+ */
+const cols = (o: Record<string, string>) =>
+  o as unknown as Record<string, YdbPrimitive>;
+
 @YdbEntity('ttl_sessions')
 @YdbTtl({ interval: 'PT2H', column: 'expires_at' })
 class TtlSessionEntity extends YdbBaseEntity {
@@ -42,9 +51,10 @@ class TtlSessionEntity extends YdbBaseEntity {
   expires_at: string;
 }
 
-@YdbEntity('ttl_numeric_col')
+// Знаковые Int64 YDB для TTL не принимает (только Uint32/Uint64/DyNumber)
+@YdbEntity('ttl_signed_numeric')
 @YdbTtl({ interval: 'P30D', column: 'expires_at', unit: 'seconds' })
-class TtlNumericColumnEntity extends YdbBaseEntity {
+class TtlSignedNumericEntity extends YdbBaseEntity {
   @YdbPrimaryColumn('Uuid')
   uuid: string;
 
@@ -72,8 +82,8 @@ describe('@YdbTtl', () => {
     expect(ttl).toEqual({ interval: 'PT2H', column: 'expires_at' });
   });
 
-  it('stores TTL with unit for numeric columns', () => {
-    const ttl = getYdbTtlMetadata(TtlNumericColumnEntity);
+  it('stores TTL with unit as provided', () => {
+    const ttl = getYdbTtlMetadata(TtlSignedNumericEntity);
     expect(ttl).toEqual({
       interval: 'P30D',
       column: 'expires_at',
@@ -100,7 +110,7 @@ describe('@YdbTtl', () => {
     }).toThrow(/can only be applied once/);
   });
 
-  it('throws when column is not specified', () => {
+  it('throws when column is not specified (no default to PK)', () => {
     class TtlNoColumnEntity extends YdbBaseEntity {
       @YdbPrimaryColumn('Uuid')
       uuid: string;
@@ -143,9 +153,65 @@ describe('validateYdbTtlAgainstSchema', () => {
       validateYdbTtlAgainstSchema(
         'E',
         { interval: 'PT2H', column: 'expires_at' },
-        { expires_at: 'Datetime' },
+        cols({ expires_at: 'Datetime' }),
       ),
     ).toEqual([]);
+  });
+
+  it('accepts Date and Timestamp columns without unit', () => {
+    expect(
+      validateYdbTtlAgainstSchema(
+        'E',
+        { interval: 'P1D', column: 'd' },
+        cols({ d: 'Date' }),
+      ),
+    ).toEqual([]);
+    expect(
+      validateYdbTtlAgainstSchema(
+        'E',
+        { interval: 'PT1H', column: 'ts' },
+        cols({ ts: 'Timestamp' }),
+      ),
+    ).toEqual([]);
+  });
+
+  it.each(['Uint32', 'Uint64', 'DyNumber'])(
+    'requires unit for numeric %s column',
+    (type) => {
+      const issues = validateYdbTtlAgainstSchema(
+        'E',
+        { interval: 'PT2H', column: 'created_at' },
+        cols({ created_at: type }),
+      );
+      expect(issues).toEqual([expect.stringContaining('requires "unit"')]);
+    },
+  );
+
+  it.each([
+    ['Uint32', 'seconds'],
+    ['Uint64', 'milliseconds'],
+    ['DyNumber', 'nanoseconds'],
+  ] as const)('accepts numeric %s column with unit %s', (type, unit) => {
+    expect(
+      validateYdbTtlAgainstSchema(
+        'E',
+        { interval: 'PT2H', column: 'created_at', unit },
+        cols({ created_at: type }),
+      ),
+    ).toEqual([]);
+  });
+
+  it('rejects signed Int64 column (YDB TTL allows only unsigned numerics)', () => {
+    const issues = validateYdbTtlAgainstSchema(
+      'E',
+      { interval: 'PT2H', column: 'created_at', unit: 'seconds' },
+      cols({ created_at: 'Int64' }),
+    );
+    expect(issues).toEqual([
+      expect.stringContaining(
+        'unsupported type Int64 — YDB TTL requires Date/Datetime/Timestamp or numeric Uint32/Uint64/DyNumber',
+      ),
+    ]);
   });
 
   it('rejects unknown TTL column', () => {
@@ -153,19 +219,9 @@ describe('validateYdbTtlAgainstSchema', () => {
       validateYdbTtlAgainstSchema(
         'E',
         { interval: 'PT2H', column: 'missing' },
-        { created_at: 'Datetime' },
+        cols({ created_at: 'Datetime' }),
       ),
     ).toEqual([expect.stringContaining('"missing" is not declared')]);
-  });
-
-  it('requires unit for numeric column', () => {
-    expect(
-      validateYdbTtlAgainstSchema(
-        'E',
-        { interval: 'PT2H', column: 'created_at' },
-        { created_at: 'Int64' },
-      ),
-    ).toEqual([expect.stringContaining('requires "unit"')]);
   });
 
   it('forbids unit for Date-like column', () => {
@@ -173,7 +229,7 @@ describe('validateYdbTtlAgainstSchema', () => {
       validateYdbTtlAgainstSchema(
         'E',
         { interval: 'PT2H', column: 'created_at', unit: 'seconds' },
-        { created_at: 'Timestamp' },
+        cols({ created_at: 'Timestamp' }),
       ),
     ).toEqual([expect.stringContaining('unit cannot be specified')]);
   });
@@ -183,7 +239,7 @@ describe('validateYdbTtlAgainstSchema', () => {
       validateYdbTtlAgainstSchema(
         'E',
         { interval: 'PT2H', column: 'name' },
-        { name: 'Utf8' },
+        cols({ name: 'Utf8' }),
       ),
     ).toEqual([expect.stringContaining('unsupported type Utf8')]);
   });
@@ -195,15 +251,6 @@ describe('ExpectedTableSchema with TTL', () => {
     expect(schema.ttl).toEqual({
       interval: 'PT2H',
       column: 'expires_at',
-    });
-  });
-
-  it('includes TTL unit for numeric column', () => {
-    const schema = buildExpectedTableSchema(meta(TtlNumericColumnEntity));
-    expect(schema.ttl).toEqual({
-      interval: 'P30D',
-      column: 'expires_at',
-      unit: 'seconds',
     });
   });
 
@@ -224,7 +271,7 @@ describe('ExpectedTableSchema with TTL', () => {
     ).toThrow(/"missing_column" is not declared/);
   });
 
-  it('throws when TTL references PK of incompatible type (no default to PK)', () => {
+  it('throws when TTL references PK of unsupported type (no default to PK)', () => {
     @YdbEntity('ttl_on_pk_uuid')
     @YdbTtl({ interval: 'PT2H', column: 'uuid' })
     class TtlOnPkUuidEntity extends YdbBaseEntity {
@@ -233,6 +280,14 @@ describe('ExpectedTableSchema with TTL', () => {
     }
     expect(() => buildExpectedTableSchema(meta(TtlOnPkUuidEntity))).toThrow(
       /unsupported type Uuid/,
+    );
+  });
+
+  it('throws when TTL column has signed numeric type (Int64)', () => {
+    expect(() =>
+      buildExpectedTableSchema(meta(TtlSignedNumericEntity)),
+    ).toThrow(
+      /unsupported type Int64 — YDB TTL requires Date\/Datetime\/Timestamp or numeric Uint32\/Uint64\/DyNumber/,
     );
   });
 });
@@ -257,22 +312,13 @@ describe('validateEntityMetadata with TTL', () => {
     expect(issues[0]).toContain('"missing_column" is not declared');
   });
 
-  it('reports missing unit for numeric TTL column', () => {
-    @YdbEntity('ttl_validate_no_unit')
-    @YdbTtl({ interval: 'PT2H', column: 'created_ms' })
-    class TtlValidateNoUnitEntity extends YdbBaseEntity {
-      @YdbPrimaryColumn('Uuid')
-      uuid: string;
-
-      @YdbColumn('Int64')
-      created_ms: bigint;
-    }
+  it('reports signed numeric TTL column as unsupported type', () => {
     const issues = validateEntityMetadata(
-      TtlValidateNoUnitEntity,
+      TtlSignedNumericEntity,
       validationCtx,
     );
     expect(issues).toHaveLength(1);
-    expect(issues[0]).toContain('requires "unit"');
+    expect(issues[0]).toContain('Uint32/Uint64/DyNumber');
   });
 });
 
@@ -293,11 +339,25 @@ describe('generateCreateTableYql with TTL', () => {
   });
 
   it('puts TTL with AS unit into WITH clause for numeric column', () => {
-    const schema = buildExpectedTableSchema(meta(TtlNumericColumnEntity));
+    // Uint64-колонку нельзя объявить через @YdbPrimitive, поэтому схема собирается вручную
+    const schema: ExpectedTableSchema = {
+      tableName: 'ttl_numeric',
+      columns: cols({ id: 'Utf8', expires_at: 'Uint64' }),
+      primaryKey: ['id'],
+      indexes: [],
+      ttl: { interval: 'P30D', column: 'expires_at', unit: 'seconds' },
+    };
     const yql = generateCreateTableYql(schema);
 
-    expect(yql).toContain(
-      'WITH (\n  TTL = Interval("P30D") ON `expires_at` AS SECONDS\n)',
+    expect(yql).toBe(
+      'CREATE TABLE `ttl_numeric` (\n' +
+        '  `id` Utf8,\n' +
+        '  `expires_at` Uint64,\n' +
+        '  PRIMARY KEY (`id`)\n' +
+        ')\n' +
+        'WITH (\n' +
+        '  TTL = Interval("P30D") ON `expires_at` AS SECONDS\n' +
+        ')',
     );
   });
 

--- a/test/ydb-ttl.spec.ts
+++ b/test/ydb-ttl.spec.ts
@@ -5,11 +5,17 @@ import {
   YdbColumn,
 } from '../src/decorators/column.decorator.js';
 import { YdbBaseEntity } from '../src/entity/base-entity.js';
-import { YdbTtl, getYdbTtlMetadata } from '../src/decorators/ttl.decorator.js';
+import {
+  YdbTtl,
+  getYdbTtlMetadata,
+  validateYdbTtlAgainstSchema,
+} from '../src/decorators/ttl.decorator.js';
 import {
   buildExpectedTableSchema,
   generateCreateTableYql,
+  generateTtlWithClause,
 } from '../src/schema/schema-sync.js';
+import { validateEntityMetadata } from '../src/metadata/validate-entity.js';
 import { getYdbEntityMetadata } from '../src/metadata/entity-metadata.js';
 
 const meta = (entity: new (...args: any[]) => any) => {
@@ -18,24 +24,32 @@ const meta = (entity: new (...args: any[]) => any) => {
   return m;
 };
 
+const validationCtx = {
+  encryptionProviderConfigured: true,
+  blindIndexProviderConfigured: true,
+};
+
 @YdbEntity('ttl_sessions')
-@YdbTtl({ interval: 'PT2H' })
+@YdbTtl({ interval: 'PT2H', column: 'expires_at' })
 class TtlSessionEntity extends YdbBaseEntity {
   @YdbPrimaryColumn('Uuid')
   uuid: string;
 
   @YdbColumn('Utf8')
   token: string;
+
+  @YdbColumn('Datetime')
+  expires_at: string;
 }
 
-@YdbEntity('ttl_custom_col')
-@YdbTtl({ interval: 'P30D', column: 'expires_at' })
-class TtlCustomColumnEntity extends YdbBaseEntity {
+@YdbEntity('ttl_numeric_col')
+@YdbTtl({ interval: 'P30D', column: 'expires_at', unit: 'seconds' })
+class TtlNumericColumnEntity extends YdbBaseEntity {
   @YdbPrimaryColumn('Uuid')
   uuid: string;
 
-  @YdbColumn('Timestamp')
-  expires_at: string;
+  @YdbColumn('Int64')
+  expires_at: bigint;
 }
 
 @YdbEntity('no_ttl_entity')
@@ -47,19 +61,6 @@ class NoTtlEntity extends YdbBaseEntity {
   name: string;
 }
 
-@YdbEntity('ttl_composite_pk')
-@YdbTtl({ interval: 'PT1H' })
-class TtlCompositePkEntity extends YdbBaseEntity {
-  @YdbPrimaryColumn('Utf8')
-  tenant_id: string;
-
-  @YdbPrimaryColumn('Int64')
-  id: string;
-
-  @YdbColumn('Utf8')
-  data: string;
-}
-
 class TtlDuplicateEntity extends YdbBaseEntity {
   @YdbPrimaryColumn('Uuid')
   uuid: string;
@@ -68,12 +69,16 @@ class TtlDuplicateEntity extends YdbBaseEntity {
 describe('@YdbTtl', () => {
   it('stores TTL metadata on class', () => {
     const ttl = getYdbTtlMetadata(TtlSessionEntity);
-    expect(ttl).toEqual({ interval: 'PT2H' });
+    expect(ttl).toEqual({ interval: 'PT2H', column: 'expires_at' });
   });
 
-  it('stores TTL with custom column', () => {
-    const ttl = getYdbTtlMetadata(TtlCustomColumnEntity);
-    expect(ttl).toEqual({ interval: 'P30D', column: 'expires_at' });
+  it('stores TTL with unit for numeric columns', () => {
+    const ttl = getYdbTtlMetadata(TtlNumericColumnEntity);
+    expect(ttl).toEqual({
+      interval: 'P30D',
+      column: 'expires_at',
+      unit: 'seconds',
+    });
   });
 
   it('returns undefined for entity without TTL', () => {
@@ -83,55 +88,217 @@ describe('@YdbTtl', () => {
 
   it('throws when applied twice to the same class', () => {
     // Apply first @YdbTtl — should succeed
-    YdbTtl({ interval: 'PT2H' })(TtlDuplicateEntity);
-    expect(getYdbTtlMetadata(TtlDuplicateEntity)).toEqual({ interval: 'PT2H' });
+    YdbTtl({ interval: 'PT2H', column: 'uuid' })(TtlDuplicateEntity);
+    expect(getYdbTtlMetadata(TtlDuplicateEntity)).toEqual({
+      interval: 'PT2H',
+      column: 'uuid',
+    });
 
     // Apply second @YdbTtl — should throw
     expect(() => {
-      YdbTtl({ interval: 'P1D' })(TtlDuplicateEntity);
+      YdbTtl({ interval: 'P1D', column: 'uuid' })(TtlDuplicateEntity);
     }).toThrow(/can only be applied once/);
+  });
+
+  it('throws when column is not specified', () => {
+    class TtlNoColumnEntity extends YdbBaseEntity {
+      @YdbPrimaryColumn('Uuid')
+      uuid: string;
+    }
+    expect(() => {
+      (YdbTtl as (options: any) => ClassDecorator)({ interval: 'PT2H' })(
+        TtlNoColumnEntity,
+      );
+    }).toThrow(/"column" is required/);
+  });
+
+  it('throws on invalid interval format', () => {
+    class TtlBadIntervalEntity extends YdbBaseEntity {
+      @YdbPrimaryColumn('Uuid')
+      uuid: string;
+    }
+    expect(() => {
+      YdbTtl({ interval: '2 hours', column: 'uuid' })(TtlBadIntervalEntity);
+    }).toThrow(/ISO 8601 duration/);
+  });
+
+  it('throws on unknown unit', () => {
+    class TtlBadUnitEntity extends YdbBaseEntity {
+      @YdbPrimaryColumn('Uuid')
+      uuid: string;
+    }
+    expect(() => {
+      (YdbTtl as (options: any) => ClassDecorator)({
+        interval: 'PT1H',
+        column: 'expires_at',
+        unit: 'weeks',
+      })(TtlBadUnitEntity);
+    }).toThrow(/invalid unit/);
+  });
+});
+
+describe('validateYdbTtlAgainstSchema', () => {
+  it('accepts Datetime column without unit', () => {
+    expect(
+      validateYdbTtlAgainstSchema(
+        'E',
+        { interval: 'PT2H', column: 'expires_at' },
+        { expires_at: 'Datetime' },
+      ),
+    ).toEqual([]);
+  });
+
+  it('rejects unknown TTL column', () => {
+    expect(
+      validateYdbTtlAgainstSchema(
+        'E',
+        { interval: 'PT2H', column: 'missing' },
+        { created_at: 'Datetime' },
+      ),
+    ).toEqual([expect.stringContaining('"missing" is not declared')]);
+  });
+
+  it('requires unit for numeric column', () => {
+    expect(
+      validateYdbTtlAgainstSchema(
+        'E',
+        { interval: 'PT2H', column: 'created_at' },
+        { created_at: 'Int64' },
+      ),
+    ).toEqual([expect.stringContaining('requires "unit"')]);
+  });
+
+  it('forbids unit for Date-like column', () => {
+    expect(
+      validateYdbTtlAgainstSchema(
+        'E',
+        { interval: 'PT2H', column: 'created_at', unit: 'seconds' },
+        { created_at: 'Timestamp' },
+      ),
+    ).toEqual([expect.stringContaining('unit cannot be specified')]);
+  });
+
+  it('rejects unsupported column type', () => {
+    expect(
+      validateYdbTtlAgainstSchema(
+        'E',
+        { interval: 'PT2H', column: 'name' },
+        { name: 'Utf8' },
+      ),
+    ).toEqual([expect.stringContaining('unsupported type Utf8')]);
   });
 });
 
 describe('ExpectedTableSchema with TTL', () => {
   it('includes TTL in schema when decorator is present', () => {
     const schema = buildExpectedTableSchema(meta(TtlSessionEntity));
-    expect(schema.ttl).toEqual({ interval: 'PT2H', column: 'uuid' });
+    expect(schema.ttl).toEqual({
+      interval: 'PT2H',
+      column: 'expires_at',
+    });
   });
 
-  it('uses custom column from TTL options', () => {
-    const schema = buildExpectedTableSchema(meta(TtlCustomColumnEntity));
-    expect(schema.ttl).toEqual({ interval: 'P30D', column: 'expires_at' });
-  });
-
-  it('defaults to first PK when column is not specified', () => {
-    const schema = buildExpectedTableSchema(meta(TtlCompositePkEntity));
-    expect(schema.ttl).toEqual({ interval: 'PT1H', column: 'tenant_id' });
+  it('includes TTL unit for numeric column', () => {
+    const schema = buildExpectedTableSchema(meta(TtlNumericColumnEntity));
+    expect(schema.ttl).toEqual({
+      interval: 'P30D',
+      column: 'expires_at',
+      unit: 'seconds',
+    });
   });
 
   it('has no TTL when decorator is absent', () => {
     const schema = buildExpectedTableSchema(meta(NoTtlEntity));
     expect(schema.ttl).toBeUndefined();
   });
+
+  it('throws when TTL column is not declared', () => {
+    @YdbEntity('ttl_unknown_col')
+    @YdbTtl({ interval: 'PT2H', column: 'missing_column' })
+    class TtlUnknownColumnEntity extends YdbBaseEntity {
+      @YdbPrimaryColumn('Uuid')
+      uuid: string;
+    }
+    expect(() =>
+      buildExpectedTableSchema(meta(TtlUnknownColumnEntity)),
+    ).toThrow(/"missing_column" is not declared/);
+  });
+
+  it('throws when TTL references PK of incompatible type (no default to PK)', () => {
+    @YdbEntity('ttl_on_pk_uuid')
+    @YdbTtl({ interval: 'PT2H', column: 'uuid' })
+    class TtlOnPkUuidEntity extends YdbBaseEntity {
+      @YdbPrimaryColumn('Uuid')
+      uuid: string;
+    }
+    expect(() => buildExpectedTableSchema(meta(TtlOnPkUuidEntity))).toThrow(
+      /unsupported type Uuid/,
+    );
+  });
+});
+
+describe('validateEntityMetadata with TTL', () => {
+  it('returns no issues for valid TTL entity', () => {
+    expect(validateEntityMetadata(TtlSessionEntity, validationCtx)).toEqual([]);
+  });
+
+  it('reports unknown TTL column', () => {
+    @YdbEntity('ttl_validate_unknown')
+    @YdbTtl({ interval: 'PT2H', column: 'missing_column' })
+    class TtlValidateUnknownEntity extends YdbBaseEntity {
+      @YdbPrimaryColumn('Uuid')
+      uuid: string;
+    }
+    const issues = validateEntityMetadata(
+      TtlValidateUnknownEntity,
+      validationCtx,
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toContain('"missing_column" is not declared');
+  });
+
+  it('reports missing unit for numeric TTL column', () => {
+    @YdbEntity('ttl_validate_no_unit')
+    @YdbTtl({ interval: 'PT2H', column: 'created_ms' })
+    class TtlValidateNoUnitEntity extends YdbBaseEntity {
+      @YdbPrimaryColumn('Uuid')
+      uuid: string;
+
+      @YdbColumn('Int64')
+      created_ms: bigint;
+    }
+    const issues = validateEntityMetadata(
+      TtlValidateNoUnitEntity,
+      validationCtx,
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toContain('requires "unit"');
+  });
 });
 
 describe('generateCreateTableYql with TTL', () => {
-  it('includes TTL clause in CREATE TABLE DDL', () => {
+  it('puts TTL into WITH clause after CREATE TABLE body', () => {
     const schema = buildExpectedTableSchema(meta(TtlSessionEntity));
     const yql = generateCreateTableYql(schema);
 
-    expect(yql).toContain('TTL = Interval("PT2H") ON `uuid`');
-    // PK идёт перед TTL
-    const pkIndex = yql.indexOf('PRIMARY KEY');
+    // Тело таблицы закрывается до WITH, TTL — внутри WITH
+    const bodyEnd = yql.indexOf('\n)');
     const ttlIndex = yql.indexOf('TTL');
-    expect(pkIndex).toBeLessThan(ttlIndex);
+    expect(bodyEnd).toBeGreaterThan(0);
+    expect(ttlIndex).toBeGreaterThan(bodyEnd);
+
+    expect(yql).toContain(
+      'WITH (\n  TTL = Interval("PT2H") ON `expires_at`\n)',
+    );
   });
 
-  it('includes TTL with custom column', () => {
-    const schema = buildExpectedTableSchema(meta(TtlCustomColumnEntity));
+  it('puts TTL with AS unit into WITH clause for numeric column', () => {
+    const schema = buildExpectedTableSchema(meta(TtlNumericColumnEntity));
     const yql = generateCreateTableYql(schema);
 
-    expect(yql).toContain('TTL = Interval("P30D") ON `expires_at`');
+    expect(yql).toContain(
+      'WITH (\n  TTL = Interval("P30D") ON `expires_at` AS SECONDS\n)',
+    );
   });
 
   it('does not include TTL clause when decorator is absent', () => {
@@ -139,9 +306,10 @@ describe('generateCreateTableYql with TTL', () => {
     const yql = generateCreateTableYql(schema);
 
     expect(yql).not.toContain('TTL');
+    expect(yql).not.toContain('WITH');
   });
 
-  it('generates valid full CREATE TABLE with TTL', () => {
+  it('generates valid full CREATE TABLE with TTL in WITH clause', () => {
     const schema = buildExpectedTableSchema(meta(TtlSessionEntity));
     const yql = generateCreateTableYql(schema);
 
@@ -149,9 +317,27 @@ describe('generateCreateTableYql with TTL', () => {
       'CREATE TABLE `ttl_sessions` (\n' +
         '  `uuid` Uuid,\n' +
         '  `token` Utf8,\n' +
-        '  PRIMARY KEY (`uuid`),\n' +
-        '  TTL = Interval("PT2H") ON `uuid`\n' +
+        '  `expires_at` Datetime,\n' +
+        '  PRIMARY KEY (`uuid`)\n' +
+        ')\n' +
+        'WITH (\n' +
+        '  TTL = Interval("PT2H") ON `expires_at`\n' +
         ')',
+    );
+  });
+
+  it('generates TTL clause via generateTtlWithClause helper', () => {
+    expect(
+      generateTtlWithClause({ interval: 'PT2H', column: 'expires_at' }),
+    ).toBe('WITH (\n  TTL = Interval("PT2H") ON `expires_at`\n)');
+    expect(
+      generateTtlWithClause({
+        interval: 'P30D',
+        column: 'expires_at',
+        unit: 'milliseconds',
+      }),
+    ).toBe(
+      'WITH (\n  TTL = Interval("P30D") ON `expires_at` AS MILLISECONDS\n)',
     );
   });
 });


### PR DESCRIPTION
Closes #81

## Проблема
- `generateCreateTableYql` добавлял `TTL = Interval(...) ON col` внутрь тела `CREATE TABLE (...)` — по синтаксису YQL TTL задаётся только в секции `WITH (...)`, поэтому DDL любой сущности с `@YdbTtl` отвергался.
- TTL-колонка по умолчанию бралась как первая PK (обычно `Uuid` — не пригоден для TTL).
- Опция `AS <unit>` не поддерживалась; тип/существование TTL-колонки не проверялись.

## Изменения
- **DDL**: `generateCreateTableYql` генерирует
  ```sql
  CREATE TABLE `t` (..., PRIMARY KEY (...))
  WITH (
    TTL = Interval("PT2H") ON `expires_at` [AS SECONDS]
  )
  ```
  Добавлен экспортируемый хелпер `generateTtlWithClause(ttl)`.
- **Декоратор** (`@YdbTtl`): `column` теперь обязателен (дефолт на PK убран — намеренно, см. #81); добавлена опция `unit: 'seconds' | 'milliseconds' | 'microseconds' | 'nanoseconds'`; ранняя валидация — формат ISO 8601 duration, непустая колонка, допустимый unit.
- **Валидация метаданных** (`validateEntityMetadata` + `buildExpectedTableSchema`) по ограничениям YDB ([docs](https://ydb.tech/docs/en/concepts/ttl#restrictions)): колонка должна существовать и иметь тип `Date`/`Datetime`/`Timestamp` (**без** unit) либо числовой **`Uint32`/`Uint64`/`DyNumber`** (только **с** unit, значение трактуется как Unix-время). Знаковые `Int32`/`Int64` YDB для TTL не принимает — отклоняются с понятной ошибкой.
- **Fail-fast при невалидном TTL — намеренное поведение** (по той же политике, что и для PK): форматные ошибки бросаются при декорировании; ошибки относительно схемы собираются `validateEntityMetadata` при инициализации модуля и бросаются в `buildExpectedTableSchema` до генерации DDL — schema sync/миграции/CLI не сгенерируют заведомо невалидный DDL. Задокументировано в JSDoc.
- **Совместимость с #88**: `ExpectedTableSchema.ttl` типизирована как `YdbTtlMetadata` (включая unit), TTL остаётся в schema metadata для сравнения actual/expected.

### Примечание про числовые TTL
Примитивы `Uint32`/`Uint64`/`DyNumber` пока не входят в `YdbPrimitive` (поддержка беззнаковых колонок — отдельная задача). Валидация уже принимает их, DDL с `AS <unit>` корректен; end-to-end числовой TTL заработает сразу после добавления примитивов.

## Тесты
`test/ydb-ttl.spec.ts` — 32 теста: позиция TTL в WITH после закрытия тела, AS SECONDS/MILLISECONDS (в т.ч. полная DDL-строка с Uint64-колонкой), отсутствие TTL без декоратора, ошибки: неизвестная колонка / несовместимый тип PK (`Uuid`) / знаковый `Int64` / отсутствие unit у числа / лишний unit у даты / невалидный interval / неизвестный unit, issues из `validateEntityMetadata`.

## Проверки
- `yarn test` — 38 suites, 397 tests passed
- `yarn build` (typecheck) — ok
- `yarn lint` — 0 errors