### PR TITLE
fix(persistence): insertMany() не конвертирует @YdbEnum для storage Int32 (#84)

### DIFF
--- a/src/persistence/entity-persistence.ts
+++ b/src/persistence/entity-persistence.ts
@@ -1287,6 +1287,7 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
     );
 
     const BATCH_SIZE = 100;
+    const enums = getYdbEnumMetadata(this.entityClass);
 
     for (let start = 0; start < dataList.length; start += BATCH_SIZE) {
       const batch = dataList.slice(start, start + BATCH_SIZE);
@@ -1320,7 +1321,9 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
 
         rows.forEach((row, i) => {
           for (const k of keys) {
-            const value = this.convertJsonOut(k, row[k]);
+            const enumMeta = enums.find((e) => e.propertyKey === k);
+            let value = this.convertEnumOut(row[k], enumMeta);
+            value = this.convertJsonOut(k, value);
             query.parameter(`${k}_${i}`, mapToYdb(dbSchema[k], value));
           }
         });

--- a/test/ydb-enum.spec.ts
+++ b/test/ydb-enum.spec.ts
@@ -218,6 +218,72 @@ describe('@YdbEnum', () => {
     });
   });
 
+  describe('insertMany with enum', () => {
+    const UUIDS = [
+      '5ad91505-d4f6-4a81-ab65-9dbc68cf4ed5',
+      '6ad91505-d4f6-4a81-ab65-9dbc68cf4ed6',
+      '7ad91505-d4f6-4a81-ab65-9dbc68cf4ed7',
+    ];
+
+    it('converts Int32 enum to ordinal indices for all rows', async () => {
+      const mock = createMockExecutor([[]]);
+      EnumInt32Entity.setExecutor(mock.executor);
+
+      const e1 = new EnumInt32Entity();
+      e1.uuid = UUIDS[0];
+      e1.status = Status.ACTIVE;
+      const e2 = new EnumInt32Entity();
+      e2.uuid = UUIDS[1];
+      e2.status = Status.INACTIVE;
+      const e3 = new EnumInt32Entity();
+      e3.uuid = UUIDS[2];
+      e3.status = Status.PENDING;
+
+      await EnumInt32Entity.insertMany([e1, e2, e3]);
+
+      expect(mock.queries).toHaveLength(1);
+      const [q] = mock.queries;
+      expect(q.sql).toContain('UPSERT INTO `test_enum_int32`');
+      // ACTIVE = index 0, INACTIVE = index 1, PENDING = index 2
+      expect(rawValue(q.params['status_0'])).toBe(0);
+      expect(rawValue(q.params['status_1'])).toBe(1);
+      expect(rawValue(q.params['status_2'])).toBe(2);
+    });
+
+    it('passes Utf8 enum string through for all rows', async () => {
+      const mock = createMockExecutor([[]]);
+      EnumUtf8Entity.setExecutor(mock.executor);
+
+      const e1 = new EnumUtf8Entity();
+      e1.uuid = UUIDS[0];
+      e1.status = Status.ACTIVE;
+      const e2 = new EnumUtf8Entity();
+      e2.uuid = UUIDS[1];
+      e2.status = Status.PENDING;
+
+      await EnumUtf8Entity.insertMany([e1, e2]);
+
+      expect(mock.queries).toHaveLength(1);
+      const [q] = mock.queries;
+      expect(q.sql).toContain('UPSERT INTO `test_enum_utf8`');
+      expect(rawValue(q.params['status_0'])).toBe('active');
+      expect(rawValue(q.params['status_1'])).toBe('pending');
+    });
+
+    it('throws on invalid enum value', async () => {
+      const mock = createMockExecutor([[]]);
+      EnumInt32Entity.setExecutor(mock.executor);
+
+      const entity = new EnumInt32Entity();
+      entity.uuid = UUIDS[0];
+      (entity as any).status = 'deleted';
+
+      await expect(EnumInt32Entity.insertMany([entity])).rejects.toThrow(
+        /Invalid enum value "deleted" for field "status"/,
+      );
+    });
+  });
+
   describe('metadata', () => {
     it('stores enum metadata correctly', () => {
       const meta = getYdbEnumMetadata(EnumUtf8Entity);


### PR DESCRIPTION
## Проблема

Общий путь биндинга (`bindParams`) применяет `convertEnumOut` + `convertJsonOut`, а ручной бинд параметров в `insertMany()` — только `convertJsonOut`. Для enum со `storage: 'Int32'` метод `save()` писал порядковый индекс, а `insertMany()` — исходную строку: ошибка драйвера или мусорные данные.

## Решение

- В `insertMany()` (src/persistence/entity-persistence.ts) перед `convertJsonOut` добавлена та же `convertEnumOut`, что и в `bindParams()`; метаданные enum поднимаются один раз до батч-цикла.
- Для `storage: 'Utf8'` поведение не изменилось (passthrough).
- `convertJsonOut`, шифрование и группировка батчей по сигнатуре ключей не затронуты.

## Тесты

Регрессионные тесты в `test/ydb-enum.spec.ts` (`insertMany with enum`):
- Int32: три строки с разными enum-значениями → фактические параметры executor'а `status_0/1/2` = индексы 0/1/2;
- Utf8: passthrough строковых значений;
- невалидное значение → `Invalid enum value ...`.

## Проверки

- `yarn test`: 391 passed (37 suites)
- `yarn build`: ok
- `yarn lint`: 0 errors (warnings — существующие)

Closes #84