### PR TITLE
fix(query): whitelist ASC|DESC в orderBy/addOrderBy (#85)

### DIFF
--- a/src/query/query-builder.spec.ts
+++ b/src/query/query-builder.spec.ts
@@ -59,6 +59,60 @@ describe('YdbQueryBuilder', () => {
     );
   });
 
+  it('normalizes direction case and whitespace in orderBy', async () => {
+    mockRuntime();
+    const { sql } = await QbPhotoEntity.query()
+      .orderBy('rating', ' desc ' as any)
+      .toYql();
+    expect(sql).toContain('ORDER BY `rating` DESC');
+
+    const { sql: ascSql } = await QbPhotoEntity.query()
+      .orderBy('rating', 'Asc' as any)
+      .toYql();
+    expect(ascSql).toContain('ORDER BY `rating` ASC');
+  });
+
+  it('normalizes and validates direction in addOrderBy', async () => {
+    mockRuntime();
+    const { sql } = await QbPhotoEntity.query()
+      .orderBy('rating', 'desc' as any)
+      .addOrderBy('title', ' Asc' as any)
+      .toYql();
+    expect(sql).toContain('ORDER BY `rating` DESC, `title` ASC');
+  });
+
+  it('rejects invalid direction before it reaches SQL (any bypass)', () => {
+    mockRuntime();
+    const injection = 'DESC, (SELECT group_concat(name) FROM users)' as any;
+    expect(() => QbPhotoEntity.query().orderBy('rating', injection)).toThrow(
+      /Invalid ORDER BY direction/,
+    );
+    expect(() => QbPhotoEntity.query().addOrderBy('rating', injection)).toThrow(
+      /Invalid ORDER BY direction/,
+    );
+  });
+
+  it('rejects invalid direction passed to addOrderBy via any', () => {
+    mockRuntime();
+    const injection = 'ASC; DROP TABLE qb_photos' as any;
+    const builder = QbPhotoEntity.query().orderBy('rating');
+    expect(() => builder.addOrderBy('title', injection)).toThrow(
+      /Invalid ORDER BY direction/,
+    );
+  });
+
+  it('rejects non-string directions from JavaScript callers', () => {
+    mockRuntime();
+    for (const bad of [null as any, 1 as any, {} as any]) {
+      expect(() => QbPhotoEntity.query().orderBy('rating', bad)).toThrow(
+        /Invalid ORDER BY direction/,
+      );
+      expect(() => QbPhotoEntity.query().addOrderBy('rating', bad)).toThrow(
+        /Invalid ORDER BY direction/,
+      );
+    }
+  });
+
   it('throws on unknown WHERE field', async () => {
     mockRuntime();
     await expect(

--- a/src/query/query-builder.ts
+++ b/src/query/query-builder.ts
@@ -99,13 +99,38 @@ export class YdbQueryBuilder<T extends YdbBaseEntity> {
   }
 
   orderBy(field: string, direction: OrderDirection = 'ASC'): this {
-    this.orderClauses = [{ field, direction }];
+    this.orderClauses = [
+      { field, direction: this.normalizeDirection(direction) },
+    ];
     return this;
   }
 
   addOrderBy(field: string, direction: OrderDirection = 'ASC'): this {
-    this.orderClauses.push({ field, direction });
+    this.orderClauses.push({
+      field,
+      direction: this.normalizeDirection(direction),
+    });
     return this;
+  }
+
+  /**
+   * Рантайм-валидация направления сортировки: trim + uppercase,
+   * whitelist ASC|DESC. Защита от SQL-инъекции через direction,
+   * переданный как any/из JS в обход TS-типа OrderDirection.
+   */
+  private normalizeDirection(direction: unknown): OrderDirection {
+    if (typeof direction !== 'string') {
+      throw new Error(
+        `Invalid ORDER BY direction: ${String(direction)}. Expected 'ASC' or 'DESC'.`,
+      );
+    }
+    const normalized = direction.trim().toUpperCase();
+    if (normalized !== 'ASC' && normalized !== 'DESC') {
+      throw new Error(
+        `Invalid ORDER BY direction: "${direction}". Allowed values: ASC, DESC.`,
+      );
+    }
+    return normalized;
   }
 
   /** Указать конкретные колонки для SELECT (вместо SELECT *). */


### PR DESCRIPTION
## Summary

Рантайм-валидация `direction` в `YdbQueryBuilder.orderBy()` / `addOrderBy()` — закрытие issue #85 (P0, SQL-инъекция через ORDER BY direction).

## Изменения

- Новый приватный метод `normalizeDirection()` (`src/query/query-builder.ts:118`):
  - нормализация `trim().toUpperCase()`;
  - whitelist только `ASC` | `DESC`;
  - любое другое значение (включая нестроки из JS/`any`) отклоняется `Error` сразу при вызове билдера — до попадания в сгенерированный SQL.
- TS-тип `OrderDirection` защищал только на этапе компиляции; теперь валидация полная.

## Поведение

- Валидные вызовы и дефолтный `'ASC'` — без изменений (408 тестов зелёные).
- Явный `undefined` по-прежнему активирует дефолт `'ASC'`.

## Тесты

Добавлены регрессионные кейсы (`src/query/query-builder.spec.ts`):
- нормализация регистра/пробелов (`' desc '`, `'Asc'`) для `orderBy` и `addOrderBy`;
- SQL-injection значение `'DESC, (SELECT ...)'` через `any` — отклоняется;
- `'ASC; DROP TABLE ...'` через `addOrderBy` — отклоняется;
- нестроковые значения (`null`, число, объект) из JS — отклоняются.

## Проверки

- `yarn test`: 37 suites, 408 passed
- typecheck: `yarn build` (tsc) — ok
- `yarn lint`: 0 errors

Closes #85