### PR TITLE
feat(schema): полный diff схемы — индексы, unique и TTL в verify/миграциях (#88)

### DIFF
--- a/src/cli/diff.ts
+++ b/src/cli/diff.ts
@@ -21,11 +21,15 @@ const KIND_STYLE: Record<
   'missing-table': { marker: '✖', color: RED },
   'missing-column': { marker: '+', color: YELLOW },
   'missing-index': { marker: '+', color: YELLOW },
+  'ttl-missing': { marker: '+', color: YELLOW },
   'type-mismatch': { marker: '~', color: RED },
   'index-columns-mismatch': { marker: '~', color: RED },
+  'unique-mismatch': { marker: '~', color: RED },
+  'ttl-mismatch': { marker: '~', color: RED },
   'primary-key-mismatch': { marker: '!', color: RED },
   'extra-column': { marker: '-', color: GRAY },
   'extra-index': { marker: '-', color: BLUE },
+  'ttl-extra': { marker: '-', color: BLUE },
 };
 
 /** Цвет включён, только если вывод — TTY и не задана NO_COLOR. */
@@ -49,7 +53,10 @@ function stripTablePrefix(issue: YdbSchemaIssue): string {
  * → `column "c": Int32 → Utf8`.
  * Аналогично для index-columns-mismatch:
  * `index "i" columns mismatch: expected [a, b], actual [b, a]`
- * → `index "i": [b, a] → [a, b]`.
+ * → `index "i": [b, a] → [a, b]`,
+ * и для ttl-mismatch:
+ * `TTL mismatch: expected PT2H ..., actual P1D ...`
+ * → `TTL: P1D ... → PT2H ...`.
  */
 function formatIssueText(issue: YdbSchemaIssue): string {
   const text = stripTablePrefix(issue);
@@ -67,6 +74,12 @@ function formatIssueText(issue: YdbSchemaIssue): string {
       );
     if (match) {
       return `index "${match[1]}": ${match[3]} → ${match[2]}`;
+    }
+  }
+  if (issue.kind === 'ttl-mismatch') {
+    const match = /TTL mismatch: expected (.+), actual (.+)$/.exec(text);
+    if (match) {
+      return `TTL: ${match[2]} → ${match[1]}`;
     }
   }
   return text;

--- a/src/decorators/ttl.decorator.ts
+++ b/src/decorators/ttl.decorator.ts
@@ -48,16 +48,21 @@ const MICROS_PER = {
   minute: 60 * MICROSECONDS_PER_SECOND,
 };
 
+/** Результат разбора ISO duration. */
+interface IsoDurationParse {
+  /** Длительность в целых микросекундах (без дроби точнее µs). */
+  micros: bigint;
+  /** Есть значимые цифры дробной части за пределами микросекунд. */
+  subMicroRemainder: boolean;
+}
+
 /**
- * Приводит ISO 8601 duration к целому числу микросекунд — внутренней
- * единице типа YDB Interval ("PT2H" → 720000000, "PT0.5S" → 500000).
- * Дробь вычисляется точно (без плавающей точки); знаки после микросекунд
- * отбрасываются детерминированно — YDB Interval хранит максимум 6 знаков.
- * Возвращает null для интервалов с календарными частями (годы/месяцы):
- * они не имеют фиксированной длины и не поддерживаются YDB Interval,
- * поэтому надёжно сравнить их с настройками из DescribeTable нельзя.
+ * Разбор ISO 8601 duration по компонентам с точной целочисленной
+ * арифметикой. Возвращает null для невалидных строк и интервалов
+ * с календарными частями (годы/месяцы): они не имеют фиксированной
+ * длины и не поддерживаются YDB Interval.
  */
-export function isoDurationToMicroseconds(iso: string): number | null {
+function parseIsoDuration(iso: string): IsoDurationParse | null {
   const match = ISO_DURATION_PARSE_RE.exec(iso);
   if (!match) return null;
   const [, years, months, weeks, days, hours, minutes, seconds] = match;
@@ -75,7 +80,34 @@ export function isoDurationToMicroseconds(iso: string): number | null {
   if (fracSeconds) {
     micros += BigInt((fracSeconds + '000000').slice(0, 6));
   }
-  return Number(micros);
+  return { micros, subMicroRemainder: /[1-9]/.test(fracSeconds.slice(6)) };
+}
+
+/**
+ * Приводит ISO 8601 duration к целому числу микросекунд — внутренней
+ * единице типа YDB Interval ("PT2H" → 720000000, "PT0.5S" → 500000).
+ * Дробь вычисляется точно (без плавающей точки); знаки после микросекунд
+ * отбрасываются детерминированно — YDB Interval хранит максимум 6 знаков.
+ * Для сравнения TTL используйте isoDurationToMicrosecondsExact:
+ * усечение скрывает расхождения.
+ */
+export function isoDurationToMicroseconds(iso: string): number | null {
+  const parsed = parseIsoDuration(iso);
+  return parsed === null ? null : Number(parsed.micros);
+}
+
+/**
+ * Строгий вариант isoDurationToMicroseconds: возвращает null для
+ * интервалов, непредставимых в YDB Interval точно, — календарные части
+ * и дробную часть точнее микросекунд ("PT0.0000001S"). Используется при
+ * сравнении TTL, чтобы непредставимый интервал не «совпал» со значением
+ * из БД после молчаливого усечения.
+ */
+export function isoDurationToMicrosecondsExact(iso: string): number | null {
+  const parsed = parseIsoDuration(iso);
+  return parsed !== null && !parsed.subMicroRemainder
+    ? Number(parsed.micros)
+    : null;
 }
 
 /**
@@ -205,6 +237,13 @@ function validateYdbTtlOptions(
       `@YdbTtl on class "${className}": ` +
         `interval must be a valid ISO 8601 duration (e.g. "PT2H", "P30D"), ` +
         `got "${options?.interval}"`,
+    );
+  }
+  if (parseIsoDuration(options.interval)?.subMicroRemainder) {
+    throw new Error(
+      `@YdbTtl on class "${className}": interval "${options.interval}" is ` +
+        `more precise than a microsecond — YDB Interval supports only integer ` +
+        `microseconds (up to 6 fractional second digits)`,
     );
   }
   if (!options.column || typeof options.column !== 'string') {

--- a/src/decorators/ttl.decorator.ts
+++ b/src/decorators/ttl.decorator.ts
@@ -35,58 +35,105 @@ const NUMERIC_TTL_TYPES: readonly string[] = ['Uint32', 'Uint64', 'DyNumber'];
 const ISO_DURATION_RE =
   /^P(?!$)(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+(\.\d+)?S)?)?$/;
 
+/** Микросекунд в секунде — внутренняя точность типа YDB Interval. */
+export const MICROSECONDS_PER_SECOND = 1_000_000;
+
 /** Строгий разбор ISO 8601 duration по компонентам (для сравнения TTL). */
 const ISO_DURATION_PARSE_RE =
   /^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?=\d)(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$/;
 
-const SECONDS_PER = {
-  day: 86400,
-  hour: 3600,
-  minute: 60,
+const MICROS_PER = {
+  day: 86_400 * MICROSECONDS_PER_SECOND,
+  hour: 3_600 * MICROSECONDS_PER_SECOND,
+  minute: 60 * MICROSECONDS_PER_SECOND,
 };
 
 /**
- * Приводит ISO 8601 duration к секундам ("PT2H" → 7200, "P30D" → 2592000).
+ * Приводит ISO 8601 duration к целому числу микросекунд — внутренней
+ * единице типа YDB Interval ("PT2H" → 720000000, "PT0.5S" → 500000).
+ * Дробь вычисляется точно (без плавающей точки); знаки после микросекунд
+ * отбрасываются детерминированно — YDB Interval хранит максимум 6 знаков.
  * Возвращает null для интервалов с календарными частями (годы/месяцы):
- * у них нет фиксированной длины, надёжно сравнить их с секундами из
- * DescribeTable нельзя.
+ * они не имеют фиксированной длины и не поддерживаются YDB Interval,
+ * поэтому надёжно сравнить их с настройками из DescribeTable нельзя.
  */
-export function isoDurationToSeconds(iso: string): number | null {
+export function isoDurationToMicroseconds(iso: string): number | null {
   const match = ISO_DURATION_PARSE_RE.exec(iso);
   if (!match) return null;
   const [, years, months, weeks, days, hours, minutes, seconds] = match;
   if (years || months) return null;
-  return (
-    Number(weeks ?? 0) * 7 * SECONDS_PER.day +
-    Number(days ?? 0) * SECONDS_PER.day +
-    Number(hours ?? 0) * SECONDS_PER.hour +
-    Number(minutes ?? 0) * SECONDS_PER.minute +
-    Number(seconds ?? 0)
-  );
+
+  // Дробная часть допустима только у секунд; разбираем её по цифрам,
+  // чтобы не терять точность на float ("0.1" * 10 !== 1).
+  const [wholeSeconds = '0', fracSeconds = ''] = (seconds ?? '').split('.');
+  let micros =
+    BigInt(weeks ?? 0) * 7n * BigInt(MICROS_PER.day) +
+    BigInt(days ?? 0) * BigInt(MICROS_PER.day) +
+    BigInt(hours ?? 0) * BigInt(MICROS_PER.hour) +
+    BigInt(minutes ?? 0) * BigInt(MICROS_PER.minute) +
+    BigInt(wholeSeconds || '0') * BigInt(MICROSECONDS_PER_SECOND);
+  if (fracSeconds) {
+    micros += BigInt((fracSeconds + '000000').slice(0, 6));
+  }
+  return Number(micros);
 }
 
 /**
- * Обратное преобразование секунд в ISO 8601 duration — используется для
+ * Обратное преобразование целого числа микросекунд в ISO 8601 duration —
+ * точный inverse `isoDurationToMicroseconds` (500000 → "PT0.5S",
+ * 720000000 → "PT2H", 90000000000 → "P1DT1H"). Используется для
  * восстановления фактических настроек TTL из БД в down-миграциях
- * и сообщениях о расхождениях (7200 → "PT2H", 90000 → "P1DT1H").
+ * и сообщениях о расхождениях; дробная часть рендерится без потери
+ * микросекундной точности YDB.
  */
-export function secondsToIsoDuration(totalSeconds: number): string {
-  let rest = Math.max(0, Math.round(totalSeconds));
-  const days = Math.floor(rest / SECONDS_PER.day);
-  rest -= days * SECONDS_PER.day;
-  const hours = Math.floor(rest / SECONDS_PER.hour);
-  rest -= hours * SECONDS_PER.hour;
-  const minutes = Math.floor(rest / SECONDS_PER.minute);
-  const seconds = rest - minutes * SECONDS_PER.minute;
+export function microsecondsToIsoDuration(totalMicros: number): string {
+  const micros = Math.max(0, Math.trunc(totalMicros));
+  const days = Math.floor(micros / MICROS_PER.day);
+  let rest = micros % MICROS_PER.day;
+  const hours = Math.floor(rest / MICROS_PER.hour);
+  rest %= MICROS_PER.hour;
+  const minutes = Math.floor(rest / MICROS_PER.minute);
+  rest %= MICROS_PER.minute;
+  const wholeSeconds = Math.floor(rest / MICROSECONDS_PER_SECOND);
+  const fracMicros = rest % MICROSECONDS_PER_SECOND;
 
   let duration = 'P';
   if (days) duration += `${days}D`;
-  const time =
-    `${hours ? `${hours}H` : ''}` +
-    `${minutes ? `${minutes}M` : ''}` +
-    `${seconds ? `${seconds}S` : ''}`;
+  let time = '';
+  if (hours) time += `${hours}H`;
+  if (minutes) time += `${minutes}M`;
+  if (wholeSeconds || fracMicros) {
+    let secondsText = String(wholeSeconds);
+    if (fracMicros) {
+      secondsText += `.${String(fracMicros).padStart(6, '0').replace(/0+$/, '')}`;
+    }
+    time += `${secondsText}S`;
+  }
   if (time) duration += `T${time}`;
   return duration === 'P' ? 'PT0S' : duration;
+}
+
+/**
+ * Приводит ISO 8601 duration к секундам ("PT2H" → 7200, "P30D" → 2592000).
+ * Возвращает null для интервалов с календарными частями (годы/месяцы).
+ * Для дробных секунд результат дробный — сравнение TTL выполняется
+ * через isoDurationToMicroseconds, эта функция осталась для удобства.
+ */
+export function isoDurationToSeconds(iso: string): number | null {
+  const micros = isoDurationToMicroseconds(iso);
+  return micros === null ? null : micros / MICROSECONDS_PER_SECOND;
+}
+
+/**
+ * Преобразует целое число секунд (формат expire_after_seconds из
+ * DescribeTable) в ISO 8601 duration (7200 → "PT2H", 90000 → "P1DT1H").
+ * Дробная часть округляется до секунд; для значений с долями секунды
+ * используйте microsecondsToIsoDuration.
+ */
+export function secondsToIsoDuration(totalSeconds: number): string {
+  return microsecondsToIsoDuration(
+    Math.round(totalSeconds) * MICROSECONDS_PER_SECOND,
+  );
 }
 
 export interface YdbTtlOptions {

--- a/src/decorators/ttl.decorator.ts
+++ b/src/decorators/ttl.decorator.ts
@@ -35,6 +35,60 @@ const NUMERIC_TTL_TYPES: readonly string[] = ['Uint32', 'Uint64', 'DyNumber'];
 const ISO_DURATION_RE =
   /^P(?!$)(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+(\.\d+)?S)?)?$/;
 
+/** Строгий разбор ISO 8601 duration по компонентам (для сравнения TTL). */
+const ISO_DURATION_PARSE_RE =
+  /^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?=\d)(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$/;
+
+const SECONDS_PER = {
+  day: 86400,
+  hour: 3600,
+  minute: 60,
+};
+
+/**
+ * Приводит ISO 8601 duration к секундам ("PT2H" → 7200, "P30D" → 2592000).
+ * Возвращает null для интервалов с календарными частями (годы/месяцы):
+ * у них нет фиксированной длины, надёжно сравнить их с секундами из
+ * DescribeTable нельзя.
+ */
+export function isoDurationToSeconds(iso: string): number | null {
+  const match = ISO_DURATION_PARSE_RE.exec(iso);
+  if (!match) return null;
+  const [, years, months, weeks, days, hours, minutes, seconds] = match;
+  if (years || months) return null;
+  return (
+    Number(weeks ?? 0) * 7 * SECONDS_PER.day +
+    Number(days ?? 0) * SECONDS_PER.day +
+    Number(hours ?? 0) * SECONDS_PER.hour +
+    Number(minutes ?? 0) * SECONDS_PER.minute +
+    Number(seconds ?? 0)
+  );
+}
+
+/**
+ * Обратное преобразование секунд в ISO 8601 duration — используется для
+ * восстановления фактических настроек TTL из БД в down-миграциях
+ * и сообщениях о расхождениях (7200 → "PT2H", 90000 → "P1DT1H").
+ */
+export function secondsToIsoDuration(totalSeconds: number): string {
+  let rest = Math.max(0, Math.round(totalSeconds));
+  const days = Math.floor(rest / SECONDS_PER.day);
+  rest -= days * SECONDS_PER.day;
+  const hours = Math.floor(rest / SECONDS_PER.hour);
+  rest -= hours * SECONDS_PER.hour;
+  const minutes = Math.floor(rest / SECONDS_PER.minute);
+  const seconds = rest - minutes * SECONDS_PER.minute;
+
+  let duration = 'P';
+  if (days) duration += `${days}D`;
+  const time =
+    `${hours ? `${hours}H` : ''}` +
+    `${minutes ? `${minutes}M` : ''}` +
+    `${seconds ? `${seconds}S` : ''}`;
+  if (time) duration += `T${time}`;
+  return duration === 'P' ? 'PT0S' : duration;
+}
+
 export interface YdbTtlOptions {
   /** ISO 8601 duration (например, "PT2H", "P30D", "PT1H"). */
   interval: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,10 @@ export type {
 export { YdbEnum, getYdbEnumMetadata } from './decorators/enum.decorator.js';
 export type { YdbEnumMeta } from './decorators/enum.decorator.js';
 export { YdbTtl, getYdbTtlMetadata } from './decorators/ttl.decorator.js';
+export {
+  isoDurationToSeconds,
+  secondsToIsoDuration,
+} from './decorators/ttl.decorator.js';
 export type {
   YdbTtlOptions,
   YdbTtlMetadata,
@@ -156,11 +160,17 @@ export {
   generateCreateTableYql,
   generateTtlWithClause,
   generateAddColumnsYql,
+  generateAddIndexYql,
+  generateDropIndexYql,
+  generateSetTtlYql,
+  generateResetTtlYql,
   checkTableSchema,
 } from './schema/schema-sync.js';
 export type {
+  ExpectedIndex,
   ExpectedTableSchema,
   YdbTableDescription,
+  YdbTableTtl,
   SchemaCheckResult,
   YdbSchemaIssue,
 } from './schema/schema-sync.js';

--- a/src/migrations/migration-generator.spec.ts
+++ b/src/migrations/migration-generator.spec.ts
@@ -296,6 +296,37 @@ describe('planMigration', () => {
     ]);
   });
 
+  it('restores fractional TTL exactly in down without rounding (#88)', () => {
+    const ttlSchema: ExpectedTableSchema = {
+      ...expected,
+      ttl: { interval: 'P1D', column: 'title' },
+    };
+    const plan = planMigration(
+      [ttlSchema],
+      [
+        description(
+          [
+            ['uuid', Type_PrimitiveTypeId.UUID],
+            ['title', Type_PrimitiveTypeId.UTF8],
+            ['width', Type_PrimitiveTypeId.INT32],
+          ],
+          ['uuid'],
+          { ttl: { column: 'width_col', expireAfterSeconds: 1.5 } },
+        ),
+      ],
+    );
+
+    expect(plan.up).toEqual([
+      'ALTER TABLE `photos` SET (TTL = Interval("P1D") ON `title`)',
+    ]);
+    // Регрессия микросекундной точности YDB Interval: прежняя конверсия
+    // через secondsToIsoDuration округляла 1.5s до "PT2S" и ломала откат.
+    // down обязан восстановить дробный TTL ровно ("PT1.5S").
+    expect(plan.down).toEqual([
+      'ALTER TABLE `photos` SET (TTL = Interval("PT1.5S") ON `width_col`)',
+    ]);
+  });
+
   it('does not reset extra TTL without entity metadata and warns (#88)', () => {
     const plan = planMigration(
       [expected],

--- a/src/migrations/migration-generator.spec.ts
+++ b/src/migrations/migration-generator.spec.ts
@@ -9,12 +9,26 @@ const expected: ExpectedTableSchema = {
   tableName: 'photos',
   columns: { uuid: 'Uuid', title: 'Utf8', width: 'Int32' },
   primaryKey: ['uuid'],
+  indexes: [],
+};
+
+const withIndexes: ExpectedTableSchema = {
+  ...expected,
+  indexes: [
+    { name: 'photos__title', columns: ['title'], unique: false },
+    {
+      name: 'photos__title_width',
+      columns: ['title', 'width'],
+      unique: false,
+    },
+  ],
 };
 
 const description = (
   columns: [string, Type_PrimitiveTypeId][],
   primaryKey: string[] = ['uuid'],
-): YdbTableDescription => ({ columns: new Map(columns), primaryKey });
+  extra: Partial<YdbTableDescription> = {},
+): YdbTableDescription => ({ columns: new Map(columns), primaryKey, ...extra });
 
 describe('planMigration', () => {
   it('plans CREATE TABLE when the table is missing', () => {
@@ -99,6 +113,210 @@ describe('planMigration', () => {
     expect(plan.up).toEqual([]);
     expect(plan.down).toEqual([]);
     expect(plan.warnings).toEqual([]);
+  });
+
+  it('plans CREATE INDEX in up and DROP INDEX in down for missing indexes (#88)', () => {
+    const plan = planMigration(
+      [withIndexes],
+      [
+        description([
+          ['uuid', Type_PrimitiveTypeId.UUID],
+          ['title', Type_PrimitiveTypeId.UTF8],
+          ['width', Type_PrimitiveTypeId.INT32],
+        ]),
+      ],
+    );
+
+    expect(plan.up).toEqual([
+      'ALTER TABLE `photos` ADD INDEX `photos__title` GLOBAL SYNC ON (`title`)',
+      'ALTER TABLE `photos` ADD INDEX `photos__title_width` GLOBAL SYNC ON (`title`, `width`)',
+    ]);
+    // down в обратном порядке: индексы удаляются до прочих откатов
+    expect(plan.down).toEqual([
+      'ALTER TABLE `photos` DROP INDEX `photos__title_width`',
+      'ALTER TABLE `photos` DROP INDEX `photos__title`',
+    ]);
+    expect(plan.warnings).toEqual([]);
+  });
+
+  it('plans UNIQUE index DDL for missing unique indexes (#88)', () => {
+    const plan = planMigration(
+      [
+        {
+          ...expected,
+          indexes: [
+            { name: 'photos__title_uq', columns: ['title'], unique: true },
+          ],
+        },
+      ],
+      [
+        description([
+          ['uuid', Type_PrimitiveTypeId.UUID],
+          ['title', Type_PrimitiveTypeId.UTF8],
+          ['width', Type_PrimitiveTypeId.INT32],
+        ]),
+      ],
+    );
+
+    expect(plan.up).toEqual([
+      'ALTER TABLE `photos` ADD UNIQUE INDEX `photos__title_uq` GLOBAL SYNC ON (`title`)',
+    ]);
+    expect(plan.down).toEqual([
+      'ALTER TABLE `photos` DROP INDEX `photos__title_uq`',
+    ]);
+  });
+
+  it('never drops extra indexes and warns instead (#88)', () => {
+    const plan = planMigration(
+      [withIndexes],
+      [
+        description(
+          [
+            ['uuid', Type_PrimitiveTypeId.UUID],
+            ['title', Type_PrimitiveTypeId.UTF8],
+            ['width', Type_PrimitiveTypeId.INT32],
+          ],
+          ['uuid'],
+          {
+            indexes: [
+              { name: 'legacy_index', columns: ['uuid'], unique: false },
+              { name: 'photos__title', columns: ['title'], unique: false },
+              {
+                name: 'photos__title_width',
+                columns: ['title', 'width'],
+                unique: false,
+              },
+            ],
+          },
+        ),
+      ],
+    );
+
+    expect(plan.up).toEqual([]);
+    expect(plan.down).toEqual([]);
+    expect(plan.warnings).toEqual([
+      'Table "photos" has extra index "legacy_index" — not dropped automatically',
+    ]);
+  });
+
+  it('only diagnoses mismatches of existing indexes (#88)', () => {
+    const plan = planMigration(
+      [withIndexes],
+      [
+        description(
+          [
+            ['uuid', Type_PrimitiveTypeId.UUID],
+            ['title', Type_PrimitiveTypeId.UTF8],
+            ['width', Type_PrimitiveTypeId.INT32],
+          ],
+          ['uuid'],
+          {
+            indexes: [
+              { name: 'photos__title', columns: ['title'], unique: true },
+              {
+                name: 'photos__title_width',
+                columns: ['width'],
+                unique: false,
+              },
+            ],
+          },
+        ),
+      ],
+    );
+
+    expect(plan.up).toEqual([]);
+    expect(plan.down).toEqual([]);
+    expect(plan.warnings.some((w) => w.includes('unique flag mismatch'))).toBe(
+      true,
+    );
+    expect(
+      plan.warnings.some(
+        (w) =>
+          w.includes('columns mismatch') &&
+          w.includes('recreate the index manually'),
+      ),
+    ).toBe(true);
+  });
+
+  it('plans SET TTL in up and RESET TTL in down when DB has no TTL (#88)', () => {
+    const ttlSchema: ExpectedTableSchema = {
+      ...expected,
+      ttl: { interval: 'PT2H', column: 'title' },
+    };
+    const plan = planMigration(
+      [ttlSchema],
+      [
+        description([
+          ['uuid', Type_PrimitiveTypeId.UUID],
+          ['title', Type_PrimitiveTypeId.UTF8],
+          ['width', Type_PrimitiveTypeId.INT32],
+        ]),
+      ],
+    );
+
+    expect(plan.up).toEqual([
+      'ALTER TABLE `photos` SET (TTL = Interval("PT2H") ON `title`)',
+    ]);
+    expect(plan.down).toEqual(['ALTER TABLE `photos` RESET (TTL)']);
+    expect(plan.warnings).toEqual([]);
+  });
+
+  it('plans TTL replacement and restores old settings in down (#88)', () => {
+    const ttlSchema: ExpectedTableSchema = {
+      ...expected,
+      ttl: { interval: 'P1D', column: 'title' },
+    };
+    const plan = planMigration(
+      [ttlSchema],
+      [
+        description(
+          [
+            ['uuid', Type_PrimitiveTypeId.UUID],
+            ['title', Type_PrimitiveTypeId.UTF8],
+            ['width', Type_PrimitiveTypeId.INT32],
+          ],
+          ['uuid'],
+          {
+            ttl: {
+              column: 'width_col',
+              expireAfterSeconds: 7200,
+              unit: 'seconds',
+            },
+          },
+        ),
+      ],
+    );
+
+    expect(plan.up).toEqual([
+      'ALTER TABLE `photos` SET (TTL = Interval("P1D") ON `title`)',
+    ]);
+    // down восстанавливает прежние настройки TTL из DescribeTable
+    expect(plan.down).toEqual([
+      'ALTER TABLE `photos` SET (TTL = Interval("PT2H") ON `width_col` AS SECONDS)',
+    ]);
+  });
+
+  it('does not reset extra TTL without entity metadata and warns (#88)', () => {
+    const plan = planMigration(
+      [expected],
+      [
+        description(
+          [
+            ['uuid', Type_PrimitiveTypeId.UUID],
+            ['title', Type_PrimitiveTypeId.UTF8],
+            ['width', Type_PrimitiveTypeId.INT32],
+          ],
+          ['uuid'],
+          { ttl: { column: 'title', expireAfterSeconds: 7200 } },
+        ),
+      ],
+    );
+
+    expect(plan.up).toEqual([]);
+    expect(plan.down).toEqual([]);
+    expect(plan.warnings).toEqual([
+      'Table "photos" has extra TTL on column "title" — not reset automatically',
+    ]);
   });
 });
 

--- a/src/migrations/migration-generator.ts
+++ b/src/migrations/migration-generator.ts
@@ -1,11 +1,20 @@
 import {
   ExpectedTableSchema,
   YdbTableDescription,
+  YdbTableTtl,
   checkTableSchema,
   generateAddColumnsYql,
+  generateAddIndexYql,
   generateCreateTableYql,
+  generateDropIndexYql,
+  generateResetTtlYql,
+  generateSetTtlYql,
 } from '../schema/schema-sync.js';
 import { quoteIdentifier } from '../core/sql-utils.js';
+import {
+  secondsToIsoDuration,
+  YdbTtlMetadata,
+} from '../decorators/ttl.decorator.js';
 
 /** План миграции: DDL для up/down и предупреждения о ручных правках. */
 export interface PlannedMigration {
@@ -14,10 +23,26 @@ export interface PlannedMigration {
   warnings: string[];
 }
 
+/** Восстанавливает YdbTtlMetadata из фактических настроек TTL в БД. */
+function ttlMetaFromActual(actual: YdbTableTtl): YdbTtlMetadata {
+  return {
+    interval: secondsToIsoDuration(actual.expireAfterSeconds),
+    column: actual.column,
+    ...(actual.unit ? { unit: actual.unit } : {}),
+  };
+}
+
 /**
  * Чистая функция: строит план миграции по ожидаемым схемам сущностей
  * и текущему состоянию БД (null — таблицы нет).
  * Используется `migration:generate`.
+ *
+ * Политика безопасности (#88):
+ *  - отсутствующие индексы и TTL создаются в up и откатываются в down;
+ *  - лишние индексы и TTL не удаляются — только предупреждение;
+ *  - расхождение существующего индекса (unique/колонки) только
+ *    диагностируется — пересоздание индекса небезопасно делать молча;
+ *  - PK, типы колонок и лишние колонки не меняются (как раньше).
  */
 export function planMigration(
   expected: ExpectedTableSchema[],
@@ -65,6 +90,62 @@ export function planMigration(
           `ALTER TABLE ${quoteIdentifier(schema.tableName)} DROP COLUMN ${quoteIdentifier(column)}`,
         );
       }
+    }
+
+    // Отсутствующие индексы: создаём в up, удаляем в down (#88).
+    for (const idx of check.missingIndexes) {
+      up.push(generateAddIndexYql(schema.tableName, idx));
+      down.unshift(generateDropIndexYql(schema.tableName, idx.name));
+    }
+
+    // Существующий индекс расходится с метаданными — только диагностируем.
+    for (const mismatch of check.uniqueMismatches) {
+      warnings.push(
+        `Table "${schema.tableName}" index "${mismatch.name}": ` +
+          `unique flag mismatch (expected ${mismatch.expected}, actual ${mismatch.actual}) — ` +
+          `recreate the index manually if needed`,
+      );
+    }
+    for (const mismatch of check.indexColumnsMismatches) {
+      warnings.push(
+        `Table "${schema.tableName}" index "${mismatch.name}": ` +
+          `columns mismatch (expected [${mismatch.expected.join(', ')}], ` +
+          `actual [${mismatch.actual.join(', ')}]) — ` +
+          `recreate the index manually if needed`,
+      );
+    }
+    // Лишние индексы никогда не удаляем автоматически.
+    for (const extra of check.extraIndexes) {
+      warnings.push(
+        `Table "${schema.tableName}" has extra index "${extra.name}" — not dropped automatically`,
+      );
+    }
+
+    // TTL: отсутствующий ставим, изменённый заменяем; down восстанавливает
+    // прежнее состояние БД (сброс или старые настройки).
+    if (check.missingTtl.length && check.missingTtl[0].expected) {
+      up.push(
+        generateSetTtlYql(schema.tableName, check.missingTtl[0].expected),
+      );
+      down.unshift(generateResetTtlYql(schema.tableName));
+    }
+    if (check.ttlMismatches.length && check.ttlMismatches[0].expected) {
+      up.push(
+        generateSetTtlYql(schema.tableName, check.ttlMismatches[0].expected),
+      );
+      down.unshift(
+        generateSetTtlYql(
+          schema.tableName,
+          ttlMetaFromActual(check.ttlMismatches[0].actual),
+        ),
+      );
+    }
+    // TTL без метаданных в сущности не сбрасываем автоматически.
+    for (const extra of check.extraTtl) {
+      warnings.push(
+        `Table "${schema.tableName}" has extra TTL on column "${extra.actual.column}" ` +
+          `— not reset automatically`,
+      );
     }
   }
 

--- a/src/migrations/migration-generator.ts
+++ b/src/migrations/migration-generator.ts
@@ -12,7 +12,8 @@ import {
 } from '../schema/schema-sync.js';
 import { quoteIdentifier } from '../core/sql-utils.js';
 import {
-  secondsToIsoDuration,
+  microsecondsToIsoDuration,
+  MICROSECONDS_PER_SECOND,
   YdbTtlMetadata,
 } from '../decorators/ttl.decorator.js';
 
@@ -26,7 +27,11 @@ export interface PlannedMigration {
 /** Восстанавливает YdbTtlMetadata из фактических настроек TTL в БД. */
 function ttlMetaFromActual(actual: YdbTableTtl): YdbTtlMetadata {
   return {
-    interval: secondsToIsoDuration(actual.expireAfterSeconds),
+    // expire_after_seconds — целые секунды; конвертация через микросекунды
+    // (точность YDB Interval) без потерь
+    interval: microsecondsToIsoDuration(
+      actual.expireAfterSeconds * MICROSECONDS_PER_SECOND,
+    ),
     column: actual.column,
     ...(actual.unit ? { unit: actual.unit } : {}),
   };

--- a/src/schema/schema-sync.spec.ts
+++ b/src/schema/schema-sync.spec.ts
@@ -565,6 +565,30 @@ describe('checkTableSchema TTL (#88)', () => {
     ]);
   });
 
+  it('matches fractional-second TTL without precision loss (#88)', () => {
+    // PT0.5S == ровно 500000µs; сравнение в целых микросекундах YDB Interval
+    const fractionalExpected = {
+      ...ttlExpected,
+      ttl: { interval: 'PT0.5S', column: 'expires_at' },
+    };
+    const equalCheck = checkTableSchema(
+      fractionalExpected,
+      sessionDescription({
+        ttl: { column: 'expires_at', expireAfterSeconds: 0.5 },
+      }),
+    );
+    expect(equalCheck.ttlMismatches).toEqual([]);
+
+    // Сдвиг на микросекунду фиксируется как расхождение
+    const changedCheck = checkTableSchema(
+      fractionalExpected,
+      sessionDescription({
+        ttl: { column: 'expires_at', expireAfterSeconds: 0.500001 },
+      }),
+    );
+    expect(changedCheck.ttlMismatches).toHaveLength(1);
+  });
+
   it('detects changed TTL column and unit', () => {
     const numericExpected: ExpectedTableSchema = {
       tableName: 'ttl_numeric',
@@ -1086,15 +1110,46 @@ describe('YdbSchemaSyncer.describeTable TTL parsing (#88)', () => {
     });
   });
 
-  it('maps numeric TTL unit from proto enum', async () => {
+  it.each([
+    [ValueSinceUnixEpochModeSettings_Unit.SECONDS, 'seconds'],
+    [ValueSinceUnixEpochModeSettings_Unit.MILLISECONDS, 'milliseconds'],
+    [ValueSinceUnixEpochModeSettings_Unit.MICROSECONDS, 'microseconds'],
+    [ValueSinceUnixEpochModeSettings_Unit.NANOSECONDS, 'nanoseconds'],
+  ] as const)(
+    'maps numeric TTL unit from proto enum (%#)',
+    async (protoUnit, expectedUnit) => {
+      const syncer = makeSyncer(
+        describeResponse({
+          mode: {
+            case: 'valueSinceUnixEpoch',
+            value: {
+              columnName: 'expires_at',
+              columnUnit: protoUnit,
+              expireAfterSeconds: 2592000,
+            },
+          },
+        }),
+      );
+
+      const desc = await syncer.describeTable('test_sessions');
+
+      expect(desc?.ttl).toEqual({
+        column: 'expires_at',
+        expireAfterSeconds: 2592000,
+        unit: expectedUnit,
+      });
+    },
+  );
+
+  it('treats UNSPECIFIED numeric TTL unit as date-like (no AS suffix)', async () => {
     const syncer = makeSyncer(
       describeResponse({
         mode: {
           case: 'valueSinceUnixEpoch',
           value: {
             columnName: 'expires_at',
-            columnUnit: ValueSinceUnixEpochModeSettings_Unit.SECONDS,
-            expireAfterSeconds: 2592000,
+            columnUnit: ValueSinceUnixEpochModeSettings_Unit.UNSPECIFIED,
+            expireAfterSeconds: 3600,
           },
         },
       }),
@@ -1104,8 +1159,7 @@ describe('YdbSchemaSyncer.describeTable TTL parsing (#88)', () => {
 
     expect(desc?.ttl).toEqual({
       column: 'expires_at',
-      expireAfterSeconds: 2592000,
-      unit: 'seconds',
+      expireAfterSeconds: 3600,
     });
   });
 

--- a/src/schema/schema-sync.spec.ts
+++ b/src/schema/schema-sync.spec.ts
@@ -1,6 +1,14 @@
 import 'reflect-metadata';
 import { jest } from '@jest/globals';
+import { create } from '@bufbuild/protobuf';
+import { anyPack } from '@bufbuild/protobuf/wkt';
 import { Type_PrimitiveTypeId } from '@ydbjs/api/value';
+import {
+  CreateSessionResultSchema,
+  DescribeTableResultSchema,
+  ValueSinceUnixEpochModeSettings_Unit,
+} from '@ydbjs/api/table';
+import { StatusIds_StatusCode } from '@ydbjs/api/operation';
 import { YdbEntity } from '../decorators/entity.decorator.js';
 import { YdbColumn, YdbPrimaryColumn } from '../decorators/column.decorator.js';
 import { YdbEncrypted } from '../decorators/encryption.decorator.js';
@@ -14,8 +22,13 @@ import {
   buildExpectedJoinTableSchema,
   buildExpectedSchemas,
   checkTableSchema,
+  checkToIssues,
+  diffSchemas,
   generateAddColumnsYql,
   generateCreateTableYql,
+  generateResetTtlYql,
+  generateSetTtlYql,
+  ExpectedTableSchema,
   YdbSchemaSyncer,
   YdbTableDescription,
 } from './schema-sync.js';
@@ -26,6 +39,7 @@ import {
 } from '../decorators/relation.decorators.js';
 import { EagerLoad } from '../decorators/eager.decorator.js';
 import { YdbIndex } from '../decorators/index.decorator.js';
+import { YdbTtl } from '../decorators/ttl.decorator.js';
 
 @YdbEntity('test_users')
 @YdbIndex({ columns: ['secret_bi'] })
@@ -86,6 +100,17 @@ class TestTagEntity extends YdbBaseEntity {
 
   @ManyToMany(() => TestPhotoEntity, (photo) => photo.tags)
   photos?: TestPhotoEntity[];
+}
+
+@YdbEntity('test_sessions')
+@YdbTtl({ interval: 'PT2H', column: 'expires_at' })
+@YdbIndex({ columns: ['expires_at'] })
+class TestSessionEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @YdbColumn('Datetime')
+  expires_at: Date;
 }
 
 @YdbEntity('test_photos')
@@ -437,6 +462,312 @@ describe('checkTableSchema', () => {
       },
     ]);
   });
+
+  it('detects index unique flag mismatch', () => {
+    const check = checkTableSchema(
+      expected,
+      description(
+        [
+          ['uuid', Type_PrimitiveTypeId.UUID],
+          ['name', Type_PrimitiveTypeId.UTF8],
+          ['secret', Type_PrimitiveTypeId.STRING],
+          ['is_active', Type_PrimitiveTypeId.BOOL],
+          ['secret_bi', Type_PrimitiveTypeId.UTF8],
+        ],
+        ['uuid'],
+        [
+          {
+            name: 'test_users__secret_bi',
+            columns: ['secret_bi'],
+            unique: false,
+          },
+          {
+            name: 'test_users__active_name',
+            columns: ['is_active', 'name'],
+            unique: true,
+          },
+        ],
+      ),
+    );
+
+    expect(check.uniqueMismatches).toEqual([
+      { name: 'test_users__active_name', expected: false, actual: true },
+    ]);
+    expect(check.missingIndexes).toEqual([]);
+    expect(check.extraIndexes).toEqual([]);
+    expect(check.indexColumnsMismatches).toEqual([]);
+  });
+});
+
+describe('checkTableSchema TTL (#88)', () => {
+  const ttlExpected = buildExpectedTableSchema(meta(TestSessionEntity));
+
+  const sessionDescription = (
+    overrides: Partial<YdbTableDescription> = {},
+  ): YdbTableDescription => ({
+    columns: new Map([
+      ['uuid', Type_PrimitiveTypeId.UUID],
+      ['expires_at', Type_PrimitiveTypeId.DATETIME],
+    ]),
+    primaryKey: ['uuid'],
+    indexes: [
+      {
+        name: 'test_sessions__expires_at',
+        columns: ['expires_at'],
+        unique: false,
+      },
+    ],
+    ttl: { column: 'expires_at', expireAfterSeconds: 7200 },
+    ...overrides,
+  });
+
+  it('passes when TTL and indexes match', () => {
+    const check = checkTableSchema(ttlExpected, sessionDescription());
+
+    expect(check.missingTtl).toEqual([]);
+    expect(check.ttlMismatches).toEqual([]);
+    expect(check.extraTtl).toEqual([]);
+    expect(check.missingIndexes).toEqual([]);
+  });
+
+  it('detects TTL declared by entity but absent in DB', () => {
+    const check = checkTableSchema(
+      ttlExpected,
+      sessionDescription({ ttl: undefined }),
+    );
+
+    expect(check.missingTtl).toEqual([
+      { expected: { interval: 'PT2H', column: 'expires_at' } },
+    ]);
+  });
+
+  it('detects changed TTL interval semantically (by seconds)', () => {
+    // P1DT0H == 24 часа != PT2H; при этом "PT120M" эквивалентен "PT2H"
+    const equalCheck = checkTableSchema(
+      ttlExpected,
+      sessionDescription({
+        ttl: { column: 'expires_at', expireAfterSeconds: 7200 },
+      }),
+    );
+    expect(equalCheck.ttlMismatches).toEqual([]);
+
+    const changedCheck = checkTableSchema(
+      ttlExpected,
+      sessionDescription({
+        ttl: { column: 'expires_at', expireAfterSeconds: 90000 },
+      }),
+    );
+    expect(changedCheck.ttlMismatches).toEqual([
+      {
+        expected: { interval: 'PT2H', column: 'expires_at' },
+        actual: { column: 'expires_at', expireAfterSeconds: 90000 },
+      },
+    ]);
+  });
+
+  it('detects changed TTL column and unit', () => {
+    const numericExpected: ExpectedTableSchema = {
+      tableName: 'ttl_numeric',
+      columns: { uuid: 'Uuid' },
+      primaryKey: ['uuid'],
+      indexes: [],
+      ttl: { interval: 'P30D', column: 'expires_at', unit: 'seconds' },
+    };
+
+    const check = checkTableSchema(numericExpected, {
+      columns: new Map([['uuid', Type_PrimitiveTypeId.UUID]]),
+      primaryKey: ['uuid'],
+      indexes: [],
+      ttl: {
+        column: 'other_col',
+        expireAfterSeconds: 2592000,
+        unit: 'milliseconds',
+      },
+    });
+
+    expect(check.ttlMismatches).toEqual([
+      {
+        expected: { interval: 'P30D', column: 'expires_at', unit: 'seconds' },
+        actual: {
+          column: 'other_col',
+          expireAfterSeconds: 2592000,
+          unit: 'milliseconds',
+        },
+      },
+    ]);
+  });
+
+  it('treats calendar-part intervals (years/months) as mismatch', () => {
+    const calendarExpected = {
+      ...ttlExpected,
+      ttl: { interval: 'P1M', column: 'expires_at' },
+    };
+    const check = checkTableSchema(
+      calendarExpected,
+      sessionDescription({
+        ttl: { column: 'expires_at', expireAfterSeconds: 2592000 },
+      }),
+    );
+
+    expect(check.ttlMismatches).toHaveLength(1);
+  });
+
+  it('detects TTL present in DB but absent in entity', () => {
+    const plainExpected = buildExpectedTableSchema(
+      meta(TestExplicitUuidPkEntity),
+    );
+    const check = checkTableSchema(plainExpected, {
+      columns: new Map([['uuid', Type_PrimitiveTypeId.UUID]]),
+      primaryKey: ['uuid'],
+      indexes: [],
+      ttl: { column: 'created_at', expireAfterSeconds: 3600 },
+    });
+
+    expect(check.extraTtl).toEqual([
+      { actual: { column: 'created_at', expireAfterSeconds: 3600 } },
+    ]);
+  });
+});
+
+describe('checkToIssues / diffSchemas (#88)', () => {
+  const ttlExpected = buildExpectedTableSchema(meta(TestSessionEntity));
+
+  const sessionDescription = (
+    overrides: Partial<YdbTableDescription> = {},
+  ): YdbTableDescription => ({
+    columns: new Map([
+      ['uuid', Type_PrimitiveTypeId.UUID],
+      ['expires_at', Type_PrimitiveTypeId.DATETIME],
+    ]),
+    primaryKey: ['uuid'],
+    indexes: [
+      {
+        name: 'test_sessions__expires_at',
+        columns: ['expires_at'],
+        unique: false,
+      },
+    ],
+    ...overrides,
+  });
+
+  it('exposes unique flag mismatch as an issue', () => {
+    const check = checkTableSchema(
+      buildExpectedTableSchema(meta(TestUserEntity)),
+      description(
+        [
+          ['uuid', Type_PrimitiveTypeId.UUID],
+          ['name', Type_PrimitiveTypeId.UTF8],
+          ['secret', Type_PrimitiveTypeId.STRING],
+          ['is_active', Type_PrimitiveTypeId.BOOL],
+          ['secret_bi', Type_PrimitiveTypeId.UTF8],
+        ],
+        ['uuid'],
+        [
+          {
+            name: 'test_users__active_name',
+            columns: ['is_active', 'name'],
+            unique: true,
+          },
+        ],
+      ),
+    );
+    const issues = checkToIssues(check);
+
+    expect(issues).toContainEqual({
+      tableName: 'test_users',
+      kind: 'unique-mismatch',
+      message:
+        'Table "test_users" index "test_users__active_name" unique flag mismatch: ' +
+        'expected false, actual true',
+    });
+  });
+
+  it('exposes missing TTL as ttl-missing issue', () => {
+    const issues = diffSchemas(
+      [ttlExpected],
+      [sessionDescription({ ttl: undefined })],
+    );
+
+    expect(issues).toContainEqual({
+      tableName: 'test_sessions',
+      kind: 'ttl-missing',
+      message:
+        'Table "test_sessions" has no TTL, entity declares PT2H on column "expires_at"',
+    });
+  });
+
+  it('exposes changed TTL with unit as ttl-mismatch issue', () => {
+    const issues = diffSchemas(
+      [
+        {
+          ...ttlExpected,
+          ttl: { interval: 'PT2H', column: 'expires_at', unit: 'seconds' },
+        },
+      ],
+      [
+        sessionDescription({
+          ttl: { column: 'expires_at', expireAfterSeconds: 3600 },
+        }),
+      ],
+    );
+
+    expect(issues).toContainEqual({
+      tableName: 'test_sessions',
+      kind: 'ttl-mismatch',
+      message:
+        'Table "test_sessions" TTL mismatch: expected PT2H on column "expires_at" AS SECONDS, ' +
+        'actual PT1H on column "expires_at"',
+    });
+  });
+
+  it('exposes DB-only TTL as ttl-extra issue', () => {
+    const plainExpected = buildExpectedTableSchema(
+      meta(TestExplicitUuidPkEntity),
+    );
+    const issues = diffSchemas(
+      [plainExpected],
+      [
+        {
+          columns: new Map([['uuid', Type_PrimitiveTypeId.UUID]]),
+          primaryKey: ['uuid'],
+          indexes: [],
+          ttl: { column: 'created_at', expireAfterSeconds: 3600 },
+        },
+      ],
+    );
+
+    expect(issues).toContainEqual({
+      tableName: 'test_explicit_uuid_pk',
+      kind: 'ttl-extra',
+      message:
+        'Table "test_explicit_uuid_pk" has TTL PT1H on column "created_at" not present in entity',
+    });
+  });
+});
+
+describe('generateSetTtlYql / generateResetTtlYql', () => {
+  it('generates ALTER TABLE SET with TTL expression compatible with WITH-clause', () => {
+    expect(
+      generateSetTtlYql('sessions', { interval: 'PT2H', column: 'expires_at' }),
+    ).toBe(
+      'ALTER TABLE `sessions` SET (TTL = Interval("PT2H") ON `expires_at`)',
+    );
+    expect(
+      generateSetTtlYql('sessions', {
+        interval: 'P30D',
+        column: 'expires_at',
+        unit: 'seconds',
+      }),
+    ).toBe(
+      'ALTER TABLE `sessions` SET (TTL = Interval("P30D") ON `expires_at` AS SECONDS)',
+    );
+  });
+
+  it('generates ALTER TABLE RESET (TTL)', () => {
+    expect(generateResetTtlYql('sessions')).toBe(
+      'ALTER TABLE `sessions` RESET (TTL)',
+    );
+  });
 });
 
 describe('YdbSchemaSyncer', () => {
@@ -630,5 +961,159 @@ describe('YdbSchemaSyncer', () => {
       },
     ]);
     expect(executedSql()).toEqual([]);
+  });
+
+  it('verify reports missing TTL and missing index (#88)', async () => {
+    mockDescribe({
+      columns: new Map([
+        ['uuid', Type_PrimitiveTypeId.UUID],
+        ['expires_at', Type_PrimitiveTypeId.DATETIME],
+      ]),
+      primaryKey: ['uuid'],
+      indexes: [],
+    });
+
+    const issues = await syncer.verify([TestSessionEntity]);
+
+    expect(issues).toEqual([
+      expect.objectContaining({ kind: 'missing-index' }),
+      {
+        tableName: 'test_sessions',
+        kind: 'ttl-missing',
+        message:
+          'Table "test_sessions" has no TTL, entity declares PT2H on column "expires_at"',
+      },
+    ]);
+  });
+
+  it('verify reports unique flag mismatch issue (#88)', async () => {
+    mockDescribe(
+      description(
+        [
+          ['uuid', Type_PrimitiveTypeId.UUID],
+          ['name', Type_PrimitiveTypeId.UTF8],
+          ['secret', Type_PrimitiveTypeId.STRING],
+          ['is_active', Type_PrimitiveTypeId.BOOL],
+          ['secret_bi', Type_PrimitiveTypeId.UTF8],
+        ],
+        ['uuid'],
+        [
+          {
+            name: 'test_users__active_name',
+            columns: ['is_active', 'name'],
+            unique: true,
+          },
+        ],
+      ),
+    );
+
+    const issues = await syncer.verify([TestUserEntity]);
+
+    expect(issues).toContainEqual({
+      tableName: 'test_users',
+      kind: 'unique-mismatch',
+      message:
+        'Table "test_users" index "test_users__active_name" unique flag mismatch: ' +
+        'expected false, actual true',
+    });
+    expect(executedSql()).toEqual([]);
+  });
+});
+
+describe('YdbSchemaSyncer.describeTable TTL parsing (#88)', () => {
+  const sessionResult = anyPack(
+    CreateSessionResultSchema,
+    create(CreateSessionResultSchema, { sessionId: 'session-ttl-1' }),
+  );
+
+  function makeSyncer(describeResponse: unknown): YdbSchemaSyncer {
+    const tableClient = {
+      createSession: jest.fn(() =>
+        Promise.resolve({ operation: { result: sessionResult } }),
+      ),
+      describeTable: jest.fn(() => Promise.resolve(describeResponse)),
+      deleteSession: jest.fn(() => Promise.resolve({})),
+    };
+    const driver = {
+      database: '/local',
+      createClient: jest.fn(() => tableClient),
+    };
+    return new YdbSchemaSyncer(driver as never, {} as YdbExecutor);
+  }
+
+  function describeResponse(ttl?: unknown): unknown {
+    return {
+      operation: {
+        status: StatusIds_StatusCode.SUCCESS,
+        result: anyPack(
+          DescribeTableResultSchema,
+          create(DescribeTableResultSchema, {
+            columns: [
+              {
+                name: 'expires_at',
+                type: {
+                  type: {
+                    case: 'typeId',
+                    value: Type_PrimitiveTypeId.DATETIME,
+                  },
+                },
+              },
+            ],
+            primaryKey: ['expires_at'],
+            indexes: [],
+            ...(ttl ? { ttlSettings: ttl } : {}),
+          }),
+        ),
+      },
+    };
+  }
+
+  it('parses date-type TTL settings', async () => {
+    const syncer = makeSyncer(
+      describeResponse({
+        mode: {
+          case: 'dateTypeColumn',
+          value: { columnName: 'expires_at', expireAfterSeconds: 7200 },
+        },
+      }),
+    );
+
+    const desc = await syncer.describeTable('test_sessions');
+
+    expect(desc?.ttl).toEqual({
+      column: 'expires_at',
+      expireAfterSeconds: 7200,
+    });
+  });
+
+  it('maps numeric TTL unit from proto enum', async () => {
+    const syncer = makeSyncer(
+      describeResponse({
+        mode: {
+          case: 'valueSinceUnixEpoch',
+          value: {
+            columnName: 'expires_at',
+            columnUnit: ValueSinceUnixEpochModeSettings_Unit.SECONDS,
+            expireAfterSeconds: 2592000,
+          },
+        },
+      }),
+    );
+
+    const desc = await syncer.describeTable('test_sessions');
+
+    expect(desc?.ttl).toEqual({
+      column: 'expires_at',
+      expireAfterSeconds: 2592000,
+      unit: 'seconds',
+    });
+  });
+
+  it('returns undefined ttl when ttlSettings is absent', async () => {
+    const syncer = makeSyncer(describeResponse());
+
+    const desc = await syncer.describeTable('test_sessions');
+
+    expect(desc?.ttl).toBeUndefined();
   });
 });

--- a/src/schema/schema-sync.spec.ts
+++ b/src/schema/schema-sync.spec.ts
@@ -31,6 +31,7 @@ import {
   ExpectedTableSchema,
   YdbSchemaSyncer,
   YdbTableDescription,
+  YdbTableTtl,
 } from './schema-sync.js';
 import {
   getManyToManyJoinTables,
@@ -113,6 +114,17 @@ class TestSessionEntity extends YdbBaseEntity {
   expires_at: Date;
 }
 
+@YdbEntity('test_ttl_numeric')
+@YdbTtl({ interval: 'P30D', column: 'expires_at', unit: 'milliseconds' })
+class TestNumericTtlEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  // Uint32 нет в YdbPrimitive — числовые TTL-типы проверяются отдельно
+  @YdbColumn('Uint32' as never)
+  expires_at: number;
+}
+
 @YdbEntity('test_photos')
 @EagerLoad(['tags'])
 class TestPhotoEntity extends YdbBaseEntity {
@@ -137,7 +149,13 @@ const description = (
   columns: [string, Type_PrimitiveTypeId][],
   primaryKey: string[] = ['uuid'],
   indexes: Array<{ name: string; columns: string[]; unique: boolean }> = [],
-): YdbTableDescription => ({ columns: new Map(columns), primaryKey, indexes });
+  ttl?: YdbTableTtl,
+): YdbTableDescription => ({
+  columns: new Map(columns),
+  primaryKey,
+  indexes,
+  ...(ttl ? { ttl } : {}),
+});
 
 describe('entity registry', () => {
   it('registers classes decorated with @YdbEntity', () => {
@@ -587,6 +605,23 @@ describe('checkTableSchema TTL (#88)', () => {
       }),
     );
     expect(changedCheck.ttlMismatches).toHaveLength(1);
+  });
+
+  it('treats sub-microsecond intervals as mismatch instead of truncating (#88)', () => {
+    // "PT0.0000001S" непредставим в YDB Interval: усечение до 0µs дало бы
+    // ложное «совпадение» с TTL = 0 секунд в БД
+    const subMicroExpected = {
+      ...ttlExpected,
+      ttl: { interval: 'PT0.0000001S', column: 'expires_at' },
+    };
+    const check = checkTableSchema(
+      subMicroExpected,
+      sessionDescription({
+        ttl: { column: 'expires_at', expireAfterSeconds: 0 },
+      }),
+    );
+
+    expect(check.ttlMismatches).toHaveLength(1);
   });
 
   it('detects changed TTL column and unit', () => {
@@ -1041,6 +1076,154 @@ describe('YdbSchemaSyncer', () => {
         'expected false, actual true',
     });
     expect(executedSql()).toEqual([]);
+  });
+
+  // Синхронизация TTL (#88): отсутствующий ставим, изменённый заменяем,
+  // лишний не сбрасываем.
+  describe('sync applies TTL changes', () => {
+    const sessionDescriptionFull = (ttl?: YdbTableTtl): YdbTableDescription =>
+      description(
+        [
+          ['uuid', Type_PrimitiveTypeId.UUID],
+          ['expires_at', Type_PrimitiveTypeId.DATETIME],
+        ],
+        ['uuid'],
+        [
+          {
+            name: 'test_sessions__expires_at',
+            columns: ['expires_at'],
+            unique: false,
+          },
+        ],
+        ttl,
+      );
+
+    const numericDescription = (ttl?: YdbTableTtl): YdbTableDescription =>
+      description(
+        [
+          ['uuid', Type_PrimitiveTypeId.UUID],
+          ['expires_at', Type_PrimitiveTypeId.UINT32],
+        ],
+        ['uuid'],
+        [],
+        ttl,
+      );
+
+    it('sets TTL declared by entity but absent in DB', async () => {
+      mockDescribe(sessionDescriptionFull());
+
+      await syncer.sync([TestSessionEntity]);
+
+      expect(executedSql()).toEqual([
+        generateSetTtlYql('test_sessions', {
+          interval: 'PT2H',
+          column: 'expires_at',
+        }),
+      ]);
+    });
+
+    it('replaces changed TTL with metadata from entity', async () => {
+      mockDescribe(
+        sessionDescriptionFull({
+          column: 'expires_at',
+          expireAfterSeconds: 90000,
+        }),
+      );
+
+      await syncer.sync([TestSessionEntity]);
+
+      expect(executedSql()).toEqual([
+        generateSetTtlYql('test_sessions', {
+          interval: 'PT2H',
+          column: 'expires_at',
+        }),
+      ]);
+    });
+
+    it('replaces changed numeric TTL including unit', async () => {
+      mockDescribe(
+        numericDescription({
+          column: 'expires_at',
+          expireAfterSeconds: 2592000,
+          unit: 'seconds',
+        }),
+      );
+
+      await syncer.sync([TestNumericTtlEntity]);
+
+      expect(executedSql()).toEqual([
+        generateSetTtlYql('test_ttl_numeric', {
+          interval: 'P30D',
+          column: 'expires_at',
+          unit: 'milliseconds',
+        }),
+      ]);
+    });
+
+    it('sets numeric TTL with unit when absent in DB', async () => {
+      mockDescribe(numericDescription());
+
+      await syncer.sync([TestNumericTtlEntity]);
+
+      expect(executedSql()).toEqual([
+        generateSetTtlYql('test_ttl_numeric', {
+          interval: 'P30D',
+          column: 'expires_at',
+          unit: 'milliseconds',
+        }),
+      ]);
+    });
+
+    it('executes no DDL when TTL matches', async () => {
+      mockDescribe(
+        sessionDescriptionFull({
+          column: 'expires_at',
+          expireAfterSeconds: 7200,
+        }),
+      );
+
+      await syncer.sync([TestSessionEntity]);
+
+      expect(executedSql()).toEqual([]);
+    });
+
+    it('warns about extra TTL without resetting it', async () => {
+      const warnSpy = jest
+        .spyOn((syncer as any).logger, 'warn')
+        .mockImplementation(() => {});
+      mockDescribe(
+        description(
+          [
+            ['uuid', Type_PrimitiveTypeId.UUID],
+            ['name', Type_PrimitiveTypeId.UTF8],
+            ['secret', Type_PrimitiveTypeId.STRING],
+            ['is_active', Type_PrimitiveTypeId.BOOL],
+            ['secret_bi', Type_PrimitiveTypeId.UTF8],
+          ],
+          ['uuid'],
+          [
+            {
+              name: 'test_users__secret_bi',
+              columns: ['secret_bi'],
+              unique: false,
+            },
+            {
+              name: 'test_users__active_name',
+              columns: ['is_active', 'name'],
+              unique: false,
+            },
+          ],
+          { column: 'legacy_expires_at', expireAfterSeconds: 3600 },
+        ),
+      );
+
+      await syncer.sync([TestUserEntity]);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('extra TTL on column "legacy_expires_at"'),
+      );
+      expect(executedSql()).toEqual([]);
+    });
   });
 });
 

--- a/src/schema/schema-sync.ts
+++ b/src/schema/schema-sync.ts
@@ -27,7 +27,7 @@ import {
 } from '../decorators/index.decorator.js';
 import {
   getYdbTtlMetadata,
-  isoDurationToMicroseconds,
+  isoDurationToMicrosecondsExact,
   microsecondsToIsoDuration,
   MICROSECONDS_PER_SECOND,
   validateYdbTtlAgainstSchema,
@@ -146,6 +146,24 @@ const PRIMITIVE_TO_TYPE_ID: Record<YdbPrimitive, Type_PrimitiveTypeId> = {
 const TYPE_ID_TO_PRIMITIVE = new Map<Type_PrimitiveTypeId, YdbPrimitive>(
   Object.entries(PRIMITIVE_TO_TYPE_ID).map(([k, v]) => [v, k as YdbPrimitive]),
 );
+
+/**
+ * Числовые типы TTL-колонок: YDB допускает TTL по Uint32/Uint64/DyNumber
+ * с unit, но эти типы не входят в YdbPrimitive (маппинг значений запросов
+ * их не поддерживает). Здесь они нужны только для схемного сравнения,
+ * чтобы sync/verify не считали такую колонку расхождением типов (#88).
+ */
+const TTL_NUMERIC_TYPE_IDS: Record<string, Type_PrimitiveTypeId> = {
+  Uint32: Type_PrimitiveTypeId.UINT32,
+  Uint64: Type_PrimitiveTypeId.UINT64,
+  DyNumber: Type_PrimitiveTypeId.DYNUMBER,
+};
+
+for (const [name, typeId] of Object.entries(TTL_NUMERIC_TYPE_IDS)) {
+  if (!TYPE_ID_TO_PRIMITIVE.has(typeId)) {
+    TYPE_ID_TO_PRIMITIVE.set(typeId, name as YdbPrimitive);
+  }
+}
 
 /** Enum Unit из TtlSettings → YdbTtlUnit (см. @YdbTtl). */
 const TTL_UNIT_BY_PROTO: Record<
@@ -372,8 +390,10 @@ function formatTableTtl(ttl: YdbTableTtl): string {
  * колонка, unit и интервал. Интервал сравнивается семантически в целых
  * микросекундах (внутренней точности YDB Interval): "PT1H" и "PT60M"
  * равны, "PT0.5S" — это ровно 500000µs, без потерь на float.
- * Интервалы с календарными частями (годы/месяцы) не сравнимы надёжно —
- * считаются расхождением, чтобы миграция выставила значение из метаданных.
+ * Интервалы, непредставимые в YDB Interval точно, — календарные части
+ * и дробь точнее микросекунд — считаются расхождением, чтобы миграция
+ * или синхронизация выставили значение из метаданных вместо ложного
+ * «совпадения» после усечения.
  */
 function ttlSettingsMatch(
   expected: YdbTtlMetadata,
@@ -381,7 +401,7 @@ function ttlSettingsMatch(
 ): boolean {
   if (expected.column !== actual.column) return false;
   if ((expected.unit ?? undefined) !== (actual.unit ?? undefined)) return false;
-  const expectedMicros = isoDurationToMicroseconds(expected.interval);
+  const expectedMicros = isoDurationToMicrosecondsExact(expected.interval);
   return (
     expectedMicros !== null &&
     expectedMicros === actual.expireAfterSeconds * MICROSECONDS_PER_SECOND
@@ -405,7 +425,11 @@ export function checkTableSchema(
       missingColumns.push([name, type]);
       continue;
     }
-    if (actualTypeId !== PRIMITIVE_TO_TYPE_ID[type]) {
+    // Числовые TTL-типы (Uint32/Uint64/DyNumber) не входят в YdbPrimitive,
+    // но валидны для схемного сравнения — см. TTL_NUMERIC_TYPE_IDS.
+    const expectedTypeId =
+      PRIMITIVE_TO_TYPE_ID[type] ?? TTL_NUMERIC_TYPE_IDS[type];
+    if (actualTypeId !== expectedTypeId) {
       typeMismatches.push({
         column: name,
         expected: type,
@@ -672,8 +696,13 @@ export class YdbSchemaSyncer {
    * Подстраивает БД под схему сущностей:
    *  - нет таблицы — CREATE TABLE;
    *  - нет колонок — ALTER TABLE ADD COLUMN;
-   *  - лишние колонки — только предупреждение в лог (не удаляем данные);
-   *  - расхождение типа/PK — ошибка (в YDB не меняется, нужна миграция).
+   *  - нет индексов — ALTER TABLE ADD INDEX;
+   *  - нет TTL или TTL отличается от метаданных — ALTER TABLE SET (TTL = ...)
+   *    (SET перезаписывает существующие настройки);
+   *  - лишние колонки/индексы/TTL — только предупреждение в лог
+   *    (не удаляем данные и настройки);
+   *  - расхождение типа/PK/колонок индекса — ошибка (в YDB не меняется,
+   *    нужна миграция).
    */
   async sync(entities: (new (...args: any[]) => any)[]): Promise<void> {
     for (const expected of buildExpectedSchemas(entities)) {
@@ -761,6 +790,36 @@ export class YdbSchemaSyncer {
         this.logger.warn(
           `Table "${expected.tableName}" index "${m.name}" unique flag mismatch: ` +
             `expected ${m.expected}, actual ${m.actual} — recreate index manually if needed`,
+        );
+      }
+
+      // TTL: отсутствующий ставим, изменённый заменяем — SET (TTL = ...)
+      // перезаписывает существующие настройки. Лишний TTL не сбрасываем
+      // автоматически: та же политика, что и в planMigration (#88).
+      if (check.missingTtl.length && check.missingTtl[0].expected) {
+        this.logger.log(
+          `Setting TTL on "${expected.tableName}" ` +
+            `(column "${check.missingTtl[0].expected.column}")`,
+        );
+        await this.executeDdl(
+          generateSetTtlYql(expected.tableName, check.missingTtl[0].expected),
+        );
+      }
+
+      for (const m of check.ttlMismatches) {
+        this.logger.log(
+          `Updating TTL on "${expected.tableName}" ` +
+            `(was ${formatTableTtl(m.actual)})`,
+        );
+        await this.executeDdl(
+          generateSetTtlYql(expected.tableName, m.expected),
+        );
+      }
+
+      for (const extra of check.extraTtl) {
+        this.logger.warn(
+          `Table "${expected.tableName}" has extra TTL on column ` +
+            `"${extra.actual.column}" — left as is`,
         );
       }
     }

--- a/src/schema/schema-sync.ts
+++ b/src/schema/schema-sync.ts
@@ -27,8 +27,9 @@ import {
 } from '../decorators/index.decorator.js';
 import {
   getYdbTtlMetadata,
-  isoDurationToSeconds,
-  secondsToIsoDuration,
+  isoDurationToMicroseconds,
+  microsecondsToIsoDuration,
+  MICROSECONDS_PER_SECOND,
   validateYdbTtlAgainstSchema,
   YdbTtlMetadata,
   YdbTtlUnit,
@@ -360,12 +361,17 @@ function formatTtlMeta(ttl: YdbTtlMetadata): string {
 /** Человекочитаемое представление фактического TTL из БД. */
 function formatTableTtl(ttl: YdbTableTtl): string {
   const unitPart = ttl.unit ? ` AS ${ttl.unit.toUpperCase()}` : '';
-  return `${secondsToIsoDuration(ttl.expireAfterSeconds)} on column "${ttl.column}"${unitPart}`;
+  return (
+    `${microsecondsToIsoDuration(ttl.expireAfterSeconds * MICROSECONDS_PER_SECOND)} ` +
+    `on column "${ttl.column}"${unitPart}`
+  );
 }
 
 /**
  * Сравнивает ожидаемый TTL с фактическим из DescribeTable:
- * колонка, unit и интервал (семантически, в секундах — "PT1H" и "PT60M" равны).
+ * колонка, unit и интервал. Интервал сравнивается семантически в целых
+ * микросекундах (внутренней точности YDB Interval): "PT1H" и "PT60M"
+ * равны, "PT0.5S" — это ровно 500000µs, без потерь на float.
  * Интервалы с календарными частями (годы/месяцы) не сравнимы надёжно —
  * считаются расхождением, чтобы миграция выставила значение из метаданных.
  */
@@ -375,9 +381,10 @@ function ttlSettingsMatch(
 ): boolean {
   if (expected.column !== actual.column) return false;
   if ((expected.unit ?? undefined) !== (actual.unit ?? undefined)) return false;
-  const expectedSeconds = isoDurationToSeconds(expected.interval);
+  const expectedMicros = isoDurationToMicroseconds(expected.interval);
   return (
-    expectedSeconds !== null && expectedSeconds === actual.expireAfterSeconds
+    expectedMicros !== null &&
+    expectedMicros === actual.expireAfterSeconds * MICROSECONDS_PER_SECOND
   );
 }
 

--- a/src/schema/schema-sync.ts
+++ b/src/schema/schema-sync.ts
@@ -5,7 +5,9 @@ import {
   TableServiceDefinition,
   CreateSessionResultSchema,
   DescribeTableResultSchema,
+  ValueSinceUnixEpochModeSettings_Unit,
 } from '@ydbjs/api/table';
+import type { TtlSettings } from '@ydbjs/api/table';
 import { StatusIds_StatusCode, IssueMessage } from '@ydbjs/api/operation';
 import { Type, Type_PrimitiveTypeId } from '@ydbjs/api/value';
 import { YdbPrimitive } from '../core/types.js';
@@ -25,8 +27,11 @@ import {
 } from '../decorators/index.decorator.js';
 import {
   getYdbTtlMetadata,
+  isoDurationToSeconds,
+  secondsToIsoDuration,
   validateYdbTtlAgainstSchema,
   YdbTtlMetadata,
+  YdbTtlUnit,
 } from '../decorators/ttl.decorator.js';
 
 /** Ожидаемый вторичный индекс таблицы. */
@@ -34,6 +39,18 @@ export interface ExpectedIndex {
   name: string;
   columns: string[];
   unique: boolean;
+}
+
+/**
+ * Нормализованные TTL-настройки существующей таблицы
+ * (TtlSettings из DescribeTable, см. issue #81/#88).
+ */
+export interface YdbTableTtl {
+  column: string;
+  /** Задержка до истечения в секундах (expire_after_seconds из proto). */
+  expireAfterSeconds: number;
+  /** Единица числовой колонки; отсутствует для Date/Datetime/Timestamp. */
+  unit?: YdbTtlUnit;
 }
 
 /** Ожидаемая схема таблицы, построенная по метаданным сущности. */
@@ -52,6 +69,11 @@ export interface YdbTableDescription {
   primaryKey: string[];
   /** Индексы, описанные в БД. */
   indexes?: Array<{ name: string; columns: string[]; unique: boolean }>;
+  /**
+   * TTL-настройки таблицы из DescribeTable (undefined — TTL не задан).
+   * Сравнивается с метаданными @YdbTtl при verify/миграциях (#88).
+   */
+  ttl?: YdbTableTtl;
 }
 
 /** Результат проверки существующей таблицы против ожидаемой схемы. */
@@ -76,6 +98,12 @@ export interface SchemaCheckResult {
     expected: string[];
     actual: string[];
   }[];
+  /** TTL объявлен сущностью, но в БД не задан. */
+  missingTtl: { expected: YdbTtlMetadata }[];
+  /** TTL задан и в БД, и в метаданных, но колонка/unit/интервал различаются. */
+  ttlMismatches: { expected: YdbTtlMetadata; actual: YdbTableTtl }[];
+  /** В БД задан TTL, которого нет в метаданных (не сбрасывается автоматически). */
+  extraTtl: { actual: YdbTableTtl }[];
 }
 
 /** Проблема схемы, найденная при verify. */
@@ -89,7 +117,11 @@ export interface YdbSchemaIssue {
     | 'extra-column'
     | 'missing-index'
     | 'extra-index'
-    | 'index-columns-mismatch';
+    | 'index-columns-mismatch'
+    | 'unique-mismatch'
+    | 'ttl-missing'
+    | 'ttl-mismatch'
+    | 'ttl-extra';
   message: string;
 }
 
@@ -113,6 +145,18 @@ const PRIMITIVE_TO_TYPE_ID: Record<YdbPrimitive, Type_PrimitiveTypeId> = {
 const TYPE_ID_TO_PRIMITIVE = new Map<Type_PrimitiveTypeId, YdbPrimitive>(
   Object.entries(PRIMITIVE_TO_TYPE_ID).map(([k, v]) => [v, k as YdbPrimitive]),
 );
+
+/** Enum Unit из TtlSettings → YdbTtlUnit (см. @YdbTtl). */
+const TTL_UNIT_BY_PROTO: Record<
+  ValueSinceUnixEpochModeSettings_Unit,
+  YdbTtlUnit | undefined
+> = {
+  [ValueSinceUnixEpochModeSettings_Unit.UNSPECIFIED]: undefined,
+  [ValueSinceUnixEpochModeSettings_Unit.SECONDS]: 'seconds',
+  [ValueSinceUnixEpochModeSettings_Unit.MILLISECONDS]: 'milliseconds',
+  [ValueSinceUnixEpochModeSettings_Unit.MICROSECONDS]: 'microseconds',
+  [ValueSinceUnixEpochModeSettings_Unit.NANOSECONDS]: 'nanoseconds',
+};
 
 /**
  * Строит ожидаемую схему таблицы по метаданным сущности:
@@ -225,12 +269,7 @@ export function buildExpectedSchemas(
  *   WITH (TTL = Interval("PT2H") ON `col` [AS SECONDS])
  */
 export function generateTtlWithClause(ttl: YdbTtlMetadata): string {
-  const unitPart = ttl.unit ? ` AS ${ttl.unit.toUpperCase()}` : '';
-  return (
-    `WITH (\n` +
-    `  TTL = Interval("${ttl.interval}") ON ${quoteIdentifier(ttl.column)}` +
-    `${unitPart}\n)`
-  );
+  return `WITH (\n  ${ttlExpression(ttl)}\n)`;
 }
 
 /** Генерирует DDL создания таблицы. */
@@ -286,6 +325,59 @@ export function generateDropIndexYql(
   return (
     `ALTER TABLE ${quoteIdentifier(tableName)} ` +
     `DROP INDEX ${quoteIdentifier(indexName)}`
+  );
+}
+
+/**
+ * Генерирует DDL установки/замены TTL через ALTER TABLE.
+ * Выражение TTL совпадает с WITH-секцией CREATE TABLE (#81):
+ *   ALTER TABLE `t` SET (TTL = Interval("PT2H") ON `col` [AS SECONDS])
+ */
+export function generateSetTtlYql(
+  tableName: string,
+  ttl: YdbTtlMetadata,
+): string {
+  return `ALTER TABLE ${quoteIdentifier(tableName)} SET (${ttlExpression(ttl)})`;
+}
+
+/** Генерирует DDL сброса TTL: ALTER TABLE `t` RESET (TTL). */
+export function generateResetTtlYql(tableName: string): string {
+  return `ALTER TABLE ${quoteIdentifier(tableName)} RESET (TTL)`;
+}
+
+/** TTL-выражение `TTL = Interval(...) ON col [AS unit]`, общее для CREATE/ALTER. */
+function ttlExpression(ttl: YdbTtlMetadata): string {
+  const unitPart = ttl.unit ? ` AS ${ttl.unit.toUpperCase()}` : '';
+  return `TTL = Interval("${ttl.interval}") ON ${quoteIdentifier(ttl.column)}${unitPart}`;
+}
+
+/** Человекочитаемое представление ожидаемого TTL (для issues/warnings). */
+function formatTtlMeta(ttl: YdbTtlMetadata): string {
+  const unitPart = ttl.unit ? ` AS ${ttl.unit.toUpperCase()}` : '';
+  return `${ttl.interval} on column "${ttl.column}"${unitPart}`;
+}
+
+/** Человекочитаемое представление фактического TTL из БД. */
+function formatTableTtl(ttl: YdbTableTtl): string {
+  const unitPart = ttl.unit ? ` AS ${ttl.unit.toUpperCase()}` : '';
+  return `${secondsToIsoDuration(ttl.expireAfterSeconds)} on column "${ttl.column}"${unitPart}`;
+}
+
+/**
+ * Сравнивает ожидаемый TTL с фактическим из DescribeTable:
+ * колонка, unit и интервал (семантически, в секундах — "PT1H" и "PT60M" равны).
+ * Интервалы с календарными частями (годы/месяцы) не сравнимы надёжно —
+ * считаются расхождением, чтобы миграция выставила значение из метаданных.
+ */
+function ttlSettingsMatch(
+  expected: YdbTtlMetadata,
+  actual: YdbTableTtl,
+): boolean {
+  if (expected.column !== actual.column) return false;
+  if ((expected.unit ?? undefined) !== (actual.unit ?? undefined)) return false;
+  const expectedSeconds = isoDurationToSeconds(expected.interval);
+  return (
+    expectedSeconds !== null && expectedSeconds === actual.expireAfterSeconds
   );
 }
 
@@ -370,6 +462,24 @@ export function checkTableSchema(
     }
   }
 
+  // TTL (#88): отсутствующий, изменённый и лишний — в БД TTL либо задан
+  // согласно @YdbTtl, либо его нет вовсе.
+  const missingTtl: SchemaCheckResult['missingTtl'] = [];
+  const ttlMismatches: SchemaCheckResult['ttlMismatches'] = [];
+  const extraTtl: SchemaCheckResult['extraTtl'] = [];
+
+  if (expected.ttl && !existing.ttl) {
+    missingTtl.push({ expected: expected.ttl });
+  } else if (!expected.ttl && existing.ttl) {
+    extraTtl.push({ actual: existing.ttl });
+  } else if (
+    expected.ttl &&
+    existing.ttl &&
+    !ttlSettingsMatch(expected.ttl, existing.ttl)
+  ) {
+    ttlMismatches.push({ expected: expected.ttl, actual: existing.ttl });
+  }
+
   return {
     tableName: expected.tableName,
     missingColumns,
@@ -380,6 +490,9 @@ export function checkTableSchema(
     extraIndexes,
     uniqueMismatches,
     indexColumnsMismatches,
+    missingTtl,
+    ttlMismatches,
+    extraTtl,
   };
 }
 
@@ -441,6 +554,42 @@ export function checkToIssues(check: SchemaCheckResult): YdbSchemaIssue[] {
       message:
         `Table "${check.tableName}" index "${m.name}" columns mismatch: ` +
         `expected [${m.expected.join(', ')}], actual [${m.actual.join(', ')}]`,
+    });
+  }
+  for (const m of check.uniqueMismatches) {
+    issues.push({
+      tableName: check.tableName,
+      kind: 'unique-mismatch',
+      message:
+        `Table "${check.tableName}" index "${m.name}" unique flag mismatch: ` +
+        `expected ${m.expected}, actual ${m.actual}`,
+    });
+  }
+  for (const m of check.missingTtl) {
+    issues.push({
+      tableName: check.tableName,
+      kind: 'ttl-missing',
+      message:
+        `Table "${check.tableName}" has no TTL, entity declares ` +
+        formatTtlMeta(m.expected),
+    });
+  }
+  for (const m of check.ttlMismatches) {
+    issues.push({
+      tableName: check.tableName,
+      kind: 'ttl-mismatch',
+      message:
+        `Table "${check.tableName}" TTL mismatch: expected ` +
+        `${formatTtlMeta(m.expected)}, actual ${formatTableTtl(m.actual)}`,
+    });
+  }
+  for (const m of check.extraTtl) {
+    issues.push({
+      tableName: check.tableName,
+      kind: 'ttl-extra',
+      message:
+        `Table "${check.tableName}" has TTL ${formatTableTtl(m.actual)} ` +
+        `not present in entity`,
     });
   }
 
@@ -670,7 +819,12 @@ export class YdbSchemaSyncer {
         unique: idx.type.case === 'globalUniqueIndex',
       }));
 
-      return { columns, primaryKey: [...result.primaryKey], indexes };
+      return {
+        columns,
+        primaryKey: [...result.primaryKey],
+        indexes,
+        ttl: this.extractTtl(result.ttlSettings),
+      };
     } finally {
       await client.deleteSession({ sessionId }).catch((error: unknown) => {
         this.logger.warn(
@@ -690,6 +844,32 @@ export class YdbSchemaSyncer {
       return current.type.value;
     }
     return Type_PrimitiveTypeId.PRIMITIVE_TYPE_ID_UNSPECIFIED;
+  }
+
+  /**
+   * Нормализует TtlSettings из DescribeTable в YdbTableTtl.
+   * Date-режим (dateTypeColumn) не имеет unit; числовой (valueSinceUnixEpoch)
+   * маппит enum Unit в YdbTtlUnit, UNSPECIFIED трактуется как отсутствие unit.
+   */
+  private extractTtl(settings?: TtlSettings): YdbTableTtl | undefined {
+    const mode = settings?.mode;
+    if (!mode?.case) return undefined;
+
+    if (mode.case === 'dateTypeColumn') {
+      return {
+        column: mode.value.columnName,
+        expireAfterSeconds: mode.value.expireAfterSeconds,
+      };
+    }
+
+    const { columnName, columnUnit, expireAfterSeconds } = mode.value;
+    return {
+      column: columnName,
+      expireAfterSeconds,
+      ...(columnUnit !== ValueSinceUnixEpochModeSettings_Unit.UNSPECIFIED
+        ? { unit: TTL_UNIT_BY_PROTO[columnUnit] }
+        : {}),
+    };
   }
 
   private formatIssues(issues?: IssueMessage[]): string {

--- a/test/cli/schema-diff.spec.ts
+++ b/test/cli/schema-diff.spec.ts
@@ -96,6 +96,49 @@ describe('renderSchemaDiff', () => {
     );
   });
 
+  it('renders unique-mismatch and TTL issues (#88)', () => {
+    const issues: YdbSchemaIssue[] = [
+      {
+        tableName: 'users',
+        kind: 'unique-mismatch',
+        message:
+          'Table "users" index "users__name" unique flag mismatch: ' +
+          'expected false, actual true',
+      },
+      {
+        tableName: 'sessions',
+        kind: 'ttl-missing',
+        message:
+          'Table "sessions" has no TTL, entity declares PT2H on column "expires_at"',
+      },
+      {
+        tableName: 'sessions',
+        kind: 'ttl-mismatch',
+        message:
+          'Table "sessions" TTL mismatch: expected PT2H on column "expires_at", ' +
+          'actual PT1H on column "expires_at"',
+      },
+      {
+        tableName: 'legacy',
+        kind: 'ttl-extra',
+        message:
+          'Table "legacy" has TTL PT1H on column "created_at" not present in entity',
+      },
+    ];
+
+    const out = renderSchemaDiff(issues, { color: false });
+    const lines = out.split('\n');
+
+    expect(lines[1]).toContain('~ index "users__name" unique flag mismatch');
+    expect(lines[3]).toContain('+ has no TTL, entity declares PT2H');
+    expect(lines[4]).toContain(
+      '~ TTL: PT1H on column "expires_at" → PT2H on column "expires_at"',
+    );
+    expect(lines[6]).toContain(
+      '- has TTL PT1H on column "created_at" not present in entity',
+    );
+  });
+
   it('adds ANSI codes when color is enabled', () => {
     const issues: YdbSchemaIssue[] = [
       {

--- a/test/ydb-ttl.spec.ts
+++ b/test/ydb-ttl.spec.ts
@@ -9,6 +9,7 @@ import {
   YdbTtl,
   getYdbTtlMetadata,
   isoDurationToMicroseconds,
+  isoDurationToMicrosecondsExact,
   isoDurationToSeconds,
   microsecondsToIsoDuration,
   secondsToIsoDuration,
@@ -528,6 +529,48 @@ describe('ISO duration microsecond precision (#88)', () => {
         micros,
       );
     }
+  });
+});
+
+describe('Exact microsecond conversion (#88)', () => {
+  it('accepts intervals representable in YDB Interval exactly', () => {
+    expect(isoDurationToMicrosecondsExact('PT2H')).toBe(7_200_000_000);
+    expect(isoDurationToMicrosecondsExact('PT0.5S')).toBe(500000);
+    // Хвостовые нули за пределами микросекунд не мешают точности
+    expect(isoDurationToMicrosecondsExact('PT0.5000000S')).toBe(500000);
+    // Официальный пример из документации YDB: ровно 6 знаков дроби
+    expect(isoDurationToMicrosecondsExact('P1W2DT2H3M4.567890S')).toBe(
+      isoDurationToMicroseconds('P1W2DT2H3M4.567890S'),
+    );
+  });
+
+  it('returns null for sub-microsecond precision instead of truncating', () => {
+    expect(isoDurationToMicrosecondsExact('PT0.0000001S')).toBeNull();
+    expect(isoDurationToMicrosecondsExact('PT4.5678909S')).toBeNull();
+  });
+
+  it('returns null for calendar parts and invalid strings', () => {
+    expect(isoDurationToMicrosecondsExact('P1M')).toBeNull();
+    expect(isoDurationToMicrosecondsExact('P1Y2M')).toBeNull();
+    expect(isoDurationToMicrosecondsExact('nope')).toBeNull();
+  });
+
+  it('rejects @YdbTtl intervals more precise than a microsecond', () => {
+    class SubMicroEntity {}
+    expect(() =>
+      YdbTtl({ interval: 'PT0.0000001S', column: 'expires_at' })(
+        SubMicroEntity,
+      ),
+    ).toThrow(/more precise than a microsecond/);
+  });
+
+  it('still accepts up to 6 fractional digits at decoration time', () => {
+    class MaxPrecisionEntity {}
+    expect(() =>
+      YdbTtl({ interval: 'PT4.567890S', column: 'expires_at' })(
+        MaxPrecisionEntity,
+      ),
+    ).not.toThrow();
   });
 });
 

--- a/test/ydb-ttl.spec.ts
+++ b/test/ydb-ttl.spec.ts
@@ -8,15 +8,20 @@ import { YdbBaseEntity } from '../src/entity/base-entity.js';
 import {
   YdbTtl,
   getYdbTtlMetadata,
+  isoDurationToMicroseconds,
   isoDurationToSeconds,
+  microsecondsToIsoDuration,
   secondsToIsoDuration,
   validateYdbTtlAgainstSchema,
 } from '../src/decorators/ttl.decorator.js';
 import {
   buildExpectedTableSchema,
+  checkTableSchema,
   generateCreateTableYql,
+  generateSetTtlYql,
   generateTtlWithClause,
   ExpectedTableSchema,
+  YdbTableDescription,
 } from '../src/schema/schema-sync.js';
 import { YdbPrimitive } from '../src/core/types.js';
 import { validateEntityMetadata } from '../src/metadata/validate-entity.js';
@@ -436,4 +441,189 @@ describe('ISO 8601 duration helpers (#88)', () => {
       expect(isoDurationToSeconds(secondsToIsoDuration(seconds))).toBe(seconds);
     }
   });
+});
+
+describe('ISO duration microsecond precision (#88)', () => {
+  it('parses fractional seconds to exact microseconds', () => {
+    expect(isoDurationToMicroseconds('PT0.5S')).toBe(500000);
+    expect(isoDurationToMicroseconds('PT1.25S')).toBe(1250000);
+    expect(isoDurationToMicroseconds('PT0.000001S')).toBe(1);
+    // Официальный пример из документации YDB Interval
+    expect(isoDurationToMicroseconds('P1W2DT2H3M4.567890S')).toBe(
+      ((7 + 2) * 24 * 3600 + 2 * 3600 + 3 * 60) * 1000000 + 4567890,
+    );
+  });
+
+  it('truncates digits beyond microseconds deterministically', () => {
+    // YDB Interval хранит максимум 6 знаков после секунды
+    expect(isoDurationToMicroseconds('PT0.0000004S')).toBe(0);
+    expect(isoDurationToMicroseconds('PT4.5678909S')).toBe(4567890);
+    expect(isoDurationToMicroseconds('PT4.5678909S')).toBe(
+      isoDurationToMicroseconds('PT4.5678901S'),
+    );
+  });
+
+  it('renders microseconds back to ISO duration exactly', () => {
+    expect(microsecondsToIsoDuration(500000)).toBe('PT0.5S');
+    expect(microsecondsToIsoDuration(1250000)).toBe('PT1.25S');
+    expect(microsecondsToIsoDuration(1)).toBe('PT0.000001S');
+    expect(microsecondsToIsoDuration(1500000)).toBe('PT1.5S');
+    expect(microsecondsToIsoDuration(7_200_000_000)).toBe('PT2H');
+    // Хвостовые нули дробной части не пишутся: .567890 → .56789
+    expect(microsecondsToIsoDuration(784_984_567_890)).toBe('P9DT2H3M4.56789S');
+    expect(microsecondsToIsoDuration(0)).toBe('PT0S');
+  });
+
+  it('is value-round-trip safe: iso → µs → iso preserves the duration', () => {
+    const cases = [
+      'PT0.5S',
+      'PT1.25S',
+      'PT0.000001S',
+      'PT2.000002S',
+      'P1W2DT2H3M4.567890S',
+      'PT2H',
+      'P30D',
+      'P1DT1H30M15S',
+    ];
+    for (const iso of cases) {
+      const micros = isoDurationToMicroseconds(iso);
+      expect(micros).not.toBeNull();
+      // Повторный разбор нормализованной строки даёт те же микросекунды —
+      // diff/verify/миграции стабильны после round-trip
+      expect(
+        isoDurationToMicroseconds(microsecondsToIsoDuration(micros!)),
+      ).toBe(micros);
+    }
+  });
+
+  it('round-trips canonical strings byte-identically', () => {
+    // Каноническая форма: без недель (они рендерятся днями) и без
+    // хвостовых нулей в дробной части
+    const canonical = [
+      'PT0.5S',
+      'PT1.25S',
+      'PT0.000001S',
+      'PT2H',
+      'P30D',
+      'P1DT1H30M15S',
+    ];
+    for (const iso of canonical) {
+      expect(microsecondsToIsoDuration(isoDurationToMicroseconds(iso)!)).toBe(
+        iso,
+      );
+    }
+  });
+
+  it('normalizes equivalent spellings to identical microseconds', () => {
+    // Недели → дни, .567890 == .56789
+    expect(isoDurationToMicroseconds('P1W2DT2H3M4.567890S')).toBe(
+      isoDurationToMicroseconds('P9DT2H3M4.56789S'),
+    );
+  });
+
+  it('round-trips integer microseconds without loss', () => {
+    const values = [1, 999999, 1000000, 1500000, 3600000000, 86_400_000_000];
+    for (const micros of values) {
+      expect(isoDurationToMicroseconds(microsecondsToIsoDuration(micros))).toBe(
+        micros,
+      );
+    }
+  });
+});
+
+describe('TTL DDL units for numeric columns (#88)', () => {
+  const units = [
+    ['seconds', 'SECONDS'],
+    ['milliseconds', 'MILLISECONDS'],
+    ['microseconds', 'MICROSECONDS'],
+    ['nanoseconds', 'NANOSECONDS'],
+  ] as const;
+
+  it.each(units)(
+    'generates SET TTL with AS %s for numeric column',
+    (unit, sqlUnit) => {
+      expect(
+        generateSetTtlYql('events', {
+          interval: 'P1D',
+          column: 'created_at',
+          unit,
+        }),
+      ).toBe(
+        `ALTER TABLE \`events\` SET (TTL = Interval("P1D") ON \`created_at\` AS ${sqlUnit})`,
+      );
+    },
+  );
+
+  it.each(units)(
+    'puts AS %s into WITH clause of CREATE TABLE for Uint32 column',
+    (unit, sqlUnit) => {
+      const schema: ExpectedTableSchema = {
+        tableName: 'ttl_events',
+        columns: cols({ id: 'Utf8', created_at: 'Uint32' }),
+        primaryKey: ['id'],
+        indexes: [],
+        ttl: { interval: 'P7D', column: 'created_at', unit },
+      };
+
+      expect(generateCreateTableYql(schema)).toBe(
+        'CREATE TABLE `ttl_events` (\n' +
+          '  `id` Utf8,\n' +
+          '  `created_at` Uint32,\n' +
+          '  PRIMARY KEY (`id`)\n' +
+          ')\n' +
+          `WITH (\n  TTL = Interval("P7D") ON \`created_at\` AS ${sqlUnit}\n)`,
+      );
+    },
+  );
+
+  it.each([['Uint32'], ['Uint64'], ['DyNumber']] as const)(
+    `matches TTL on %s column by unit and seconds`,
+    (columnType) => {
+      const schema: ExpectedTableSchema = {
+        tableName: 'ttl_numeric',
+        columns: cols({ uuid: 'Uuid', expires_at: columnType }),
+        primaryKey: ['uuid'],
+        indexes: [],
+        ttl: {
+          interval: 'PT2H',
+          column: 'expires_at',
+          unit: 'milliseconds',
+        },
+      };
+      const description = (): YdbTableDescription => ({
+        columns: new Map(),
+        primaryKey: ['uuid'],
+        indexes: [],
+        ttl: {
+          column: 'expires_at',
+          expireAfterSeconds: 7200,
+          unit: 'milliseconds',
+        },
+      });
+
+      // Ровно 2 часа — совпадение независимо от типа числовой колонки
+      expect(checkTableSchema(schema, description()).ttlMismatches).toEqual([]);
+
+      const changed = checkTableSchema(schema, {
+        ...description(),
+        ttl: {
+          column: 'expires_at',
+          expireAfterSeconds: 7201,
+          unit: 'milliseconds',
+        },
+      });
+      expect(changed.ttlMismatches).toHaveLength(1);
+
+      // Расхождение unit тоже фиксируется
+      const wrongUnit = checkTableSchema(schema, {
+        ...description(),
+        ttl: {
+          column: 'expires_at',
+          expireAfterSeconds: 7200,
+          unit: 'seconds',
+        },
+      });
+      expect(wrongUnit.ttlMismatches).toHaveLength(1);
+    },
+  );
 });

--- a/test/ydb-ttl.spec.ts
+++ b/test/ydb-ttl.spec.ts
@@ -8,6 +8,8 @@ import { YdbBaseEntity } from '../src/entity/base-entity.js';
 import {
   YdbTtl,
   getYdbTtlMetadata,
+  isoDurationToSeconds,
+  secondsToIsoDuration,
   validateYdbTtlAgainstSchema,
 } from '../src/decorators/ttl.decorator.js';
 import {
@@ -399,5 +401,39 @@ describe('generateCreateTableYql with TTL', () => {
     ).toBe(
       'WITH (\n  TTL = Interval("P30D") ON `expires_at` AS MILLISECONDS\n)',
     );
+  });
+});
+
+describe('ISO 8601 duration helpers (#88)', () => {
+  it('converts ISO duration to seconds', () => {
+    expect(isoDurationToSeconds('PT2H')).toBe(7200);
+    expect(isoDurationToSeconds('P30D')).toBe(2592000);
+    expect(isoDurationToSeconds('P1DT2H30M')).toBe(95400);
+    expect(isoDurationToSeconds('PT90S')).toBe(90);
+    expect(isoDurationToSeconds('P1W')).toBe(604800);
+    // Семантически равные записи дают одно и то же число секунд
+    expect(isoDurationToSeconds('PT1H')).toBe(isoDurationToSeconds('PT60M'));
+  });
+
+  it('returns null for calendar parts and invalid strings', () => {
+    // У годов/месяцев нет фиксированной длины — сравнить с секундами нельзя
+    expect(isoDurationToSeconds('P1Y')).toBeNull();
+    expect(isoDurationToSeconds('P1M')).toBeNull();
+    expect(isoDurationToSeconds('2 hours')).toBeNull();
+    expect(isoDurationToSeconds('')).toBeNull();
+  });
+
+  it('converts seconds back to ISO duration', () => {
+    expect(secondsToIsoDuration(7200)).toBe('PT2H');
+    expect(secondsToIsoDuration(2592000)).toBe('P30D');
+    expect(secondsToIsoDuration(90000)).toBe('P1DT1H');
+    expect(secondsToIsoDuration(0)).toBe('PT0S');
+    expect(secondsToIsoDuration(-5)).toBe('PT0S');
+  });
+
+  it('round-trips seconds through ISO duration', () => {
+    for (const seconds of [1, 59, 3600, 86399, 86400, 90061, 2592000]) {
+      expect(isoDurationToSeconds(secondsToIsoDuration(seconds))).toBe(seconds);
+    }
   });
 });


### PR DESCRIPTION
## Что сделано

Реализация issue #88: `planMigration`/`diffSchemas` больше не теряют индексы, unique-флаги и TTL существующих таблиц.

### schema-sync
- **`checkToIssues`/`diffSchemas`**: `uniqueMismatches` конвертируются в issue с новым kind `unique-mismatch` (раньше `schema:verify` молча пропускал расхождение unique-флага).
- **TTL в сравнении actual/expected**:
  - `describeTable` парсит `ttlSettings` из DescribeTable в нормализованный `YdbTableTtl` (`{ column, expireAfterSeconds, unit? }`), enum Unit маппится в `YdbTtlUnit`;
  - `checkTableSchema` возвращает `missingTtl` / `ttlMismatches` / `extraTtl`;
  - новые kinds `ttl-missing`, `ttl-mismatch`, `ttl-extra` попадают в `verify()` и CLI diff.
- **Новые DDL-генераторы**, совместимые с #81 (то же выражение `TTL = Interval(...) ON col [AS unit]`):
  - `generateSetTtlYql` → `ALTER TABLE \`t\` SET (TTL = Interval("PT2H") ON \`col\` [AS SECONDS])`;
  - `generateResetTtlYql` → `ALTER TABLE \`t\` RESET (TTL)`.
- Интервалы сравниваются семантически в секундах (`PT1H == PT60M`); календарные части (годы/месяцы) несравнимы → считаются mismatch. Хелперы `isoDurationToSeconds` / `secondsToIsoDuration` экспортированы.

### migration-generator (`planMigration`)
- Отсутствующие индексы: `ADD INDEX` в up, `DROP INDEX` в down (в обратном порядке).
- TTL отсутствует: `SET (TTL = ...)` в up, `RESET (TTL)` в down.
- TTL изменён: `SET (новый)` в up, down восстанавливает прежние настройки из DescribeTable.
- **Лишние индексы и TTL никогда не удаляются автоматически** — только warning.
- Расхождение существующего индекса (unique/колонки) только диагностируется warning'ом.
- Политика для PK/типов колонок/лишних колонок не изменена.

### cli/diff.ts
- Стили новых kinds; `ttl-mismatch` рендерится как «было → стало».

## Тесты
- `src/schema/schema-sync.spec.ts`: unique-mismatch, missing/mismatch/extra TTL, семантическое сравнение интервалов, DDL SET/RESET TTL, `verify()`, парсинг ttlSettings из proto (date + numeric unit).
- `src/migrations/migration-generator.spec.ts`: индексы up/down, unique-индексы, лишние индексы (warning), диагностика mismatch, TTL set/reset/replace/extra.
- `test/cli/schema-diff.spec.ts`: рендеринг новых kinds.
- `test/ydb-ttl.spec.ts`: ISO duration ↔ секунды (round-trip).

`yarn test` — 438 passed, `yarn build` — ok, `yarn lint` — без новых замечаний.

Closes #88