### PR TITLE
fix(cli): устойчивый генератор миграций — антиколлизия имён файлов, валидные классы, валидация planMigration (#102)

### DIFF
--- a/src/cli/generators.spec.ts
+++ b/src/cli/generators.spec.ts
@@ -1,12 +1,14 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { jest } from '@jest/globals';
 import {
   createEntityFile,
   createMigrationFile,
   toKebabCase,
   toPascalCase,
   toSnakeCase,
+  toValidClassName,
 } from './generators.js';
 
 let dir: string;
@@ -26,6 +28,23 @@ describe('case utils', () => {
     expect(toPascalCase('UserProfile')).toBe('UserProfile');
     expect(toSnakeCase('UserProfile')).toBe('user_profile');
     expect(toKebabCase('UserProfile')).toBe('user-profile');
+  });
+});
+
+describe('toValidClassName (#102)', () => {
+  it('keeps valid identifiers untouched', () => {
+    expect(toValidClassName('create users')).toBe('CreateUsers');
+    expect(toValidClassName('UserProfile')).toBe('UserProfile');
+  });
+
+  it('prefixes digit-leading names so the class compiles', () => {
+    expect(toValidClassName('123')).toBe('Migration123');
+    expect(toValidClassName('2fa setup')).toBe('Migration2faSetup');
+  });
+
+  it('falls back to Migration when the name has no letters or digits', () => {
+    expect(toValidClassName('---')).toBe('Migration');
+    expect(toValidClassName('')).toBe('Migration');
   });
 });
 
@@ -78,5 +97,62 @@ describe('createMigrationFile', () => {
       'await executeSql(executor, "DROP TABLE `photos`");',
     );
     expect(content).toContain('WARNING: Table "photos": extra column "legacy"');
+  });
+
+  it('does not collide when called repeatedly at the same millisecond (#102)', () => {
+    // Фиксируем Date.now() в будущем (после любых реальных вызовов
+    // в других тестах): все три генерации попадают в одну миллисекунду.
+    const fixed = Date.now() + 60_000;
+    const spy = jest.spyOn(Date, 'now').mockReturnValue(fixed);
+    try {
+      const first = createMigrationFile(dir, 'add photos');
+      const second = createMigrationFile(dir, 'add photos');
+      const third = createMigrationFile(dir, 'add photos');
+
+      expect(first.name).toBe(`${fixed}-AddPhotos`);
+      expect(second.name).toBe(`${fixed}-AddPhotos-1`);
+      expect(third.name).toBe(`${fixed}-AddPhotos-2`);
+
+      for (const created of [first, second, third]) {
+        expect(fs.existsSync(created.filePath)).toBe(true);
+      }
+
+      // Лексикографическая сортировка загрузчика сохраняет хронологию:
+      // порядок имён после сортировки совпадает с порядком генерации.
+      expect([first.name, second.name, third.name].sort()).toEqual([
+        first.name,
+        second.name,
+        third.name,
+      ]);
+
+      // Имена классов уникальны и являются валидными идентификаторами.
+      const classNames = [first, second, third].map(
+        (created) =>
+          fs
+            .readFileSync(created.filePath, 'utf-8')
+            .match(/export class (\w+) implements/)?.[1],
+      );
+      expect(new Set(classNames).size).toBe(3);
+      for (const className of classNames) {
+        expect(className).toMatch(/^[A-Za-z_$][A-Za-z0-9_$]*$/);
+      }
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('generates a compilable class for names without letters or with leading digits (#102)', () => {
+    const fromDigits = createMigrationFile(dir, '123');
+    const fromSymbols = createMigrationFile(dir, '---');
+    const fromMixed = createMigrationFile(dir, '2fa setup');
+
+    for (const created of [fromDigits, fromSymbols, fromMixed]) {
+      const content = fs.readFileSync(created.filePath, 'utf-8');
+      const className = content.match(/export class (\w+) implements/)?.[1];
+      // Класс не может начинаться с цифры — иначе файл не скомпилируется.
+      expect(className).toMatch(/^[A-Za-z_$][A-Za-z0-9_$]*$/);
+      expect(content).toContain(`readonly name = "${created.name}";`);
+      expect(path.basename(created.filePath)).toBe(`${created.name}.ts`);
+    }
   });
 });

--- a/src/cli/generators.ts
+++ b/src/cli/generators.ts
@@ -31,6 +31,18 @@ export function toKebabCase(input: string): string {
     .join('-');
 }
 
+/**
+ * Гарантирует валидный TypeScript-идентификатор класса (#102): `toPascalCase`
+ * от имени без буквенных слов ('123', '---') возвращает пустую строку или
+ * строку с ведущей цифрой — такой класс не скомпилируется. Валидные имена
+ * возвращаются без изменений (обратная совместимость).
+ */
+export function toValidClassName(input: string): string {
+  const name = toPascalCase(input);
+  if (!name || /^[0-9]/.test(name)) return `Migration${name}`;
+  return name;
+}
+
 export interface CreatedFile {
   filePath: string;
   name: string;
@@ -47,21 +59,53 @@ function writeFile(dir: string, fileName: string, content: string): string {
 }
 
 /**
+ * Последние использованные timestamp и суффикс: защита от коллизии имён
+ * файлов миграций (#102). `Date.now()` имеет миллисекундную точность —
+ * две генерации в пределах одной миллисекунды (или при скачке часов назад)
+ * обязаны получить разные имена, иначе writeFile падает на существующем файле.
+ */
+let lastTimestamp = 0;
+let lastSuffix = 0;
+
+/**
  * Создаёт файл миграции. Без плана — пустой шаблон (migration:create),
  * с планом — заполненный DDL (migration:generate).
+ *
+ * Имя файла — `<timestamp>-<Name>`; повторная генерация в ту же миллисекунду
+ * получает антиколлизионный суффикс `-1`, `-2`, … (#102). Лексикографическая
+ * сортировка загрузчика сохраняется: все timestamps одной длины, короткое
+ * имя (без суффикса) идёт раньше длиннее.
  */
 export function createMigrationFile(
   dir: string,
   name: string,
   plan?: PlannedMigration,
 ): CreatedFile {
-  const timestamp = Date.now();
-  const baseName = `${timestamp}-${toPascalCase(name)}`;
+  const now = Date.now();
+  let timestamp: number;
+  let suffix: number | null = null;
+  if (now > lastTimestamp) {
+    timestamp = now;
+    lastSuffix = 0;
+  } else {
+    timestamp = lastTimestamp;
+    lastSuffix += 1;
+    suffix = lastSuffix;
+  }
+  lastTimestamp = timestamp;
+
+  const pascal = toValidClassName(name);
+  const baseName =
+    suffix === null
+      ? `${timestamp}-${pascal}`
+      : `${timestamp}-${pascal}-${suffix}`;
   const filePath = writeFile(
     dir,
     `${baseName}.ts`,
     renderMigrationFile(
-      `${toPascalCase(name)}${timestamp}`,
+      suffix === null
+        ? `${pascal}${timestamp}`
+        : `${pascal}${timestamp}_${suffix}`,
       baseName,
       plan ?? { up: [], down: [], warnings: [] },
     ),

--- a/src/migrations/migration-generator.spec.ts
+++ b/src/migrations/migration-generator.spec.ts
@@ -351,6 +351,39 @@ describe('planMigration', () => {
   });
 });
 
+describe('planMigration input validation (#102)', () => {
+  it('rejects non-array inputs with a clear error', () => {
+    const wrongExpected = () =>
+      planMigration(
+        expected as unknown as ExpectedTableSchema[],
+        undefined as unknown as (YdbTableDescription | null)[],
+      );
+    expect(wrongExpected).toThrow(TypeError);
+    expect(wrongExpected).toThrow(/"expected" must be an array/);
+
+    const wrongExisting = () =>
+      planMigration(
+        [expected],
+        null as unknown as (YdbTableDescription | null)[],
+      );
+    expect(wrongExisting).toThrow(TypeError);
+    expect(wrongExisting).toThrow(/"existing" must be an array/);
+  });
+
+  it('rejects mismatched array lengths instead of matching positionally', () => {
+    expect(() => planMigration([expected], [])).toThrow(
+      /"expected" \(1\) and "existing" \(0\) must have the same length/,
+    );
+    expect(() => planMigration([], [null])).toThrow(
+      /"expected" \(0\) and "existing" \(1\) must have the same length/,
+    );
+  });
+
+  it('mentions the involved tables in the length-mismatch error', () => {
+    expect(() => planMigration([expected], [])).toThrow(/photos/);
+  });
+});
+
 describe('renderMigrationFile', () => {
   it('renders a migration class with up/down statements', () => {
     const content = renderMigrationFile(

--- a/src/migrations/migration-generator.ts
+++ b/src/migrations/migration-generator.ts
@@ -38,6 +38,40 @@ function ttlMetaFromActual(actual: YdbTableTtl): YdbTtlMetadata {
 }
 
 /**
+ * Валидирует входы planMigration (#102). Массивы сопоставляются строго
+ * по индексу (expected[i] ↔ existing[i]) — это часть публичного контракта,
+ * поэтому расхождение длин должно падать с понятной ошибкой, а не молча
+ * порождать неверный DDL.
+ */
+function validatePlanInputs(
+  expected: ExpectedTableSchema[],
+  existing: (YdbTableDescription | null)[],
+): void {
+  if (!Array.isArray(expected)) {
+    throw new TypeError(
+      'planMigration: "expected" must be an array of ExpectedTableSchema',
+    );
+  }
+  if (!Array.isArray(existing)) {
+    throw new TypeError(
+      'planMigration: "existing" must be an array of YdbTableDescription or null',
+    );
+  }
+  if (expected.length !== existing.length) {
+    const expectedTables = expected
+      .map((schema) => schema?.tableName)
+      .filter(Boolean)
+      .join(', ');
+    throw new Error(
+      `planMigration: "expected" (${expected.length}) and "existing" ` +
+        `(${existing.length}) must have the same length — entries are matched ` +
+        `positionally (expected[i] <-> existing[i])` +
+        (expectedTables ? `; expected tables: ${expectedTables}` : ''),
+    );
+  }
+}
+
+/**
  * Чистая функция: строит план миграции по ожидаемым схемам сущностей
  * и текущему состоянию БД (null — таблицы нет).
  * Используется `migration:generate`.
@@ -53,6 +87,8 @@ export function planMigration(
   expected: ExpectedTableSchema[],
   existing: (YdbTableDescription | null)[],
 ): PlannedMigration {
+  validatePlanInputs(expected, existing);
+
   const up: string[] = [];
   const down: string[] = [];
   const warnings: string[] = [];


### PR DESCRIPTION
## Summary

Fixes #102 — три проблемы генератора миграций:

1. **Коллизия имён файлов.** `createMigrationFile` строил имя из `Date.now()`; две генерации в пределах одной миллисекунды давали одно имя и `writeFile` падал с "File already exists". Теперь повторные вызовы в ту же миллисекунду (а также при скачке часов назад) получают антиколлизионный суффикс `-1`, `-2`, … Лексикографическая сортировка загрузчика миграций сохраняется: timestamps одной длины, короткое имя идёт раньше длиннее.

2. **Невалидное имя класса.** `className = Pascal(name) + timestamp`: если name не содержит буквенных слов (`'---'`) или начинается с цифры (`'123'`), класс начинался с цифры и файл не компилировался. Новый санитайзер `toValidClassName` добавляет префикс `Migration`; валидные имена возвращаются без изменений (обратная совместимость).

3. **Хрупкий контракт `planMigration()`.** Сопоставление `expected[i]`/`existing[i]` строго по индексу без валидации входа: при расхождении длин молча порождался неверный DDL. Теперь не-массив даёт `TypeError`, расхождение длин — понятная ошибка с числом элементов и списком ожидаемых таблиц.

Сгенерированный SQL и семантика миграций не изменены.

## Testing

- Регрессионные тесты в `src/cli/generators.spec.ts`: три генерации с одним замоканным `Date.now()` → уникальные файлы/классы, порядок сортировки сохранён; имена без букв/с ведущей цифрой → компилируемый класс.
- Тесты валидации `planMigration` в `src/migrations/migration-generator.spec.ts`.
- `yarn test` — 513 passed (37 suites), `yarn build`, `yarn lint` — 0 errors.