### PR TITLE
fix(cli): строгий разбор флагов, диагностика ошибок, цвет по целевому потоку и надёжный поиск конфига (#103)

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,9 +317,9 @@ ydb-orm entity:create UserProfile         # сущность ./src/user-profile.
 ydb-orm completion bash                   # скрипт shell-автодополнения (bash|zsh|fish)
 ```
 
-Опции: `--dir <path>` (директория миграций, по умолчанию `./migrations`; для `entity:create` — `./src`), `--config <path>`, `--json` (для `migration:show`/`migration:check`).
+Опции: `--dir <path>` (директория миграций, по умолчанию `./migrations`; для `entity:create` — `./src`), `--config <path>`, `--json` (для `migration:show`/`migration:check`), `--verbose` (полный стек ошибки и цепочка cause при сбое). Неизвестные флаги и пустые значения опций считаются ошибкой.
 
-`migration:generate` и `schema:verify` печатают цветной diff расхождений «сущности vs БД», сгруппированный по таблицам; цвета отключаются при выводе не в TTY или переменной `NO_COLOR`.
+`migration:generate` и `schema:verify` печатают цветной diff расхождений «сущности vs БД», сгруппированный по таблицам; цвет определяется по потоку, куда попадает вывод (для `schema:verify` это stderr), отключается при выводе не в TTY или переменной `NO_COLOR`.
 
 Автодополнение команд и флагов для шелла:
 
@@ -332,7 +332,7 @@ ydb-orm completion zsh > ~/.zsh/completions/_ydb-orm
 ydb-orm completion fish > ~/.config/fish/completions/ydb-orm.fish
 ```
 
-Конфиг подключения — `./ydb-orm.config.ts` (или `.mts`/`.mjs`/`.js`; также ищется в `./src/`):
+Конфиг подключения — `./ydb-orm.config.ts` (или `.mts`/`.mjs`/`.js`; ищется в текущей директории и выше, до корня ФС; поддерживается как default, так и именованный экспорт):
 
 ```ts
 import { UserEntity } from './src/user.entity.js';

--- a/src/cli/args.spec.ts
+++ b/src/cli/args.spec.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from '@jest/globals';
+import { CliArgsError, formatError, parseArgs } from './args.js';
+
+describe('parseArgs (#103)', () => {
+  it('parses command with positional and boolean flags', () => {
+    const args = parseArgs(['migration:show', 'extra', '--json', '--verbose']);
+
+    expect(args).toMatchObject({
+      command: 'migration:show',
+      positional: 'extra',
+      json: true,
+      verbose: true,
+    });
+  });
+
+  it('parses --config/--dir values', () => {
+    const args = parseArgs([
+      '--config',
+      'custom.config.ts',
+      '--dir',
+      './migrations',
+      'migration:run',
+    ]);
+
+    expect(args.config).toBe('custom.config.ts');
+    expect(args.dir).toBe('./migrations');
+    expect(args.command).toBe('migration:run');
+  });
+
+  it('supports --flag=value syntax', () => {
+    const args = parseArgs(['migration:run', '--dir=./db/migrations']);
+
+    expect(args.dir).toBe('./db/migrations');
+    expect(args.command).toBe('migration:run');
+  });
+
+  it('rejects unknown flag instead of making it positional', () => {
+    // Раньше `migration:create --nme foo` создавал миграцию с именем «--nme».
+    expect(() => parseArgs(['migration:create', '--nme', 'foo'])).toThrow(
+      CliArgsError,
+    );
+    expect(() => parseArgs(['migration:create', '--nme', 'foo'])).toThrow(
+      /Unknown option: --nme/,
+    );
+  });
+
+  it('rejects unknown short flag', () => {
+    expect(() => parseArgs(['migration:run', '-x'])).toThrow(
+      /Unknown option: -x/,
+    );
+  });
+
+  it('rejects missing value at end of argv for value flags', () => {
+    // Раньше `--config` без значения тихо откатывался к env/дефолту.
+    expect(() => parseArgs(['migration:run', '--config'])).toThrow(
+      /Option --config requires a non-empty value/,
+    );
+    expect(() => parseArgs(['migration:show', '--dir'])).toThrow(
+      /Option --dir requires a non-empty value/,
+    );
+  });
+
+  it('rejects empty string value', () => {
+    expect(() => parseArgs(['migration:run', '--config', ''])).toThrow(
+      /Option --config requires a non-empty value/,
+    );
+    expect(() => parseArgs(['migration:run', '--dir='])).toThrow(
+      /Option --dir requires a non-empty value/,
+    );
+  });
+
+  it('rejects whitespace-only value', () => {
+    expect(() => parseArgs(['migration:run', '--dir', '   '])).toThrow(
+      /Option --dir requires a non-empty value/,
+    );
+  });
+
+  it('rejects next flag instead of treating it as value', () => {
+    expect(() =>
+      parseArgs(['migration:run', '--config', '--dir', './m']),
+    ).toThrow(/Option --config requires a non-empty value/);
+  });
+
+  it('rejects extra positional arguments instead of ignoring them', () => {
+    expect(() => parseArgs(['entity:create', 'user', 'photo'])).toThrow(
+      CliArgsError,
+    );
+    expect(() => parseArgs(['entity:create', 'user', 'photo'])).toThrow(
+      /Unexpected extra argument\(s\): photo/,
+    );
+  });
+
+  it('recognizes -h/--help anywhere without a command', () => {
+    expect(parseArgs(['--help']).help).toBe(true);
+    expect(parseArgs(['-h']).help).toBe(true);
+    expect(parseArgs(['schema:verify', '--help']).help).toBe(true);
+  });
+
+  it('treats bare "-" as positional, not as an option', () => {
+    const args = parseArgs(['-']);
+    expect(args.command).toBe('-');
+  });
+});
+
+describe('formatError (#103)', () => {
+  it('keeps the message only by default', () => {
+    const error = new Error('boom', { cause: new Error('root cause') });
+    const out = formatError(error);
+
+    expect(out).toContain('boom');
+    expect(out).not.toContain('at '); // стек не печатается без verbose
+  });
+
+  it('preserves the cause chain by default', () => {
+    // Раньше в catch печатался только error.message.
+    const error = new Error('boom', {
+      cause: new Error('middle', { cause: new Error('root') }),
+    });
+
+    expect(formatError(error)).toBe(
+      ['boom', 'Caused by: middle', 'Caused by: root'].join('\n'),
+    );
+  });
+
+  it('prints full stacks of every cause in verbose mode', () => {
+    const root = new Error('root');
+    const error = new Error('boom', { cause: root });
+    const out = formatError(error, { verbose: true });
+
+    expect(out).toContain('Error: boom');
+    expect(out).toContain('Caused by: Error: root');
+    expect(out).toMatch(/\n\s+at /); // реальные кадры стека сохранены
+  });
+
+  it('prints context lines first in verbose mode', () => {
+    const out = formatError(new Error('boom'), {
+      verbose: true,
+      context: ['cwd: /tmp'],
+    });
+
+    expect(out).toMatch(/^\[ydb-orm\] cwd: \/tmp\n/);
+  });
+
+  it('formats non-error throwables', () => {
+    expect(formatError('plain string')).toBe('Unexpected error: plain string');
+    expect(formatError(undefined)).toBe('Unexpected error: undefined');
+  });
+});

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,0 +1,200 @@
+/**
+ * Разбор аргументов командной строки CLI (#103).
+ *
+ * Раньше неизвестные флаги молча становились позиционными аргументами
+ * (`migration:create --nme foo` создавал миграцию с именем «--nme»),
+ * а `--config`/`--dir` без значения тихо откатывались к дефолтам/env.
+ * Теперь разбор строгий: неизвестный флаг или пустое значение — ошибка.
+ */
+
+/** Ошибка разбора аргументов — печатается без стека, но с подсказкой. */
+export class CliArgsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CliArgsError';
+  }
+}
+
+export interface CliArgs {
+  command?: string;
+  positional?: string;
+  config?: string;
+  dir?: string;
+  json?: boolean;
+  asApplied?: boolean;
+  asReverted?: boolean;
+  verbose?: boolean;
+  help?: boolean;
+}
+
+/** Флаги, принимающие значение (арность 1). */
+const VALUE_FLAGS = new Set(['--config', '--dir']);
+
+/** Булевы флаги (арность 0). */
+const BOOLEAN_FLAGS = new Set([
+  '--json',
+  '--as-applied',
+  '--as-reverted',
+  '--verbose',
+  '--help',
+  '-h',
+]);
+
+function isFlagLike(token: string): boolean {
+  return token.startsWith('-') && token !== '-';
+}
+
+function requireValue(flag: string, value?: string): string {
+  if (value === undefined || value.trim() === '') {
+    throw new CliArgsError(
+      `Option ${flag} requires a non-empty value ` +
+        `(example: ydb-orm migration:run ${flag} ./migrations).`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Строго разбирает argv:
+ *  - неизвестный флаг (`--nme`, `-x`) — ошибка, а не позиционный аргумент;
+ *  - `--config`/`--dir` без значения, с пустой строкой или со следующим
+ *    флагом вместо значения — ошибка, а не тихий дефолт;
+ *  - поддерживается синтаксис `--flag=value`;
+ *  - больше одного позиционного аргумента после команды — ошибка,
+ *    лишние аргументы больше не игнорируются молча.
+ */
+export function parseArgs(argv: string[]): CliArgs {
+  const result: CliArgs = {};
+  const rest: string[] = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+
+    if (!isFlagLike(token)) {
+      rest.push(token);
+      continue;
+    }
+
+    let flag = token;
+    let inlineValue: string | undefined;
+    const eqIndex = token.indexOf('=');
+    if (eqIndex > 0) {
+      flag = token.slice(0, eqIndex);
+      inlineValue = token.slice(eqIndex + 1);
+    }
+
+    if (VALUE_FLAGS.has(flag)) {
+      if (inlineValue === undefined) {
+        const next = argv[i + 1];
+        // Следующий флаг вместо значения — почти наверняка опечатка:
+        // `--config --dir x` не должен превращаться в config="--dir".
+        if (next === undefined || isFlagLike(next)) {
+          i++;
+          throw new CliArgsError(
+            `Option ${flag} requires a non-empty value ` +
+              `(example: ydb-orm migration:run ${flag} ./migrations).`,
+          );
+        }
+        result[flag === '--config' ? 'config' : 'dir'] = requireValue(
+          flag,
+          next,
+        );
+        i++;
+        continue;
+      }
+      result[flag === '--config' ? 'config' : 'dir'] = requireValue(
+        flag,
+        inlineValue,
+      );
+      continue;
+    }
+
+    if (BOOLEAN_FLAGS.has(flag)) {
+      switch (flag) {
+        case '--json':
+          result.json = true;
+          break;
+        case '--as-applied':
+          result.asApplied = true;
+          break;
+        case '--as-reverted':
+          result.asReverted = true;
+          break;
+        case '--verbose':
+          result.verbose = true;
+          break;
+        case '--help':
+        case '-h':
+          result.help = true;
+          break;
+      }
+      continue;
+    }
+
+    throw new CliArgsError(
+      `Unknown option: ${flag}. ` +
+        "Run 'ydb-orm --help' to list available options.",
+    );
+  }
+
+  if (rest.length > 2) {
+    throw new CliArgsError(
+      `Unexpected extra argument(s): ${rest.slice(2).join(', ')}.`,
+    );
+  }
+  [result.command, result.positional] = rest;
+  return result;
+}
+
+interface ErrorWithCause {
+  message: string;
+  stack?: string;
+  cause?: unknown;
+}
+
+function errorChain(error: unknown): ErrorWithCause[] {
+  const chain: ErrorWithCause[] = [];
+  let current = error;
+  while (current instanceof Error && chain.length < 10) {
+    chain.push(current);
+    current = (current as ErrorWithCause).cause;
+  }
+  return chain;
+}
+
+/**
+ * Форматирует ошибку для вывода в stderr (#103):
+ *  - по умолчанию — сообщение и цепочка cause («Caused by: ...»);
+ *  - при verbose — строки context, затем полный стек каждого звена цепочки.
+ * Раньше печатался только error.message — стек и причина терялись.
+ */
+export function formatError(
+  error: unknown,
+  options?: { verbose?: boolean; context?: string[] },
+): string {
+  const lines: string[] = [];
+
+  if (options?.verbose && options.context?.length) {
+    lines.push(...options.context.map((line) => `[ydb-orm] ${line}`), '');
+  }
+
+  if (!(error instanceof Error)) {
+    lines.push(`Unexpected error: ${String(error)}`);
+    return lines.join('\n');
+  }
+
+  const chain = errorChain(error);
+  for (let i = 0; i < chain.length; i++) {
+    const entry = chain[i];
+    const prefix = i === 0 ? '' : 'Caused by: ';
+    if (options?.verbose && entry.stack) {
+      lines.push(prefix + entry.stack);
+    } else if (i === 0) {
+      lines.push(entry.message);
+    } else {
+      lines.push(`${prefix}${entry.message}`);
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -14,6 +14,7 @@ import { connectCli, loadCliConfig } from './config.js';
 import { createEntityFile, createMigrationFile } from './generators.js';
 import { renderCompletionScript } from './completion.js';
 import { renderSchemaDiff } from './diff.js';
+import { CliArgsError, formatError, parseArgs, CliArgs } from './args.js';
 
 const HELP = `ydb-orm — CLI для миграций и генерации кода
 
@@ -30,45 +31,47 @@ const HELP = `ydb-orm — CLI для миграций и генерации ко
   ydb-orm completion <bash|zsh|fish>  Скрипт shell-автодополнения (в stdout)
 
 Опции:
-  --config <path>   Путь к конфигу (по умолчанию ./ydb-orm.config.ts|mts|mjs|js,
-                    иначе env: YDB_ENDPOINT, YDB_AUTH_TYPE,
-                    YDB_AUTHORIZED_KEY_PATH)
+  --config <path>   Путь к конфигу (ищется в CWD и выше:
+                    ydb-orm.config.ts|mts|mjs|js, иначе env: YDB_ENDPOINT,
+                    YDB_AUTH_TYPE, YDB_AUTHORIZED_KEY_PATH)
   --dir <path>      Директория миграций (по умолчанию ./migrations)
                     или сущностей для entity:create (по умолчанию ./src)
   --json            JSON-вывод (для migration:show и migration:check)
+  --verbose         Полный стек ошибки и цепочка cause при сбое
+  -h, --help        Эта справка
 
+Неизвестные флаги и пустые значения опций считаются ошибкой (#103).
 `;
 
-interface ParsedArgs {
-  command?: string;
-  positional?: string;
-  config?: string;
-  dir?: string;
-  json?: boolean;
-  asApplied?: boolean;
-  asReverted?: boolean;
-}
-
-function parseArgs(argv: string[]): ParsedArgs {
-  const result: ParsedArgs = {};
-  const rest: string[] = [];
-  for (let i = 0; i < argv.length; i++) {
-    if (argv[i] === '--config') result.config = argv[++i];
-    else if (argv[i] === '--dir') result.dir = argv[++i];
-    else if (argv[i] === '--json') result.json = true;
-    else if (argv[i] === '--as-applied') result.asApplied = true;
-    else if (argv[i] === '--as-reverted') result.asReverted = true;
-    else rest.push(argv[i]);
-  }
-  [result.command, result.positional] = rest;
-  return result;
-}
-
 async function main(): Promise<void> {
-  const args = parseArgs(process.argv.slice(2));
+  let args: CliArgs = {};
+  try {
+    args = parseArgs(process.argv.slice(2));
+    await runCommand(args);
+  } catch (error) {
+    process.exitCode = 1;
+    const verbose = args.verbose === true;
+    console.error(
+      formatError(error, {
+        verbose,
+        // Полезная диагностика окружения при verbose (#103).
+        context: [
+          `cwd: ${process.cwd()}`,
+          `argv: ${JSON.stringify(process.argv.slice(2))}`,
+          `node: ${process.version}`,
+        ],
+      }),
+    );
+    if (!verbose && !(error instanceof CliArgsError)) {
+      console.error('\nRun with --verbose for the full stack trace.');
+    }
+  }
+}
+
+async function runCommand(args: CliArgs): Promise<void> {
   const command = args.command;
 
-  if (!command || command === '--help' || command === '-h') {
+  if (!command || args.help) {
     console.log(HELP);
     return;
   }
@@ -77,7 +80,7 @@ async function main(): Promise<void> {
     try {
       console.log(renderCompletionScript(args.positional ?? ''));
     } catch (error) {
-      console.error((error as Error).message);
+      console.error(formatError(error));
       process.exitCode = 1;
     }
     return;
@@ -169,7 +172,11 @@ async function main(): Promise<void> {
         console.log('Schema OK — no issues found');
       } else {
         console.error(`Found ${issues.length} schema issue(s):`);
-        console.error(renderSchemaDiff(issues));
+        // Расхождения пишутся в stderr — цвет решаем по stderr, а не по
+        // stdout (#103): при `ydb-orm schema:verify 2>issues.txt` ANSI-коды
+        // не должны уезжать в перенаправленный файл, а при
+        // `... | cat` — теряться, если stderr остался TTY.
+        console.error(renderSchemaDiff(issues, { stream: process.stderr }));
         process.exitCode = 1;
       }
     } finally {
@@ -328,7 +335,4 @@ function requireEntityMeta(entity: any) {
   return meta;
 }
 
-main().catch((error: unknown) => {
-  console.error((error as Error).message);
-  process.exitCode = 1;
-});
+main();

--- a/src/cli/completion.ts
+++ b/src/cli/completion.ts
@@ -33,13 +33,14 @@ export const CLI_COMMANDS: CliCommand[] = [
   { name: 'completion', description: 'Print shell completion script' },
 ];
 
-/** Флаги, которые парсит CLI (см. parseArgs в cli.ts). */
+/** Флаги, которые парсит CLI (см. parseArgs в args.ts). */
 export const CLI_FLAGS = [
   '--config',
   '--dir',
   '--json',
   '--as-applied',
   '--as-reverted',
+  '--verbose',
 ];
 
 /** Поддерживаемые шеллы. */
@@ -122,7 +123,8 @@ ${commands}
             '--dir[Migrations/entities directory]:directory:_files -/' \\
             '--json[JSON output]' \\
             '--as-applied[Repair: mark migration as applied]' \\
-            '--as-reverted[Repair: remove bookkeeping record]'
+            '--as-reverted[Repair: remove bookkeeping record]' \\
+            '--verbose[Full error stack and cause chain]'
           ;;
       esac
       ;;
@@ -161,6 +163,7 @@ function renderFish(): string {
     "complete -c ydb-orm -l json -d 'JSON output'",
     "complete -c ydb-orm -l as-applied -d 'Repair: mark migration as applied'",
     "complete -c ydb-orm -l as-reverted -d 'Repair: remove bookkeeping record'",
+    "complete -c ydb-orm -l verbose -d 'Full error stack and cause chain'",
   );
   return lines.join('\n') + '\n';
 }

--- a/src/cli/config.spec.ts
+++ b/src/cli/config.spec.ts
@@ -1,0 +1,152 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, afterEach, beforeEach, expect, it } from '@jest/globals';
+import {
+  extractCliConfig,
+  findDefaultConfig,
+  loadCliConfig,
+} from './config.js';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ydb-orm-config-'));
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('extractCliConfig (#103)', () => {
+  const endpoint = 'grpc://localhost:2136/local';
+
+  it('accepts a default export object', () => {
+    const config = { endpoint };
+    expect(extractCliConfig({ default: config }, 'cfg.ts')).toBe(config);
+  });
+
+  it('accepts a named export instead of the default one', () => {
+    // Раньше понимался только default export: файл с named экспортом
+    // давал ложную ошибку «endpoint is required».
+    const config = { endpoint };
+    expect(extractCliConfig({ config }, 'cfg.ts')).toBe(config);
+    expect(extractCliConfig({ cliConfig: config }, 'cfg.ts')).toBe(config);
+  });
+
+  it('prefers default over named exports when they differ', () => {
+    const config = { endpoint };
+    const named = { endpoint: 'grpc://other:2136/local' };
+
+    expect(extractCliConfig({ config: named, default: config }, 'cfg.ts')).toBe(
+      config,
+    );
+  });
+
+  it('treats default and named exports of the same object as one candidate', () => {
+    const config = {
+      endpoint,
+      migrationsDir: './migrations',
+      entities: [],
+    };
+    const mod = { config, default: config };
+
+    expect(extractCliConfig(mod, 'cfg.ts')).toBe(config);
+  });
+
+  it('reports an ambiguity between several named exports', () => {
+    const mod = {
+      a: { endpoint },
+      b: { endpoint },
+    };
+
+    expect(() => extractCliConfig(mod, 'cfg.ts')).toThrow(
+      /multiple exports look like a CLI config \(a, b\)/,
+    );
+  });
+
+  it('lists actual exports when nothing looks like a config', () => {
+    expect(() => extractCliConfig({ helper: 42 }, 'cfg.ts')).toThrow(
+      /expected a default or named export with an "endpoint" \(found exports: helper\)/,
+    );
+    expect(() => extractCliConfig({}, 'cfg.ts')).toThrow(
+      /\(found exports: none\)/,
+    );
+  });
+
+  it('names the offending export when endpoint is missing', () => {
+    expect(() =>
+      extractCliConfig({ config: { migrationsDir: './m' } }, 'cfg.ts'),
+    ).toThrow(/"endpoint" is required/);
+    expect(() =>
+      extractCliConfig({ config: { migrationsDir: './m' } }, 'cfg.ts'),
+    ).toThrow(/\("config"\)/);
+  });
+});
+
+describe('findDefaultConfig (#103)', () => {
+  it('searches upwards through parent directories', () => {
+    const nested = path.join(dir, 'a', 'b');
+    fs.mkdirSync(nested, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'ydb-orm.config.mjs'), '', 'utf-8');
+
+    expect(findDefaultConfig(nested)).toBe(
+      path.join(dir, 'ydb-orm.config.mjs'),
+    );
+  });
+
+  it('respects extension priority inside one directory', () => {
+    fs.writeFileSync(path.join(dir, 'ydb-orm.config.js'), '', 'utf-8');
+    fs.writeFileSync(path.join(dir, 'ydb-orm.config.mts'), '', 'utf-8');
+
+    expect(findDefaultConfig(dir)).toBe(path.join(dir, 'ydb-orm.config.mts'));
+  });
+
+  it('returns undefined when nothing found up to the filesystem root', () => {
+    expect(findDefaultConfig(dir)).toBeUndefined();
+  });
+});
+
+describe('loadCliConfig (#103)', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('loads a named-export .mjs config found above the start directory', async () => {
+    fs.writeFileSync(
+      path.join(dir, 'ydb-orm.config.mjs'),
+      `export const config = {
+        endpoint: 'grpc://named:2136/local',
+        migrationsDir: './migrations',
+      };`,
+      'utf-8',
+    );
+    const nested = path.join(dir, 'nested');
+    fs.mkdirSync(nested);
+
+    const config = await loadCliConfig(undefined, nested);
+
+    expect(config.endpoint).toBe('grpc://named:2136/local');
+    expect(config.migrationsDir).toBe('./migrations');
+  });
+
+  it('fails clearly when --config points to a missing file', async () => {
+    await expect(loadCliConfig('./no-such.config.ts', dir)).rejects.toThrow(
+      new RegExp(`Config file not found: .*no-such\\.config\\.ts`),
+    );
+  });
+
+  it('falls back to env variables when no config exists', async () => {
+    delete process.env.YDB_ENDPOINT;
+    delete process.env.YDB_CONNECTION_STRING;
+    delete process.env.YDB_AUTH_TYPE;
+    process.env.YDB_ENDPOINT = 'grpc://env:2136/local';
+
+    const config = await loadCliConfig(undefined, dir);
+
+    expect(config.endpoint).toBe('grpc://env:2136/local');
+    expect(config.auth_type).toBe('anonymous');
+  });
+});

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -21,24 +21,115 @@ const DEFAULT_CONFIG_NAMES = [
 ];
 
 /**
+ * Похож ли экспорт модуля на CLI-конфиг (#103).
+ * Нужен, чтобы поддержать именованные экспорты конфига:
+ * раньше понимался только default, и файл вида
+ * `export const config = { endpoint: ... }` давал ложную ошибку
+ * «endpoint is required».
+ */
+function looksLikeConfig(value: unknown): value is YdbCliConfig {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const obj = value as Record<string, any>;
+  return (
+    typeof obj.endpoint === 'string' ||
+    Array.isArray(obj.entities) ||
+    typeof obj.migrationsDir === 'string'
+  );
+}
+
+/**
+ * Достаёт конфиг из импортированного модуля конфигурации.
+ * Поддерживает default export и именованные экспорты; при нескольких
+ * разных подходящих экспортах приоритет у `default`, иначе — неоднозначность
+ * (ошибка со списком кандидатов), а не молчаливый выбор первого (#103).
+ * Отсутствие endpoint — ошибка с указанием файла и имени экспорта.
+ */
+export function extractCliConfig(
+  mod: Record<string, unknown>,
+  file: string,
+): YdbCliConfig {
+  const candidates = Object.entries(mod).filter(([, value]) =>
+    looksLikeConfig(value),
+  ) as [string, YdbCliConfig][];
+
+  if (candidates.length === 0) {
+    throw new Error(
+      `Config ${file}: expected a default or named export with an "endpoint" ` +
+        `(found exports: ${Object.keys(mod).join(', ') || 'none'}).`,
+    );
+  }
+
+  // Дедупликация по значению: default и именованный экспорт одного
+  // и того же объекта — один кандидат.
+  const byValue = new Map<YdbCliConfig, string[]>();
+  for (const [name, value] of candidates) {
+    const names = byValue.get(value) ?? [];
+    names.push(name);
+    byValue.set(value, names);
+  }
+
+  const defaultCandidate = candidates.find(([name]) => name === 'default');
+  if (byValue.size > 1 && !defaultCandidate) {
+    const allNames = [...byValue.values()].flat().sort().join(', ');
+    throw new Error(
+      `Config ${file}: multiple exports look like a CLI config ` +
+        `(${allNames}). Keep exactly one or use the default export.`,
+    );
+  }
+  const [exportName, config] =
+    byValue.size > 1 ? defaultCandidate! : candidates[0];
+
+  if (!config.endpoint) {
+    throw new Error(
+      `Config ${file} ("${exportName}"): "endpoint" is required.`,
+    );
+  }
+  return config;
+}
+
+/**
+ * Ищет дефолтный конфиг в startDir и вверх по дереву каталогов до корня ФС
+ * (#103). Раньше поиск шёл только в CWD — запуск из вложенной директории
+ * монорепо не находил конфиг в корне проекта. В одной директории приоритет:
+ * .ts → .mts → .mjs → .js.
+ */
+export function findDefaultConfig(startDir?: string): string | undefined {
+  let current = path.resolve(startDir ?? process.cwd());
+  for (;;) {
+    for (const name of DEFAULT_CONFIG_NAMES) {
+      const candidate = path.join(current, name);
+      if (fs.existsSync(candidate)) return candidate;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) return undefined;
+    current = parent;
+  }
+}
+
+/**
  * Загружает конфиг CLI:
- *  1. --config <path> или ./ydb-orm.config.{ts,mts,mjs,js};
+ *  1. --config <path> или ydb-orm.config.{ts,mts,mjs|js}, найденный в CWD
+ *     или выше; default и именованные экспорты эквивалентны;
  *  2. иначе — переменные окружения YDB_ENDPOINT / YDB_CONNECTION_STRING,
  *     YDB_AUTH_TYPE (по умолчанию anonymous), YDB_AUTHORIZED_KEY_PATH.
  */
 export async function loadCliConfig(
   configPath?: string,
+  startDir?: string,
 ): Promise<YdbCliConfig> {
-  const file = configPath ?? findDefaultConfig();
+  const file = configPath
+    ? path.resolve(configPath)
+    : findDefaultConfig(startDir);
   if (file) {
+    if (!fs.existsSync(file)) {
+      throw new Error(`Config file not found: ${path.resolve(file)}`);
+    }
     const mod = (await import(
       pathToFileURL(path.resolve(file)).href
-    )) as Record<string, any>;
-    const config = (mod.default ?? mod) as YdbCliConfig;
-    if (!config.endpoint) {
-      throw new Error(`Config ${file}: "endpoint" is required`);
-    }
-    return config;
+    )) as Record<string, unknown>;
+    return extractCliConfig(mod, file);
   }
 
   const endpoint =
@@ -58,12 +149,6 @@ export async function loadCliConfig(
       authorized_key_path: process.env.YDB_AUTHORIZED_KEY_PATH,
     },
   };
-}
-
-function findDefaultConfig(): string | undefined {
-  return DEFAULT_CONFIG_NAMES.map((name) => path.resolve(name)).find((p) =>
-    fs.existsSync(p),
-  );
 }
 
 /** Подключение для команд CLI: driver + executor, закрывается через close(). */

--- a/src/cli/diff.ts
+++ b/src/cli/diff.ts
@@ -32,9 +32,16 @@ const KIND_STYLE: Record<
   'ttl-extra': { marker: '-', color: BLUE },
 };
 
-/** Цвет включён, только если вывод — TTY и не задана NO_COLOR. */
-export function shouldUseColor(): boolean {
-  return Boolean(process.stdout.isTTY) && !process.env.NO_COLOR;
+/**
+ * Цвет включён, только если целевой поток вывода — TTY и не задана
+ * NO_COLOR (#103). Раньше TTY проверялся только у stdout, хотя расхождения
+ * в schema:verify пишутся в stderr — при перенаправлении stdout ANSI-коды
+ * попадали в файл, а при перенаправлении stderr цвет зря отключался.
+ */
+export function shouldUseColor(
+  stream: NodeJS.WriteStream = process.stdout,
+): boolean {
+  return Boolean(stream.isTTY) && !process.env.NO_COLOR;
 }
 
 /** Оборачивает текст в ANSI-цвет, если раскраска включена. */
@@ -88,12 +95,15 @@ function formatIssueText(issue: YdbSchemaIssue): string {
 /**
  * Рендерит список расхождений, сгруппированный по таблицам.
  * Возвращает многострочную строку (без завершающего перевода строки).
+ *
+ * Цвет определяется по потоку, куда вывод реально попадает: опция
+ * `stream` (по умолчанию stdout) или явный `color`.
  */
 export function renderSchemaDiff(
   issues: YdbSchemaIssue[],
-  options?: { color?: boolean },
+  options?: { color?: boolean; stream?: NodeJS.WriteStream },
 ): string {
-  const colorEnabled = options?.color ?? shouldUseColor();
+  const colorEnabled = options?.color ?? shouldUseColor(options?.stream);
 
   // Группировка по таблицам с сохранением исходного порядка.
   const byTable = new Map<string, YdbSchemaIssue[]>();

--- a/src/migrations/migration-loader.spec.ts
+++ b/src/migrations/migration-loader.spec.ts
@@ -65,11 +65,12 @@ describe('loadMigrationsFromDir', () => {
     expect(migrations[0].name).toBe('custom-name');
   });
 
-  it('returns empty list for missing directory', async () => {
-    const migrations = await loadMigrationsFromDir(
-      path.join(dir, 'not-exists'),
-    );
-    expect(migrations).toEqual([]);
+  it('fails clearly for missing directory (#103)', async () => {
+    // Раньше возвращался [] — опечатка в --dir выглядела как
+    // «No pending migrations».
+    await expect(
+      loadMigrationsFromDir(path.join(dir, 'not-exists')),
+    ).rejects.toThrow(/Migration directory does not exist/);
   });
 
   it('throws when a file exports no migration class', async () => {
@@ -242,6 +243,31 @@ describe('loadMigrationsFromDir', () => {
       await expect(loadMigrationsFromDir(dir)).rejects.toThrow(
         /identical content/,
       );
+    });
+  });
+
+  describe('missing directory (#103)', () => {
+    it('fails clearly instead of returning []', async () => {
+      // Раньше несуществующая директория выглядела как «No pending
+      // migrations» — опечатка в --dir была неотличима от пустой директории.
+      const missing = path.join(dir, 'no-such-dir');
+
+      await expect(loadMigrationsFromDir(missing)).rejects.toThrow(
+        /Migration directory does not exist: .*no-such-dir/,
+      );
+    });
+
+    it('fails when the path is a file, not a directory', async () => {
+      const filePath = path.join(dir, 'not-a-dir.ts');
+      fs.writeFileSync(filePath, '', 'utf-8');
+
+      await expect(loadMigrationsFromDir(filePath)).rejects.toThrow(
+        /is not a directory/,
+      );
+    });
+
+    it('still accepts an existing empty directory', async () => {
+      expect(await loadMigrationsFromDir(dir)).toEqual([]);
     });
   });
 });

--- a/src/migrations/migration-loader.ts
+++ b/src/migrations/migration-loader.ts
@@ -91,7 +91,21 @@ function collectCandidates(mod: Record<string, any>): MigrationCandidate[] {
 export async function loadMigrationsFromDir(
   dir: string,
 ): Promise<YdbMigration[]> {
-  if (!fs.existsSync(dir)) return [];
+  // Несуществующая директория — ошибка, а не «No pending migrations» (#103):
+  // опечатка в --dir не должна выглядеть как отсутствие миграций.
+  if (!fs.existsSync(dir)) {
+    throw new Error(
+      `Migration directory does not exist: ${path.resolve(dir)} ` +
+        `(resolved from "${dir}"). Create it with ` +
+        `"ydb-orm migration:create <name>" or pass a correct --dir.`,
+    );
+  }
+  if (!fs.statSync(dir).isDirectory()) {
+    throw new Error(
+      `Migration directory is not a directory: ${path.resolve(dir)} ` +
+        `(resolved from "${dir}").`,
+    );
+  }
 
   const files = fs.readdirSync(dir).filter(isMigrationFileName).sort();
 

--- a/test/cli/schema-diff.spec.ts
+++ b/test/cli/schema-diff.spec.ts
@@ -270,6 +270,36 @@ describe('shouldUseColor', () => {
     expect(shouldUseColor()).toBe(true);
   });
 
+  it('decides by the passed stream, not always stdout (#103)', () => {
+    // schema:verify пишет расхождения в stderr: при pipe stdout
+    // (`ydb-orm schema:verify | cat`) цвет должен решаться по stderr.
+    const ttyStderr = { isTTY: true } as unknown as NodeJS.WriteStream;
+    const pipedStdout = { isTTY: false } as unknown as NodeJS.WriteStream;
+
+    expect(shouldUseColor(ttyStderr)).toBe(true);
+    expect(shouldUseColor(pipedStdout)).toBe(false);
+  });
+
+  it('renderSchemaDiff colors by the target stream (#103)', () => {
+    delete process.env.NO_COLOR;
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: undefined,
+      configurable: true,
+    });
+    const issues = diffSchemas([makeExpected()], [makeExisting()]);
+
+    // stderr остался TTY, хотя stdout перенаправлен — цвет включается.
+    const colored = renderSchemaDiff(issues, {
+      stream: { isTTY: true } as unknown as NodeJS.WriteStream,
+    });
+    expect(colored).toMatch(ANSI_RE);
+
+    const plain = renderSchemaDiff(issues, {
+      stream: { isTTY: false } as unknown as NodeJS.WriteStream,
+    });
+    expect(plain).not.toMatch(ANSI_RE);
+  });
+
   it('renderSchemaDiff without options emits no ANSI when NO_COLOR is set', () => {
     Object.defineProperty(process.stdout, 'isTTY', {
       value: true,


### PR DESCRIPTION
## Summary

Fixes #103 — все заявленные проблемы CLI, без посторонних изменений.

### Что исправлено

1. **parseArgs молча глотал неизвестные флаги и пустые значения**
   - Разбор аргументов вынесен в `src/cli/args.ts` и сделан строгим:
     - неизвестный флаг (`migration:create --nme foo`) — ошибка `Unknown option: --nme`, а не создание миграции с именем «--nme»;
     - `--config`/`--dir` без значения, с пустой строкой или со следующим флагом вместо значения — ошибка вместо тихого отката к дефолтам/env;
     - лишние позиционные аргументы после команды тоже отклоняются (раньше молча игнорировались);
     - поддержан синтаксис `--flag=value`.

2. **Несуществующая `--dir` выглядела как «No pending migrations»**
   - `loadMigrationsFromDir` теперь падает с понятной ошибкой (абсолютный путь + подсказка про `migration:create`/`--dir`), если директории нет или путь указывает на файл.

3. **Стек и cause терялись, verbose-режима не было**
   - Обработчик ошибок печатает цепочку cause («Caused by: ...»); новый флаг `--verbose` добавляет полный стек каждого звена и контекст (cwd, argv, версия node). Без verbose выводится подсказка про `--verbose`. Ошибки использования (CliArgsError) печатаются без шума.
   - Добавлен `-h/--help` как полноценный флаг (раньше распознавался только как «команда»).

4. **Цвет schema:verify решался по stdout при выводе в stderr**
   - `shouldUseColor(stream)` / `renderSchemaDiff(issues, { stream })`: цвет определяется по потоку, куда реально пишутся расхождения (stderr для `schema:verify`, stdout для diff в `migration:generate`). При `schema:verify 2>file` ANSI-коды больше не уедут в файл, при pipe stdout цвет по stderr сохранится.

5. **Конфиг: только default export и только CWD**
   - Поддержаны именованные экспорты (`export const config = {...}`) наравне с default: named export больше не даёт ложную ошибку «endpoint is required»; несколько разных подходящих экспортов — явная ошибка неоднозначности (default имеет приоритет);
   - дефолтный конфиг ищется в CWD и вверх по дереву каталогов до корня ФС (приоритет расширений .ts → .mts → .mjs → .js внутри одной директории);
   - отсутствующий явный `--config <path>` даёт ясную ошибку вместо сырого ERR_MODULE_NOT_FOUND;
   - ошибки «endpoint is required» называют файл и имя экспорта.

### Тесты

Регрессионные тесты на каждый пункт:
- `src/cli/args.spec.ts` — 17 тестов: неизвестные флаги, пустые/флаговые значения, лишние позиционные, `=`-синтаксис, help, форматирование ошибок (cause chain, verbose-стек, контекст);
- `src/cli/config.spec.ts` — 13 тестов: default/named экспорт, приоритет default, неоднозначность, список экспортов в ошибке, поиск вверх по дереву, приоритет расширений, отсутствие конфига/env-fallback;
- `src/migrations/migration-loader.spec.ts` — несуществующая директория/файл вместо молчаливого `[]` (старый тест, документировавший баговое поведение, обновлён);
- `test/cli/schema-diff.spec.ts` — цвет по переданному потоку (TTY stderr + перенаправленный stdout).

`yarn test` — 548 passed; `yarn build` и `yarn lint` — без новых замечаний (0 errors).