### PR TITLE
fix(core): standalone-конфигурация наравне с NestJS — uuidVersion, сброс провайдеров, валидация метаданных (#108)

### DIFF
--- a/src/core/standalone.ts
+++ b/src/core/standalone.ts
@@ -4,12 +4,19 @@ import type {
   YdbEncryptionProvider,
 } from '../encryption/ydb-encryption-provider.interface.js';
 import { YdbBaseEntity } from '../entity/base-entity.js';
+import { getEntityRuntime } from '../entity/entity-runtime.js';
 import { getOrCreateRepository } from '../repository/repository-resolver.js';
+import { validateEntityMetadata } from '../metadata/validate-entity.js';
+import { v4 as uuidv4, v7 as uuidv7 } from 'uuid';
 
 /**
  * Конфигурация сущностей для программного использования без NestJS.
- * Устанавливает executor и (опционально) провайдеры шифрования
- * на каждую переданную сущность и создаёт для неё YdbRepository.
+ * Валидирует метаданные каждой сущности, устанавливает executor,
+ * генератор UUID (uuidVersion) и провайдеры шифрования на каждую
+ * переданную сущность и создаёт для неё YdbRepository.
+ *
+ * Повторный вызов полностью заменяет конфигурацию: если провайдеры
+ * не переданы, прошлые сбрасываются (актуально для тестов и hot-restart).
  *
  * @example
  * ```ts
@@ -26,6 +33,8 @@ export function configureEntities(
     executor: YdbExecutor;
     encryptionProvider?: YdbEncryptionProvider;
     blindIndexProvider?: YdbBlindIndexProvider;
+    /** Версия генерируемых UUID для PK: v7 (по умолчанию) или v4. */
+    uuidVersion?: 'v4' | 'v7';
   },
 ): void {
   if (!options?.executor) {
@@ -34,31 +43,50 @@ export function configureEntities(
         'Create it via createExecutor(driver, opts).',
     );
   }
+
+  // Сначала валидируем все сущности: невалидная сущность не должна
+  // получить executor/провайдеры и падать позже с малопонятной ошибкой.
   for (const entity of entities) {
-    if (
-      typeof entity !== 'function' ||
-      !(entity.prototype instanceof YdbBaseEntity)
-    ) {
+    assertEntityClass(entity);
+    const issues = validateEntityMetadata(
+      entity as unknown as typeof YdbBaseEntity,
+      {
+        encryptionProviderConfigured: Boolean(options.encryptionProvider),
+        blindIndexProviderConfigured: Boolean(options.blindIndexProvider),
+      },
+    );
+    if (issues.length) {
       throw new Error(
-        `configureEntities(): ${entity?.name ?? String(entity)} ` +
-          `is not a YdbBaseEntity subclass. ` +
-          `Only entities extending YdbBaseEntity can be configured.`,
+        `configureEntities(): metadata validation failed for ${entity.name}:\n` +
+          issues.map((i) => `  - ${i}`).join('\n'),
       );
     }
-    (entity as unknown as typeof YdbBaseEntity).setExecutor(options.executor);
+  }
 
-    if (options.encryptionProvider) {
-      (entity as unknown as typeof YdbBaseEntity).setEncryptionProvider(
-        options.encryptionProvider,
-      );
-    }
+  // Затем применяем конфигурацию. Провайдеры перезаписываются безусловно:
+  // undefined сбрасывает провайдеры прошлой конфигурации при re-bootstrap.
+  for (const entity of entities) {
+    const entityClass = entity as unknown as typeof YdbBaseEntity;
+    getEntityRuntime(entityClass).uuidGenerator =
+      options.uuidVersion === 'v4' ? uuidv4 : uuidv7;
 
-    if (options.blindIndexProvider) {
-      (entity as unknown as typeof YdbBaseEntity).setBlindIndexProvider(
-        options.blindIndexProvider,
-      );
-    }
+    entityClass.setExecutor(options.executor);
+    entityClass.setEncryptionProvider(options.encryptionProvider);
+    entityClass.setBlindIndexProvider(options.blindIndexProvider);
 
-    getOrCreateRepository(entity as unknown as typeof YdbBaseEntity);
+    getOrCreateRepository(entityClass);
+  }
+}
+
+function assertEntityClass(entity: unknown): void {
+  if (
+    typeof entity !== 'function' ||
+    !(entity.prototype instanceof YdbBaseEntity)
+  ) {
+    throw new Error(
+      `configureEntities(): ${(entity as any)?.name ?? String(entity)} ` +
+        `is not a YdbBaseEntity subclass. ` +
+        `Only entities extending YdbBaseEntity can be configured.`,
+    );
   }
 }

--- a/src/entity/base-entity.ts
+++ b/src/entity/base-entity.ts
@@ -27,22 +27,34 @@ import {
 export class YdbBaseEntity {
   // ---- Runtime setters (публичный API для тестов и standalone-конфигурации) ----
 
-  static setExecutor(this: typeof YdbBaseEntity, db: YdbExecutor): void {
+  /**
+   * Устанавливает executor. Передача undefined сбрасывает executor
+   * (нужно при повторном бутстрапе и очистке состояния в тестах).
+   */
+  static setExecutor(this: typeof YdbBaseEntity, db?: YdbExecutor): void {
     getEntityRuntime(this).executor = db;
     this.clearRepository();
   }
 
+  /**
+   * Устанавливает encryption-провайдер. Передача undefined сбрасывает
+   * провайдер (нужно при повторном бутстрапе без шифрования).
+   */
   static setEncryptionProvider(
     this: typeof YdbBaseEntity,
-    provider: YdbEncryptionProvider,
+    provider?: YdbEncryptionProvider,
   ): void {
     getEntityRuntime(this).encryptionProvider = provider;
     this.clearRepository();
   }
 
+  /**
+   * Устанавливает blind-index-провайдер. Передача undefined сбрасывает
+   * провайдер (нужно при повторном бутстрапе без шифрования).
+   */
   static setBlindIndexProvider(
     this: typeof YdbBaseEntity,
-    provider: YdbBlindIndexProvider,
+    provider?: YdbBlindIndexProvider,
   ): void {
     getEntityRuntime(this).blindIndexProvider = provider;
     this.clearRepository();

--- a/src/module/repository-factory.ts
+++ b/src/module/repository-factory.ts
@@ -49,12 +49,11 @@ export function createActiveRecordEntityProvider(
         opts.uuidVersion === 'v4' ? uuidv4 : uuidv7;
 
       entityClass.setExecutor(db);
-      if (encryptionProvider) {
-        entityClass.setEncryptionProvider(encryptionProvider);
-      }
-      if (blindIndexProvider) {
-        entityClass.setBlindIndexProvider(blindIndexProvider);
-      }
+      // Провайдеры перезаписываются безусловно: повторный бутстрап без них
+      // (тесты, hot-restart) не должен оставлять провайдеры прошлой
+      // конфигурации — undefined сбрасывает предыдущее значение.
+      entityClass.setEncryptionProvider(encryptionProvider);
+      entityClass.setBlindIndexProvider(blindIndexProvider);
 
       getOrCreateRepository(entityClass as any);
 

--- a/test/base-entity-crud.spec.ts
+++ b/test/base-entity-crud.spec.ts
@@ -18,14 +18,14 @@ describe('BaseEntity CRUD (mock executor)', () => {
   afterEach(() => {
     // Сброс executor/providers у всех тестовых сущностей
     UserEntity.setExecutor(undefined as any);
-    UserEntity.setEncryptionProvider(undefined as any);
-    UserEntity.setBlindIndexProvider(undefined as any);
+    UserEntity.setEncryptionProvider(undefined);
+    UserEntity.setBlindIndexProvider(undefined);
     UserRoleEntity.setExecutor(undefined as any);
-    UserRoleEntity.setEncryptionProvider(undefined as any);
-    UserRoleEntity.setBlindIndexProvider(undefined as any);
+    UserRoleEntity.setEncryptionProvider(undefined);
+    UserRoleEntity.setBlindIndexProvider(undefined);
     PhotoEntity.setExecutor(undefined as any);
-    PhotoEntity.setEncryptionProvider(undefined as any);
-    PhotoEntity.setBlindIndexProvider(undefined as any);
+    PhotoEntity.setEncryptionProvider(undefined);
+    PhotoEntity.setBlindIndexProvider(undefined);
   });
 
   describe('find()', () => {

--- a/test/composite-pk.spec.ts
+++ b/test/composite-pk.spec.ts
@@ -51,8 +51,8 @@ describe('Composite PK CRUD', () => {
       MembershipEntity,
     ]) {
       e.setExecutor(undefined as any);
-      e.setEncryptionProvider(undefined as any);
-      e.setBlindIndexProvider(undefined as any);
+      e.setEncryptionProvider(undefined);
+      e.setBlindIndexProvider(undefined);
     }
   });
 

--- a/test/e2e/base-entity.e2e.spec.ts
+++ b/test/e2e/base-entity.e2e.spec.ts
@@ -49,8 +49,8 @@ afterAll(async () => {
   // Cleanup runtime
   E2eItemEntity.setExecutor(undefined as any);
   E2eSecretEntity.setExecutor(undefined as any);
-  E2eSecretEntity.setEncryptionProvider(undefined as any);
-  E2eSecretEntity.setBlindIndexProvider(undefined as any);
+  E2eSecretEntity.setEncryptionProvider(undefined);
+  E2eSecretEntity.setBlindIndexProvider(undefined);
   E2eOrderEntity.setExecutor(undefined as any);
   E2eOrderItemEntity.setExecutor(undefined as any);
 

--- a/test/e2e/encryption.e2e.spec.ts
+++ b/test/e2e/encryption.e2e.spec.ts
@@ -25,8 +25,8 @@ afterAll(async () => {
   if (!ctx) return;
   await dropTableForEntity(ctx.executor, E2eSecretEntity);
   E2eSecretEntity.setExecutor(undefined as any);
-  E2eSecretEntity.setEncryptionProvider(undefined as any);
-  E2eSecretEntity.setBlindIndexProvider(undefined as any);
+  E2eSecretEntity.setEncryptionProvider(undefined);
+  E2eSecretEntity.setBlindIndexProvider(undefined);
   closeE2eContext(ctx);
 });
 

--- a/test/error-guards.spec.ts
+++ b/test/error-guards.spec.ts
@@ -24,8 +24,8 @@ const uuid1 = '5ad91505-d4f6-4a81-ab65-9dbc68cf4ed5';
 describe('error guards: понятные fail-fast ошибки', () => {
   afterEach(() => {
     UserEntity.setExecutor(undefined as any);
-    UserEntity.setEncryptionProvider(undefined as any);
-    UserEntity.setBlindIndexProvider(undefined as any);
+    UserEntity.setEncryptionProvider(undefined);
+    UserEntity.setBlindIndexProvider(undefined);
     UserRoleEntity.setExecutor(undefined as any);
     NoPkEntity.setExecutor(undefined as any);
     UndecoratedEntity.setExecutor(undefined as any);

--- a/test/findBy.spec.ts
+++ b/test/findBy.spec.ts
@@ -6,8 +6,8 @@ import { UserEntity } from './fixtures/user/user.entity.js';
 describe('findBy / findOneBy', () => {
   afterEach(() => {
     UserEntity.setExecutor(undefined as any);
-    UserEntity.setEncryptionProvider(undefined as any);
-    UserEntity.setBlindIndexProvider(undefined as any);
+    UserEntity.setEncryptionProvider(undefined);
+    UserEntity.setBlindIndexProvider(undefined);
   });
 
   const uuid1 = '5ad91505-d4f6-4a81-ab65-9dbc68cf4ed5';

--- a/test/lazy-decrypt.spec.ts
+++ b/test/lazy-decrypt.spec.ts
@@ -57,8 +57,8 @@ describe('lazy decrypt (@YdbEncrypted({ lazy: true }))', () => {
 
   afterEach(() => {
     LazySecretEntity.setExecutor(undefined as any);
-    LazySecretEntity.setEncryptionProvider(undefined as any);
-    LazySecretEntity.setBlindIndexProvider(undefined as any);
+    LazySecretEntity.setEncryptionProvider(undefined);
+    LazySecretEntity.setBlindIndexProvider(undefined);
   });
 
   it('не дешифрует lazy-поле при find, обычные поля дешифруются сразу', async () => {

--- a/test/nestjs/provider-reset.spec.ts
+++ b/test/nestjs/provider-reset.spec.ts
@@ -1,0 +1,165 @@
+import 'reflect-metadata';
+import { Test } from '@nestjs/testing';
+import { Module } from '@nestjs/common';
+import {
+  YdbCoreModule,
+  YdbModule,
+  YDB_DRIVER,
+  YDB_QUERY,
+  YdbEncryptionProvider,
+  YdbBlindIndexProvider,
+  YdbBaseEntity,
+  YdbEntity,
+  YdbPrimaryColumn,
+  YdbColumn,
+} from '../../src/index.js';
+import { PhotoEntity } from '../fixtures/photo/photo.entity.js';
+import { createActiveRecordEntityProvider } from '../../src/module/repository-factory.js';
+import { getEntityRuntime } from '../../src/entity/entity-runtime.js';
+import { createMockExecutor, MockExecutor } from '../helpers/mock-executor.js';
+
+@Module({
+  imports: [YdbModule.forFeature([PhotoEntity])],
+})
+class TestFeatureModule {}
+
+/** Сущность без шифрованных полей — для проверки сброса на уровне фабрики. */
+@YdbEntity('reset_plain')
+class ResetPlain extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid!: string;
+
+  @YdbColumn('Utf8')
+  name!: string;
+}
+
+/** Тегированные заглушки провайдеров: по значению видно, кто использован. */
+function makeTaggedProviders(tag: string): {
+  encryptionProvider: YdbEncryptionProvider;
+  blindIndexProvider: YdbBlindIndexProvider;
+} {
+  return {
+    encryptionProvider: {
+      encrypt: (_plaintext: string) =>
+        Promise.resolve(new TextEncoder().encode(`enc:${tag}`)),
+      decrypt: (ciphertext: Uint8Array) =>
+        Promise.resolve(
+          new TextDecoder().decode(ciphertext).replace(/^enc:/, ''),
+        ),
+    },
+    blindIndexProvider: {
+      hash: (plaintext: string) => Promise.resolve(`bi:${tag}:${plaintext}`),
+    },
+  };
+}
+
+async function bootstrap(
+  providers: {
+    encryptionProvider?: YdbEncryptionProvider;
+    blindIndexProvider?: YdbBlindIndexProvider;
+  },
+  rows: any[][] = [[]],
+): Promise<{ mock: MockExecutor; close: () => Promise<void> }> {
+  const mock = createMockExecutor(rows);
+  const module = await Test.createTestingModule({
+    imports: [
+      YdbCoreModule.forRootAsync({
+        useFactory: () => ({
+          endpoint: 'grpc://localhost:2136/local',
+          auth_type: 'anonymous' as const,
+          authOptions: {},
+          ...providers,
+        }),
+      }),
+      TestFeatureModule,
+    ],
+  })
+    .overrideProvider(YDB_DRIVER)
+    .useValue({})
+    .overrideProvider(YDB_QUERY)
+    .useValue(mock.executor)
+    .compile();
+
+  return { mock, close: () => module.close() };
+}
+
+describe('NestJS integration: сброс провайдеров при повторном бутстрапе', () => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    await cleanup?.();
+    cleanup = undefined;
+    // Чистим runtime-состояние сущностей между тестами
+    for (const e of [PhotoEntity, ResetPlain]) {
+      e.setExecutor(undefined);
+      e.setEncryptionProvider(undefined);
+      e.setBlindIndexProvider(undefined);
+    }
+  });
+
+  it('повторный бутстрап подменяет провайдеры новыми', async () => {
+    const first = await bootstrap(makeTaggedProviders('A'));
+    cleanup = first.close;
+    await first.close();
+
+    const second = await bootstrap(makeTaggedProviders('B'));
+    cleanup = second.close;
+
+    const photo = new PhotoEntity();
+    photo.title = 'Sunset';
+    photo.author_email = 'a@b.c';
+    await PhotoEntity.save(photo);
+
+    // Использованы новые провайдеры, а не оставшиеся от прошлого бутстрапа
+    const [upsert] = second.mock.queries;
+    expect((upsert.params.author_email as any).value).toEqual(
+      new TextEncoder().encode('enc:B'),
+    );
+    expect((upsert.params.author_email_bi as any).value).toBe('bi:B:a@b.c');
+  });
+
+  it('бутстрап без провайдеров не проходит молча: валидация называет сущность', async () => {
+    const first = await bootstrap(makeTaggedProviders('A'));
+    cleanup = first.close;
+    await first.close();
+
+    // У PhotoEntity есть @YdbEncrypted поля — бутстрап без encryptionProvider
+    // обязан упасть с понятной ошибкой, а не оставить прошлые провайдеры.
+    await expect(bootstrap({})).rejects.toThrow(
+      /PhotoEntity[\s\S]*metadata validation failed[\s\S]*no encryptionProvider is configured/,
+    );
+  });
+
+  it('createActiveRecordEntityProvider: повторный вызов без провайдеров сбрасывает их', () => {
+    const provider = createActiveRecordEntityProvider(ResetPlain);
+    const useFactory = (
+      provider as unknown as {
+        useFactory: (
+          db: any,
+          opts: any,
+          encryptionProvider?: YdbEncryptionProvider,
+          blindIndexProvider?: YdbBlindIndexProvider,
+        ) => unknown;
+      }
+    ).useFactory;
+    const opts = {
+      endpoint: 'grpc://localhost:2136/local',
+      authOptions: {},
+    };
+    const db = createMockExecutor().executor;
+    const { encryptionProvider, blindIndexProvider } = makeTaggedProviders('A');
+
+    useFactory(db, opts, encryptionProvider, blindIndexProvider);
+    expect(getEntityRuntime(ResetPlain).encryptionProvider).toBe(
+      encryptionProvider,
+    );
+    expect(getEntityRuntime(ResetPlain).blindIndexProvider).toBe(
+      blindIndexProvider,
+    );
+
+    // Повторная инициализация без провайдеров — явный сброс в undefined
+    useFactory(db, opts, undefined, undefined);
+    expect(getEntityRuntime(ResetPlain).encryptionProvider).toBeUndefined();
+    expect(getEntityRuntime(ResetPlain).blindIndexProvider).toBeUndefined();
+  });
+});

--- a/test/select-columns.spec.ts
+++ b/test/select-columns.spec.ts
@@ -5,8 +5,8 @@ import { UserEntity } from './fixtures/user/user.entity.js';
 describe('select columns (issue #10)', () => {
   afterEach(() => {
     UserEntity.setExecutor(undefined as any);
-    UserEntity.setEncryptionProvider(undefined as any);
-    UserEntity.setBlindIndexProvider(undefined as any);
+    UserEntity.setEncryptionProvider(undefined);
+    UserEntity.setBlindIndexProvider(undefined);
   });
 
   const uuid1 = '5ad91505-d4f6-4a81-ab65-9dbc68cf4ed5';

--- a/test/standalone-config.spec.ts
+++ b/test/standalone-config.spec.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, afterEach } from '@jest/globals';
 import {
   YdbEntity,
   YdbColumn,
@@ -9,6 +9,7 @@ import {
 } from '../src/index.js';
 import { TestOnlyEncryptionProvider } from '@ycforge/js-dev-tools';
 import { configureEntities } from '../src/core/standalone.js';
+import { getEntityRuntime } from '../src/entity/entity-runtime.js';
 import { createMockExecutor } from './helpers/mock-executor.js';
 
 @YdbEntity('test_users')
@@ -47,7 +48,50 @@ class TestEncrypted extends YdbBaseEntity {
   secret?: string;
 }
 
+/** Класс-наследник YdbBaseEntity без @YdbEntity. */
+class UndecoratedStandalone extends YdbBaseEntity {}
+
+/** Сущность без PK — метаданные невалидны. */
+@YdbEntity('test_no_pk')
+class NoPkStandalone extends YdbBaseEntity {
+  @YdbColumn('Utf8')
+  name!: string;
+}
+
+/** Тегированные заглушки провайдеров: по значению видно, кто использован. */
+function makeTaggedProviders(tag: string) {
+  return {
+    encryptionProvider: {
+      encrypt: (_plaintext: string) =>
+        Promise.resolve(new TextEncoder().encode(`enc:${tag}`)),
+      decrypt: (ciphertext: Uint8Array) =>
+        Promise.resolve(
+          new TextDecoder().decode(ciphertext).replace(/^enc:/, ''),
+        ),
+    },
+    blindIndexProvider: {
+      hash: (plaintext: string) => Promise.resolve(`bi:${tag}:${plaintext}`),
+    },
+  };
+}
+
 describe('configureEntities', () => {
+  afterEach(() => {
+    // Чистим runtime-состояние между тестами: сущности глобальны для файла.
+    for (const e of [
+      TestUser,
+      TestPost,
+      TestSimple,
+      TestEncrypted,
+      UndecoratedStandalone,
+      NoPkStandalone,
+    ]) {
+      e.setExecutor(undefined);
+      e.setEncryptionProvider(undefined);
+      e.setBlindIndexProvider(undefined);
+    }
+  });
+
   it('устанавливает executor на все сущности', async () => {
     const { executor } = createMockExecutor();
     configureEntities([TestUser, TestPost], { executor });
@@ -87,5 +131,132 @@ describe('configureEntities', () => {
   it('устанавливает executor на пустом массиве сущностей без ошибок', () => {
     const { executor } = createMockExecutor();
     expect(() => configureEntities([], { executor })).not.toThrow();
+  });
+
+  // ---- uuidVersion (#108) ----
+
+  it('по умолчанию генерирует UUID v7', async () => {
+    const mock = createMockExecutor([[]]);
+    configureEntities([TestSimple], { executor: mock.executor });
+
+    await TestSimple.save(Object.assign(new TestSimple(), { value: 'x' }));
+
+    const generated = String(mock.queries[0].params.uuid);
+    expect(generated[14]).toBe('7');
+  });
+
+  it('генерирует UUID v4 при uuidVersion: "v4"', async () => {
+    const mock = createMockExecutor([[]]);
+    configureEntities([TestSimple], {
+      executor: mock.executor,
+      uuidVersion: 'v4',
+    });
+
+    await TestSimple.save(Object.assign(new TestSimple(), { value: 'x' }));
+
+    const generated = String(mock.queries[0].params.uuid);
+    expect(generated[14]).toBe('4');
+  });
+
+  // ---- сброс провайдеров при повторном бутстрапе (#108) ----
+
+  it('повторный бутстрап шифрованной сущности без провайдеров падает громко', () => {
+    const mock = createMockExecutor([[]]);
+
+    configureEntities([TestEncrypted], {
+      executor: mock.executor,
+      ...makeTaggedProviders('A'),
+    });
+
+    // Повторный бутстрап без провайдеров отклоняется валидацией с именем
+    // сущности — провайдеры прошлой конфигурации не переживают его молча.
+    expect(() =>
+      configureEntities([TestEncrypted], { executor: mock.executor }),
+    ).toThrow(
+      /configureEntities\(\)[\s\S]*TestEncrypted[\s\S]*no encryptionProvider is configured/,
+    );
+    expect(mock.queries).toHaveLength(0);
+  });
+
+  it('повторный бутстрап сбрасывает прошлые провайдеры у обычной сущности', () => {
+    const mock = createMockExecutor([[]]);
+    const { encryptionProvider, blindIndexProvider } = makeTaggedProviders('A');
+
+    // Провайдеры остались от прошлой конфигурации
+    TestSimple.setExecutor(mock.executor);
+    TestSimple.setEncryptionProvider(encryptionProvider);
+    TestSimple.setBlindIndexProvider(blindIndexProvider);
+
+    // Повторный бутстрап без провайдеров — явный сброс, а не «молча остались»
+    configureEntities([TestSimple], { executor: mock.executor });
+
+    expect(getEntityRuntime(TestSimple).encryptionProvider).toBeUndefined();
+    expect(getEntityRuntime(TestSimple).blindIndexProvider).toBeUndefined();
+  });
+
+  it('повторный бутстрап подменяет executor и провайдеры на новые', async () => {
+    const first = createMockExecutor([[]]);
+    const second = createMockExecutor([[]]);
+
+    configureEntities([TestEncrypted], {
+      executor: first.executor,
+      ...makeTaggedProviders('A'),
+    });
+    configureEntities([TestEncrypted], {
+      executor: second.executor,
+      ...makeTaggedProviders('B'),
+    });
+
+    const e = new TestEncrypted();
+    e.secret = 'hello';
+    await TestEncrypted.save(e);
+
+    // Executor старой конфигурации больше не используется
+    expect(first.queries).toHaveLength(0);
+    expect(second.queries).toHaveLength(1);
+
+    // Использованы новые провайдеры, а не оставшиеся от прошлого бутстрапа
+    const [upsert] = second.queries;
+    expect((upsert.params.secret as any).value).toEqual(
+      new TextEncoder().encode('enc:B'),
+    );
+    expect((upsert.params.secret_bi as any).value).toBe('bi:B:hello');
+  });
+
+  // ---- валидация метаданных перед регистрацией (#108) ----
+
+  it('класс без @YdbEntity — понятная ошибка с именем класса', () => {
+    const { executor } = createMockExecutor();
+
+    expect(() =>
+      configureEntities([UndecoratedStandalone], { executor }),
+    ).toThrow(
+      /configureEntities\(\)[\s\S]*UndecoratedStandalone[\s\S]*is not decorated with @YdbEntity/,
+    );
+  });
+
+  it('невалидная сущность — ошибка с именем сущности и списком проблем', () => {
+    const { executor } = createMockExecutor();
+
+    expect(() => configureEntities([NoPkStandalone], { executor })).toThrow(
+      /configureEntities\(\)[\s\S]*NoPkStandalone[\s\S]*must declare at least one primary key/,
+    );
+  });
+
+  it('валидирует все сущности до применения конфигурации (без частичной настройки)', async () => {
+    const { executor } = createMockExecutor();
+
+    @YdbEntity('test_atomic_valid')
+    class AtomicValid extends YdbBaseEntity {
+      @YdbPrimaryColumn('Uuid')
+      uuid!: string;
+    }
+
+    expect(() =>
+      configureEntities([AtomicValid, UndecoratedStandalone], { executor }),
+    ).toThrow(/UndecoratedStandalone/);
+
+    // Валидная соседняя сущность тоже не сконфигурирована
+    await expect(AtomicValid.findAll()).rejects.toThrow(/YDB executor not set/);
   });
 });

--- a/test/tojson.spec.ts
+++ b/test/tojson.spec.ts
@@ -8,11 +8,11 @@ import { TestOnlyEncryptionProvider } from '@ycforge/js-dev-tools';
 describe('toJSON()', () => {
   afterEach(() => {
     PhotoEntity.setExecutor(undefined as any);
-    PhotoEntity.setEncryptionProvider(undefined as any);
-    PhotoEntity.setBlindIndexProvider(undefined as any);
+    PhotoEntity.setEncryptionProvider(undefined);
+    PhotoEntity.setBlindIndexProvider(undefined);
     UserEntity.setExecutor(undefined as any);
-    UserEntity.setEncryptionProvider(undefined as any);
-    UserEntity.setBlindIndexProvider(undefined as any);
+    UserEntity.setEncryptionProvider(undefined);
+    UserEntity.setBlindIndexProvider(undefined);
     UserRoleEntity.setExecutor(undefined as any);
   });
 

--- a/test/updateBy-deleteBy.spec.ts
+++ b/test/updateBy-deleteBy.spec.ts
@@ -80,23 +80,23 @@ const userRow = {
 describe('updateBy() / deleteBy()', () => {
   afterEach(() => {
     UserEntity.setExecutor(undefined as any);
-    UserEntity.setEncryptionProvider(undefined as any);
-    UserEntity.setBlindIndexProvider(undefined as any);
+    UserEntity.setEncryptionProvider(undefined);
+    UserEntity.setBlindIndexProvider(undefined);
     UserRoleEntity.setExecutor(undefined as any);
-    UserRoleEntity.setEncryptionProvider(undefined as any);
-    UserRoleEntity.setBlindIndexProvider(undefined as any);
+    UserRoleEntity.setEncryptionProvider(undefined);
+    UserRoleEntity.setBlindIndexProvider(undefined);
     TimestampEntity.setExecutor(undefined as any);
-    TimestampEntity.setEncryptionProvider(undefined as any);
-    TimestampEntity.setBlindIndexProvider(undefined as any);
+    TimestampEntity.setEncryptionProvider(undefined);
+    TimestampEntity.setBlindIndexProvider(undefined);
     AadEntity.setExecutor(undefined as any);
-    AadEntity.setEncryptionProvider(undefined as any);
-    AadEntity.setBlindIndexProvider(undefined as any);
+    AadEntity.setEncryptionProvider(undefined);
+    AadEntity.setBlindIndexProvider(undefined);
     AadMultiEntity.setExecutor(undefined as any);
-    AadMultiEntity.setEncryptionProvider(undefined as any);
-    AadMultiEntity.setBlindIndexProvider(undefined as any);
+    AadMultiEntity.setEncryptionProvider(undefined);
+    AadMultiEntity.setBlindIndexProvider(undefined);
     AadCompositeEntity.setExecutor(undefined as any);
-    AadCompositeEntity.setEncryptionProvider(undefined as any);
-    AadCompositeEntity.setBlindIndexProvider(undefined as any);
+    AadCompositeEntity.setEncryptionProvider(undefined);
+    AadCompositeEntity.setBlindIndexProvider(undefined);
   });
 
   describe('updateBy()', () => {

--- a/test/where-operators.spec.ts
+++ b/test/where-operators.spec.ts
@@ -6,8 +6,8 @@ import { TestOnlyEncryptionProvider } from '@ycforge/js-dev-tools';
 describe('WHERE operators', () => {
   afterEach(() => {
     WhereOperatorEntity.setExecutor(undefined as any);
-    WhereOperatorEntity.setEncryptionProvider(undefined as any);
-    WhereOperatorEntity.setBlindIndexProvider(undefined as any);
+    WhereOperatorEntity.setEncryptionProvider(undefined);
+    WhereOperatorEntity.setBlindIndexProvider(undefined);
   });
 
   describe('comparison operators', () => {

--- a/test/ydb-validate.spec.ts
+++ b/test/ydb-validate.spec.ts
@@ -20,8 +20,8 @@ function setupMock(rows: any[][] = [[]]) {
 describe('YdbValidate — валидация перед записью', () => {
   afterEach(() => {
     UserEntity.setExecutor(undefined as any);
-    UserEntity.setEncryptionProvider(undefined as any);
-    UserEntity.setBlindIndexProvider(undefined as any);
+    UserEntity.setEncryptionProvider(undefined);
+    UserEntity.setBlindIndexProvider(undefined);
     UserEntity.setValidationProvider(undefined as any);
   });
 


### PR DESCRIPTION
## Summary

Выравнивает standalone-конфигурацию (`configureEntities()`) с NestJS-путём (`YdbModuleOptions`) по трём пунктам issue #108:

1. **uuidVersion** — `configureEntities()` принимает `uuidVersion: 'v4' | 'v7'` (по умолчанию v7) и прокидывает генератор в entity-runtime; раньше работал только fallback на uuidv7.
2. **Сброс провайдеров** — encryption/blindIndex-провайдеры перезаписываются **безусловно** при каждом бутстрапе (и standalone, и в `repository-factory`): повторный бутстрап без провайдеров (тесты, hot-restart) сбрасывает их в `undefined` вместо молчаливого наследования прошлой конфигурации. Для этого `setExecutor` / `setEncryptionProvider` / `setBlindIndexProvider` принимают optional-аргумент.
3. **Валидация метаданных** — `configureEntities()` прогоняет каждую сущность через `validateEntityMetadata()` **до** применения конфигурации (двухпроходно: сначала валидация всего списка, потом применение): недекорированный класс или сущность без PK падают сразу с понятной ошибкой, называя сущность, без частичной настройки пакета.

NestJS-поведение не изменено: в `repository-factory` валидация уже была, заменено лишь условное «если truthy» на явную перезапись.

## Тесты

- `test/standalone-config.spec.ts`: UUID v7 по умолчанию и v4 при `uuidVersion`; громкий отказ re-bootstrap шифрованной сущности без провайдеров; сброс и подмена провайдеров/executor при повторном бутстрапе; ошибки для недекорированных и невалидных сущностей; атомарность валидации.
- `test/nestjs/provider-reset.spec.ts` (новый): подмена провайдеров при повторном бутстрапе модуля (тегированные заглушки A→B), отказ бутстрапа без провайдеров с именем сущности, прямой тест фабрики `createActiveRecordEntityProvider` на сброс в `undefined`.
- Попутно: существующие тесты очистки состояния переведены с `setEncryptionProvider(undefined as any)` на типобезопасный `undefined`.

## Проверка

- `yarn test` — 559 passed (40 suites)
- `yarn build` — ok
- `yarn lint` — 0 errors

Closes #108