### PR TITLE
fix(decorators): явная семантика наследования EagerLoad/YdbEnum/YdbSecurityAAD (#107)

### DIFF
--- a/src/decorators/eager.decorator.ts
+++ b/src/decorators/eager.decorator.ts
@@ -4,11 +4,22 @@ export const YDB_EAGER_KEY = 'ydb:eagerLoad';
 
 /**
  * Автоматически подгружает указанные relations при find / findAll.
+ *
+ * Семантика наследования: связи родителя не затираются — список дочернего
+ * класса объединяется с унаследованным (сначала родительские имена, затем
+ * новые из потомка). Повторы по имени отбрасываются: первое объявление
+ * выигрывает, каждая связь встречается в списке один раз.
  * @example @EagerLoad(['orders', 'profile'])
  */
 export function EagerLoad(relations: string[]): ClassDecorator {
   return (target) => {
-    Reflect.defineMetadata(YDB_EAGER_KEY, relations, target);
+    const inherited: string[] =
+      Reflect.getMetadata(YDB_EAGER_KEY, target) || [];
+    const merged: string[] = [...inherited];
+    for (const name of relations) {
+      if (!merged.includes(name)) merged.push(name);
+    }
+    Reflect.defineMetadata(YDB_EAGER_KEY, merged, target);
   };
 }
 

--- a/src/decorators/encryption.decorator.ts
+++ b/src/decorators/encryption.decorator.ts
@@ -49,12 +49,17 @@ export function YdbEncrypted(options?: YdbEncryptedOptions): PropertyDecorator {
 /**
  * Помечает поле первичного ключа как участника AAD (Additional Authenticated Data).
  * Может применяться только к колонкам, объявленным через @YdbPrimaryColumn.
+ *
+ * Семантика наследования и повторного применения: дедупликация по имени поля
+ * (как у @YdbPrimaryColumn) — повторное объявление на наследнике или на том же
+ * классе не создаёт дублей в AAD-строке.
  */
 export function YdbSecurityAAD(): PropertyDecorator {
   return (target, propertyKey) => {
     const constructor = target.constructor;
     const inherited: string[] =
       Reflect.getMetadata(YDB_SECURITY_AAD_KEY, constructor) || [];
+    if (inherited.includes(propertyKey as string)) return;
     Reflect.defineMetadata(
       YDB_SECURITY_AAD_KEY,
       [...inherited, propertyKey as string],

--- a/src/decorators/enum.decorator.ts
+++ b/src/decorators/enum.decorator.ts
@@ -11,6 +11,11 @@ export interface YdbEnumMeta {
 
 /**
  * Декоратор enum-колонки: маппинг enum ↔ Utf8 (строковое значение) или Int32 (порядковый номер).
+ *
+ * Семантика наследования и повторного применения: последняя декларация
+ * побеждает (last-write-wins). Переопределение @YdbEnum на свойстве,
+ * унаследованном от родителя, заменяет values/storage — а не игнорируется.
+ * Для каждого propertyKey в метаданных остаётся ровно одна запись.
  * @example
  *   enum Status { ACTIVE = 'active', INACTIVE = 'inactive' }
  *
@@ -27,20 +32,15 @@ export function YdbEnum(options: {
     const existing: YdbEnumMeta[] =
       Reflect.getMetadata(YDB_ENUM_KEY, constructor) || [];
 
-    if (existing.some((e) => e.propertyKey === propertyKey)) return;
-
-    Reflect.defineMetadata(
-      YDB_ENUM_KEY,
-      [
-        ...existing,
-        {
-          propertyKey: propertyKey as string,
-          values: options.values,
-          storage: options.storage ?? 'Utf8',
-        },
-      ],
-      constructor,
-    );
+    const list: YdbEnumMeta[] = [
+      ...existing.filter((e) => e.propertyKey !== propertyKey),
+      {
+        propertyKey: propertyKey as string,
+        values: options.values,
+        storage: options.storage ?? 'Utf8',
+      },
+    ];
+    Reflect.defineMetadata(YDB_ENUM_KEY, list, constructor);
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ export type {
   JoinTableMetadata,
   ManyToManyJoinTable,
 } from './decorators/relation.decorators.js';
-export { EagerLoad } from './decorators/eager.decorator.js';
+export { EagerLoad, getEagerRelations } from './decorators/eager.decorator.js';
 export { YdbJson, getJsonColumns } from './decorators/json.decorator.js';
 export {
   YdbCreateDateColumn,

--- a/test/decorator-inheritance.spec.ts
+++ b/test/decorator-inheritance.spec.ts
@@ -1,0 +1,298 @@
+import 'reflect-metadata';
+import {
+  YdbEntity,
+  YdbColumn,
+  YdbPrimaryColumn,
+  YdbBaseEntity,
+  YdbEnum,
+  getYdbEnumMetadata,
+  EagerLoad,
+  OneToMany,
+  YdbSecurityAAD,
+  getEagerRelations,
+  getYdbEntityMetadata,
+} from '../src/index.js';
+import { createMockExecutor } from './helpers/mock-executor.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Фикстуры @EagerLoad
+// ─────────────────────────────────────────────────────────────────────────────
+
+class RelatedStub extends YdbBaseEntity {}
+
+/** Родитель без @EagerLoad — базовый уровень иерархии. */
+@YdbEntity('inh_eager_root')
+class EagerRoot extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid!: string;
+}
+
+/** Один уровень наследования: родитель задаёт eager-связь, ребёнок добавляет свою. */
+@YdbEntity('inh_eager_parent')
+@EagerLoad(['parentItems'])
+class EagerParent extends EagerRoot {
+  @OneToMany(() => RelatedStub, 'parent_uuid')
+  parentItems?: RelatedStub[];
+}
+
+@YdbEntity('inh_eager_child')
+@EagerLoad(['childItems'])
+class EagerChild extends EagerParent {
+  @OneToMany(() => RelatedStub, 'child_uuid')
+  childItems?: RelatedStub[];
+}
+
+/** Ребёнок повторяет имя связи родителя — должно остаться одно вхождение. */
+@YdbEntity('inh_eager_dup')
+@EagerLoad(['parentItems'])
+class EagerDupChild extends EagerParent {
+  @OneToMany(() => RelatedStub, 'dup_uuid')
+  dupItems?: RelatedStub[];
+}
+
+/** Три уровня: grandparent -> parent -> child, каждый добавляет связи. */
+@YdbEntity('inh_eager_gp')
+@EagerLoad(['gpItem'])
+class EagerGrandParent extends YdbBaseEntity {
+  @OneToMany(() => RelatedStub, 'gp_uuid')
+  gpItem?: RelatedStub;
+}
+
+@YdbEntity('inh_eager_mp')
+@EagerLoad(['midItemA', 'midItemB'])
+class EagerMiddle extends EagerGrandParent {
+  @OneToMany(() => RelatedStub, 'mid_uuid')
+  midItemA?: RelatedStub;
+
+  @OneToMany(() => RelatedStub, 'mid_uuid')
+  midItemB?: RelatedStub;
+}
+
+@YdbEntity('inh_eager_lc')
+@EagerLoad(['leafItem', 'midItemB'])
+class EagerLeaf extends EagerMiddle {
+  @OneToMany(() => RelatedStub, 'leaf_uuid')
+  leafItem?: RelatedStub;
+
+  @OneToMany(() => RelatedStub, 'leaf_uuid')
+  leafDup?: RelatedStub;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Фикстуры @YdbEnum
+// ─────────────────────────────────────────────────────────────────────────────
+
+enum BaseStatus {
+  ACTIVE = 'active',
+  INACTIVE = 'inactive',
+}
+
+enum ExtendedStatus {
+  ACTIVE = 'active',
+  ARCHIVED = 'archived',
+}
+
+@YdbEntity('inh_enum_parent')
+class EnumParent extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid!: string;
+
+  @YdbColumn('Utf8')
+  @YdbEnum({ values: Object.values(BaseStatus), storage: 'Utf8' })
+  status!: string;
+}
+
+/**
+ * Переопределяет enum унаследованного поля: другой список значений
+ * и другое хранилище (Utf8 -> Int32).
+ */
+@YdbEntity('inh_enum_child')
+class EnumChild extends EnumParent {
+  @YdbColumn('Int32')
+  @YdbEnum({ values: Object.values(ExtendedStatus), storage: 'Int32' })
+  declare status: ExtendedStatus;
+}
+
+/** Повторный @YdbEnum на том же свойстве того же класса: last-write-wins.
+ * Декораторы свойств применяются снизу вверх (стандарт TS), поэтому
+ * «последнее» выполненное объявление — верхнее в исходнике.
+ */
+enum RepeatedStatus {
+  DRAFT = 'draft',
+  PUBLISHED = 'published',
+}
+
+@YdbEntity('inh_enum_repeated')
+class EnumRepeated extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid!: string;
+
+  @YdbColumn('Utf8')
+  // Применится последним — победит этот список.
+  @YdbEnum({ values: Object.values(RepeatedStatus), storage: 'Utf8' })
+  @YdbEnum({ values: ['gone'], storage: 'Utf8' })
+  status!: string;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Фикстуры @YdbSecurityAAD
+// ─────────────────────────────────────────────────────────────────────────────
+
+@YdbEntity('inh_aad_parent')
+class AadParent extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  @YdbSecurityAAD()
+  id!: string;
+}
+
+/** Наследует AAD-поле родителя и добавляет собственное. */
+@YdbEntity('inh_aad_child')
+class AadChild extends AadParent {
+  @YdbPrimaryColumn('Utf8')
+  @YdbSecurityAAD()
+  tenant_id!: string;
+}
+
+/** Двойное применение на одном и том же поле одного класса. */
+@YdbEntity('inh_aad_dup')
+class AadDuplicated extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  @YdbSecurityAAD()
+  @YdbSecurityAAD()
+  id!: string;
+}
+
+describe('decorator inheritance semantics (#107)', () => {
+  describe('@EagerLoad', () => {
+    it('ребёнок без собственного @EagerLoad наследует связи родителя', () => {
+      expect(getEagerRelations(EagerRoot)).toEqual([]);
+      expect(getEagerRelations(EagerParent)).toEqual(['parentItems']);
+    });
+
+    it('собственный @EagerLoad ребёнка не затирает связи родителя (merge)', () => {
+      expect(getEagerRelations(EagerChild)).toEqual([
+        'parentItems',
+        'childItems',
+      ]);
+    });
+
+    it('повтор имени связи из родителя дедуплицируется', () => {
+      expect(getEagerRelations(EagerDupChild)).toEqual(['parentItems']);
+    });
+
+    it('multi-level наследование накапливает связи по порядку объявления', () => {
+      expect(getEagerRelations(EagerLeaf)).toEqual([
+        'gpItem',
+        'midItemA',
+        'midItemB',
+        'leafItem',
+      ]);
+    });
+
+    it('copy-on-write: объявление на ребёнке не мутирует метаданные родителя', () => {
+      // EagerChild / EagerDupChild / EagerLeaf уже декорированы выше —
+      // родительские списки должны остаться нетронутыми.
+      expect(getEagerRelations(EagerParent)).toEqual(['parentItems']);
+      expect(getEagerRelations(EagerGrandParent)).toEqual(['gpItem']);
+      expect(getEagerRelations(EagerMiddle)).toEqual([
+        'gpItem',
+        'midItemA',
+        'midItemB',
+      ]);
+    });
+
+    it('без наследования поведение прежнее: порядок как объявлено', () => {
+      expect(getEagerRelations(EagerMiddle)).toEqual([
+        'gpItem',
+        'midItemA',
+        'midItemB',
+      ]);
+    });
+  });
+
+  describe('@YdbEnum', () => {
+    afterEach(() => {
+      EnumChild.setExecutor(undefined as any);
+      EnumRepeated.setExecutor(undefined as any);
+    });
+
+    it('переопределение на наследнике заменяет values и storage', () => {
+      const childMeta = getYdbEnumMetadata(EnumChild);
+      const parentMeta = getYdbEnumMetadata(EnumParent);
+
+      expect(childMeta).toHaveLength(1);
+      expect(childMeta[0]).toMatchObject({
+        propertyKey: 'status',
+        values: ['active', 'archived'],
+        storage: 'Int32',
+      });
+
+      // Метаданные родителя не затронуты
+      expect(parentMeta).toHaveLength(1);
+      expect(parentMeta[0]).toMatchObject({
+        propertyKey: 'status',
+        values: ['active', 'inactive'],
+        storage: 'Utf8',
+      });
+    });
+
+    it('наследник видит эффективные метаданные через proto-chain', () => {
+      const meta = getYdbEnumMetadata(EnumChild);
+      expect(meta[0].storage).toBe('Int32');
+    });
+
+    it('повторное применение на том же классе: last-write-wins', () => {
+      const meta = getYdbEnumMetadata(EnumRepeated);
+      expect(meta).toHaveLength(1);
+      expect(meta[0]).toMatchObject({
+        propertyKey: 'status',
+        values: ['draft', 'published'],
+        storage: 'Utf8',
+      });
+    });
+
+    it('переопределённые values реально применяются при save (не игнорируются)', async () => {
+      const mock = createMockExecutor([[]]);
+      EnumChild.setExecutor(mock.executor);
+
+      // Без PK — save идёт по пути INSERT (как в test/ydb-enum.spec.ts).
+      const entity = new EnumChild();
+      (entity as any).status = ExtendedStatus.ARCHIVED;
+      await EnumChild.save(entity);
+
+      const [q] = mock.queries;
+      expect(q.sql).toContain('UPSERT INTO `inh_enum_child`');
+      // Int32-storage ребёнка: ARCHIVED = индекс 1
+      const raw =
+        q.params.status && typeof q.params.status === 'object'
+          ? (q.params.status as any).value
+          : q.params.status;
+      expect(raw).toBe(1);
+
+      // Значение 'inactive' невалидно для списка ребёнка — значит,
+      // применился именно переопределённый список, а не родительский.
+      const other = new EnumChild();
+      (other as any).status = BaseStatus.INACTIVE;
+      await expect(EnumChild.save(other)).rejects.toThrow(
+        /Invalid enum value "inactive" for field "status"/,
+      );
+    });
+  });
+
+  describe('@YdbSecurityAAD', () => {
+    it('повторное применение на том же поле не дублирует запись', () => {
+      const meta = getYdbEntityMetadata(AadDuplicated)!;
+      expect(meta.aadFields).toEqual(['id']);
+    });
+
+    it('унаследованное AAD-поле + собственное: каждая запись по одному разу', () => {
+      const meta = getYdbEntityMetadata(AadChild)!;
+      expect(meta.aadFields).toEqual(['id', 'tenant_id']);
+    });
+
+    it('метаданные родителя не содержат AAD-полей ребёнка (copy-on-write)', () => {
+      const meta = getYdbEntityMetadata(AadParent)!;
+      expect(meta.aadFields).toEqual(['id']);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Реализует #107 — определяет и внедряет явную семантику merge/override для декораторов при наследовании метаданных.

### Семантика

| Декоратор | Правило |
|---|---|
| `@EagerLoad` | **merge**: список ребёнка объединяется с унаследованным (сначала родительские имена, затем новые из потомка). Дедупликация по имени, первое объявление выигрывает. Связи родителя больше не затираются. |
| `@YdbEnum` | **last-write-wins** по `propertyKey`: переопределение на наследнике (или повтор на том же классе) заменяет `values`/`storage` вместо молчаливого игнорирования. В метаданных ровно одна запись на поле, поэтому потребители через `.find()` получают эффективные значения. |
| `@YdbSecurityAAD` | **dedupe** как у `@YdbPrimaryColumn`: повторное применение не создаёт дублей записи в AAD-строке. |

Во всех случаях сохранён copy-on-write: объявление на наследнике не мутирует массивы метаданных родителя. Поведение без наследования не изменилось.

### Изменения

- `src/decorators/eager.decorator.ts` — union-merge с дедупликацией.
- `src/decorators/enum.decorator.ts` — замена записи по `propertyKey` вместо early-return.
- `src/decorators/encryption.decorator.ts` — dedupe в `@YdbSecurityAAD`.
- `src/index.ts` — экспорт `getEagerRelations` из публичного API.
- `test/decorator-inheritance.spec.ts` — 13 регрессионных тестов: наследование/merge/dedupe/multi-level/copy-on-write для `@EagerLoad`; override метаданных + runtime-проверка при `save()` для `@YdbEnum`; dedupe и наследование для `@YdbSecurityAAD`.

## Test plan

- [x] `yarn test` — 41 suite / 572 теста прошли
- [x] `yarn build` — без ошибок
- [x] `yarn lint` — 0 ошибок (warnings только pre-existing/типовые)

Fixes #107