### PR TITLE
fix(query): контекст ошибок и валидация маппера — Timestamp, Int32/Int64, Date (#105)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ await UserEntity.findAll({
 ## Декораторы
 
 - `@YdbEntity('table')` — имя таблицы; класс попадает в глобальный реестр сущностей (используется schema sync).
-- `@YdbColumn('Uuid' | 'Utf8' | 'Bytes' | 'Int32' | 'Int64' | 'Bool' | 'Double' | 'Float' | 'Date' | 'Datetime' | 'Timestamp' | 'Json' | 'JsonDocument')` — колонка.
+- `@YdbColumn('Uuid' | 'Utf8' | 'Bytes' | 'Int32' | 'Int64' | 'Bool' | 'Double' | 'Float' | 'Date' | 'Datetime' | 'Timestamp' | 'Json' | 'JsonDocument')` — колонка. Дата-типы принимают `Date`, число (мс от эпохи) или ISO-строку; **точность `Timestamp` ограничена миллисекундами**: JS `Date` хранит только мс, поэтому субмиллисекундные значения (микро-/наносекунды) не сохраняются — при чтении младшие разряды YDB-микросекунд теряются.
 - `@YdbPrimaryColumn(type)` — колонка первичного ключа (поддерживается составной PK: несколько таких колонок). Если PK не объявлен, используется `uuid`.
 - `@YdbEncrypted({ blindIndex, lazy })` — поле шифруется перед записью и дешифруется после чтения; `blindIndex: true` (по умолчанию) добавляет synthetic колонку `{field}_bi` для поиска по хешу. Шифротекст хранится в колонке `Bytes` (raw bytes), тип из `@YdbColumn` для таких полей игнорируется. Опция `lazy: true` откладывает дешифровку: поле не дешифруется при SELECT (экономия CPU), plaintext возвращают `await entity.decryptField('field')` / `await entity.decryptLazyFields()` (результат кешируется в инстансе); `toJSON()`/`JSON.stringify()` бросают ошибку, пока lazy-поля не дешифрованы.
 - `@YdbSecurityAAD()` — незашифрованное поле участвует в AAD (может применяться только к PK-колонкам).

--- a/src/core/mapper.spec.ts
+++ b/src/core/mapper.spec.ts
@@ -156,6 +156,37 @@ describe('mapToYdb', () => {
     it('rejects NaN as Int64', () => {
       expect(() => mapToYdb('Int64', Number.NaN)).toThrow(/Failed to convert/);
     });
+
+    it('accepts Number.MAX_SAFE_INTEGER as a number', () => {
+      const val = mapToYdb('Int64', Number.MAX_SAFE_INTEGER);
+      expect(val).toBeInstanceOf(Int64);
+      expect((val as any).value).toBe(9007199254740991n);
+    });
+
+    it('rejects MAX_SAFE_INTEGER + 1 as a number (unsafe)', () => {
+      expect(() => mapToYdb('Int64', Number.MAX_SAFE_INTEGER + 1)).toThrow(
+        /safe integer/,
+      );
+    });
+
+    it('rejects an unsafe number that would otherwise pass Int64 range', () => {
+      const unsafe = 9007199254740994; // 2^53 + 2, внутри Int64, но number округляет
+      expect(Number.isSafeInteger(unsafe)).toBe(false);
+      expect(BigInt(unsafe)).toBeLessThan(9223372036854775807n);
+      expect(() => mapToYdb('Int64', unsafe)).toThrow(/safe integer/);
+    });
+
+    it('accepts exact bigint values above MAX_SAFE_INTEGER', () => {
+      const val = mapToYdb('Int64', 9007199254740992n);
+      expect(val).toBeInstanceOf(Int64);
+      expect((val as any).value).toBe(9007199254740992n);
+    });
+
+    it('accepts exact string values above MAX_SAFE_INTEGER', () => {
+      const val = mapToYdb('Int64', '9007199254740992');
+      expect(val).toBeInstanceOf(Int64);
+      expect((val as any).value).toBe(9007199254740992n);
+    });
   });
 
   describe('Bool', () => {

--- a/src/core/mapper.spec.ts
+++ b/src/core/mapper.spec.ts
@@ -82,6 +82,28 @@ describe('mapToYdb', () => {
       const val = mapToYdb('Int32', null);
       expect(val).toBeInstanceOf(Optional);
     });
+
+    it('accepts the Int32 lower boundary', () => {
+      const val = mapToYdb('Int32', -2147483648);
+      expect(val).toBeInstanceOf(Int32);
+    });
+
+    it('accepts the Int32 upper boundary', () => {
+      const val = mapToYdb('Int32', 2147483647);
+      expect(val).toBeInstanceOf(Int32);
+    });
+
+    it('rejects values above the Int32 range', () => {
+      expect(() => mapToYdb('Int32', 2147483648)).toThrow(/out of range/);
+    });
+
+    it('rejects values below the Int32 range', () => {
+      expect(() => mapToYdb('Int32', -2147483649)).toThrow(/out of range/);
+    });
+
+    it('rejects non-integer values', () => {
+      expect(() => mapToYdb('Int32', 1.5)).toThrow(/must be an integer/);
+    });
   });
 
   describe('Int64', () => {
@@ -103,6 +125,36 @@ describe('mapToYdb', () => {
     it('returns Optional<Int64> for null', () => {
       const val = mapToYdb('Int64', null);
       expect(val).toBeInstanceOf(Optional);
+    });
+
+    it('accepts the Int64 upper boundary', () => {
+      const val = mapToYdb('Int64', 9223372036854775807n);
+      expect(val).toBeInstanceOf(Int64);
+    });
+
+    it('accepts the Int64 lower boundary', () => {
+      const val = mapToYdb('Int64', -9223372036854775808n);
+      expect(val).toBeInstanceOf(Int64);
+    });
+
+    it('rejects values above the Int64 range', () => {
+      expect(() => mapToYdb('Int64', 9223372036854775808n)).toThrow(
+        /out of range/,
+      );
+    });
+
+    it('rejects values below the Int64 range', () => {
+      expect(() => mapToYdb('Int64', -9223372036854775809n)).toThrow(
+        /out of range/,
+      );
+    });
+
+    it('rejects fractional numbers (BigInt throws raw RangeError)', () => {
+      expect(() => mapToYdb('Int64', 4.5)).toThrow(/Failed to convert/);
+    });
+
+    it('rejects NaN as Int64', () => {
+      expect(() => mapToYdb('Int64', Number.NaN)).toThrow(/Failed to convert/);
     });
   });
 
@@ -169,6 +221,41 @@ describe('mapToYdb', () => {
       expect(mapToYdb('Datetime', null)).toBeInstanceOf(Optional);
       expect(mapToYdb('Timestamp', null)).toBeInstanceOf(Optional);
     });
+
+    it('accepts a Date instance with milliseconds', () => {
+      const ms = new global.Date('2026-08-18T12:30:00.123Z');
+      expect(mapToYdb('Timestamp', ms)).toBeInstanceOf(Timestamp);
+      expect(mapToYdb('Datetime', ms)).toBeInstanceOf(Datetime);
+      expect(mapToYdb('Date', ms)).toBeInstanceOf(YdbDate);
+    });
+
+    it('stores Timestamp with millisecond precision (getTime() * 1000n)', () => {
+      const ms = new Date('2026-08-18T12:30:00.123Z');
+      const val = mapToYdb('Timestamp', ms) as any;
+      expect(val.value).toBe(BigInt(ms.getTime()) * 1000n);
+      // Субмиллисекунды не сохраняются: JS Date не может их нести.
+      expect(val.value % 1000n).toBe(0n);
+    });
+
+    it('rejects an invalid Date instance for all temporal types', () => {
+      const invalid = new Date('garbage');
+      expect(Number.isNaN(invalid.getTime())).toBe(true);
+      expect(() => mapToYdb('Date', invalid)).toThrow(/Invalid Date/);
+      expect(() => mapToYdb('Datetime', invalid)).toThrow(/Invalid Date/);
+      expect(() => mapToYdb('Timestamp', invalid)).toThrow(/Invalid Date/);
+    });
+
+    it('rejects a garbage string for all temporal types', () => {
+      expect(() => mapToYdb('Date', 'not-a-date')).toThrow(/Invalid Date/);
+      expect(() => mapToYdb('Datetime', 'not-a-date')).toThrow(/Invalid Date/);
+      expect(() => mapToYdb('Timestamp', 'not-a-date')).toThrow(/Invalid Date/);
+    });
+
+    it('rejects NaN epoch ms for all temporal types', () => {
+      expect(() => mapToYdb('Date', Number.NaN)).toThrow(/Invalid Date/);
+      expect(() => mapToYdb('Datetime', Number.NaN)).toThrow(/Invalid Date/);
+      expect(() => mapToYdb('Timestamp', Number.NaN)).toThrow(/Invalid Date/);
+    });
   });
 
   describe('Json', () => {
@@ -216,10 +303,52 @@ describe('mapToYdb', () => {
       );
     });
 
+    it('includes the field name on undefined value', () => {
+      expect(() => mapToYdb('Uuid', undefined, 'userId')).toThrow(
+        /field "userId"/,
+      );
+    });
+
     it('throws on unsupported type', () => {
       expect(() => mapToYdb('Foo' as any, 'bar')).toThrow(
         /Unsupported YDB type/,
       );
+    });
+  });
+
+  describe('conversion error context', () => {
+    const captureMessage = (fn: () => unknown): string => {
+      let msg = '';
+      try {
+        fn();
+      } catch (err) {
+        msg = (err as Error).message;
+      }
+      expect(msg).not.toBe('');
+      return msg;
+    };
+
+    it('includes field name, YDB type and value for Int32 overflow', () => {
+      const msg = captureMessage(() => mapToYdb('Int32', 2147483648, 'age'));
+      expect(msg).toContain('field "age"');
+      expect(msg).toContain('YDB type Int32');
+      expect(msg).toContain('2147483648');
+    });
+
+    it('includes field name, YDB type and value for invalid Date', () => {
+      const msg = captureMessage(() =>
+        mapToYdb('Timestamp', 'not-a-date', 'createdAt'),
+      );
+      expect(msg).toContain('field "createdAt"');
+      expect(msg).toContain('YDB type Timestamp');
+      expect(msg).toContain('not-a-date');
+    });
+
+    it('wraps the raw BigInt RangeError with field/type/value context', () => {
+      const msg = captureMessage(() => mapToYdb('Int64', 4.5, 'counter'));
+      expect(msg).toContain('field "counter"');
+      expect(msg).toContain('YDB type Int64');
+      expect(msg).toContain('4.5');
     });
   });
 });

--- a/src/core/mapper.ts
+++ b/src/core/mapper.ts
@@ -160,6 +160,13 @@ const valueMappers: Record<YdbPrimitive, (value: any) => unknown> = {
     return new Int32(value);
   },
   Int64: (value: bigint | number | string) => {
+    if (typeof value === 'number' && !Number.isSafeInteger(value)) {
+      // JS number небезопасен выше Number.MAX_SAFE_INTEGER (2^53 - 1):
+      // BigInt(value) превратит уже округлённое число в другой BigInt.
+      throw new TypeError(
+        `Int64 value must be a safe integer, got ${valuePreview(value)} (use bigint or string for exact values above 2^53 - 1)`,
+      );
+    }
     let asBigInt: bigint;
     try {
       asBigInt = BigInt(value);

--- a/src/core/mapper.ts
+++ b/src/core/mapper.ts
@@ -29,7 +29,17 @@ import {
 } from '@ydbjs/value/primitive';
 import { Optional } from '@ydbjs/value/optional';
 
-/** Конструкторы YDB-типов для null-значений (Optional<null>). */
+/** Границы знакового 32-битного целого. */
+const INT32_MIN = -2147483648; // -2^31
+const INT32_MAX = 2147483647; // 2^31 - 1
+
+/** Границы знакового 64-битного целого. */
+const INT64_MIN = -9223372036854775808n; // -2^63
+const INT64_MAX = 9223372036854775807n; // 2^63 - 1
+
+/**
+ * Конструкторы YDB-типов для null-значений (Optional<null>).
+ */
 const nullTypeFactories = {
   Uuid: () => new UuidType(),
   Utf8: () => new Utf8Type(),
@@ -46,43 +56,165 @@ const nullTypeFactories = {
   JsonDocument: () => new JsonDocumentType(),
 } satisfies Record<YdbPrimitive, () => unknown>;
 
-/** Нормализация JS-даты: принимает Date, число (мс) или ISO-строку. */
+/**
+ * Безопасное строковое представление значения для сообщений об ошибках:
+ * не раскрывает содержимое больших строк и бинарных данных.
+ */
+function valuePreview(value: unknown): string {
+  if (value === null) return 'null';
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? 'Invalid Date' : value.toISOString();
+  }
+  if (typeof value === 'string') {
+    return value.length > 64
+      ? `"${value.slice(0, 64)}…(${value.length} chars)"`
+      : JSON.stringify(value);
+  }
+  if (typeof value === 'bigint') return `${value}n`;
+  if (ArrayBuffer.isView(value)) {
+    return `<${value.constructor.name} length=${value.byteLength}>`;
+  }
+  switch (typeof value) {
+    case 'number':
+    case 'boolean':
+    case 'undefined':
+      return String(value);
+    case 'symbol':
+      return value.toString();
+    case 'function':
+      return `<function ${value.name ?? 'anonymous'}>`;
+    default: {
+      // Произвольный объект — показываем JSON, а не "[object Object]".
+      try {
+        const json = JSON.stringify(value);
+        if (json !== undefined) {
+          return json.length > 64
+            ? `${json.slice(0, 64)}…(${json.length} chars)`
+            : json;
+        }
+      } catch {
+        /* circular reference */
+      }
+      return '<object>';
+    }
+  }
+}
+
+/** Суффикс имени поля для сообщения об ошибке (если поле указано). */
+function fieldSuffix(field: string | undefined): string {
+  return field ? ` (field "${field}")` : '';
+}
+
+/** Оборачивает ошибку конвертации, добавляя контекст (поле, тип, значение). */
+function wrapConversionError(
+  type: YdbPrimitive,
+  value: unknown,
+  field: string | undefined,
+  err: unknown,
+): TypeError {
+  const detail = err instanceof Error ? err.message : String(err);
+  return new TypeError(
+    `Failed to convert value ${valuePreview(value)} to YDB type ${type}${fieldSuffix(field)}: ${detail}`,
+  );
+}
+
+/**
+ * Нормализация JS-даты: принимает Date, число (мс от эпохи) или ISO-строку.
+ *
+ * Внимание (точность): JS `Date` хранит только миллисекунды. YDB `Timestamp` —
+ * микросекунды. Конвертация идёт как `getTime() * 1000n`, поэтому
+ * субмиллисекундные значения (микро-/наносекунды) принципиально не могут быть
+ * сохранены: при записи они обнуляются, при чтении YDB-микросекунды теряют
+ * младшие три разряда. Используйте `Timestamp` только для миллисекундной
+ * точности.
+ */
 function toJsDate(value: Date | number | string): Date {
   return value instanceof Date ? value : new Date(value);
 }
 
-/** Обёртки JS-значений в YDB-значения. */
+/** Проверяет корректность даты; невалидные значения (Invalid Date) отклоняются. */
+function toValidJsDate(value: Date | number | string): Date {
+  const date = toJsDate(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new TypeError(`Invalid Date value (${valuePreview(value)})`);
+  }
+  return date;
+}
+
+/** Обёртки JS-значений в YDB-значения с валидацией типов и диапазонов. */
 const valueMappers: Record<YdbPrimitive, (value: any) => unknown> = {
   Uuid: (value: string) => new Uuid(value),
   Utf8: (value: string) => new Utf8(value),
   Bytes: (value: Uint8Array) => new Bytes(value),
-  Int32: (value: number) => new Int32(value),
-  Int64: (value: bigint | number | string) => new Int64(BigInt(value)),
+  Int32: (value: number) => {
+    if (typeof value !== 'number' || !Number.isInteger(value)) {
+      throw new TypeError(
+        `Int32 value must be an integer, got ${valuePreview(value)}`,
+      );
+    }
+    if (value < INT32_MIN || value > INT32_MAX) {
+      throw new RangeError(
+        `Int32 value ${value} is out of range [${INT32_MIN}, ${INT32_MAX}]`,
+      );
+    }
+    return new Int32(value);
+  },
+  Int64: (value: bigint | number | string) => {
+    let asBigInt: bigint;
+    try {
+      asBigInt = BigInt(value);
+    } catch (err) {
+      // BigInt() бросает сырой RangeError для дробных/NaN — добавим контекст.
+      throw new TypeError(
+        `Int64 value must be an integer, got ${valuePreview(value)}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    if (asBigInt < INT64_MIN || asBigInt > INT64_MAX) {
+      throw new RangeError(`Int64 value ${asBigInt} is out of range`);
+    }
+    return new Int64(asBigInt);
+  },
   Bool: (value: boolean) => new Bool(value),
   Double: (value: number) => new Double(value),
   Float: (value: number) => new Float(value),
-  Date: (value: Date | number | string) => new YdbDate(toJsDate(value)),
-  Datetime: (value: Date | number | string) => new Datetime(toJsDate(value)),
-  Timestamp: (value: Date | number | string) => new Timestamp(toJsDate(value)),
+  Date: (value: Date | number | string) => new YdbDate(toValidJsDate(value)),
+  Datetime: (value: Date | number | string) =>
+    new Datetime(toValidJsDate(value)),
+  // См. JSDoc `toJsDate` про миллисекундную точность Timestamp.
+  Timestamp: (value: Date | number | string) =>
+    new Timestamp(toValidJsDate(value)),
   Json: (value: any) =>
     new Json(typeof value === 'string' ? value : JSON.stringify(value)),
   JsonDocument: (value: any) =>
     new JsonDocument(typeof value === 'string' ? value : JSON.stringify(value)),
 };
 
-export function mapToYdb(type: YdbPrimitive, value: unknown) {
+/**
+ * Преобразует JS-значение в YDB-значение.
+ *
+ * @param type целевой YDB-тип
+ * @param value JS-значение (null → Optional<null>)
+ * @param field имя поля для контекста ошибок конвертации (необязательно)
+ */
+export function mapToYdb(type: YdbPrimitive, value: unknown, field?: string) {
   const wrap = valueMappers[type];
   if (!wrap) {
     throw new Error(`Unsupported YDB type: ${type as string}`);
   }
 
   if (value === undefined) {
-    throw new Error(`Undefined passed to YDB for type ${type}`);
+    throw new TypeError(
+      `Undefined passed to YDB for type ${type}${fieldSuffix(field)}`,
+    );
   }
 
   if (value === null) {
     return new Optional(null, nullTypeFactories[type]());
   }
 
-  return wrap(value);
+  try {
+    return wrap(value);
+  } catch (err) {
+    throw wrapConversionError(type, value, field, err);
+  }
 }

--- a/src/migrations/migration-runner.ts
+++ b/src/migrations/migration-runner.ts
@@ -448,11 +448,11 @@ export class YdbMigrationRunner {
         '(`id`, `timestamp`, `name`, `hash`, `state`) ' +
         'VALUES ($id, $timestamp, $name, $hash, $state)',
     ] as unknown as TemplateStringsArray);
-    query.parameter('id', mapToYdb('Int64', id));
-    query.parameter('timestamp', mapToYdb('Int64', Date.now()));
-    query.parameter('name', mapToYdb('Utf8', name));
-    query.parameter('hash', mapToYdb('Utf8', hash ?? null));
-    query.parameter('state', mapToYdb('Utf8', state));
+    query.parameter('id', mapToYdb('Int64', id, 'id'));
+    query.parameter('timestamp', mapToYdb('Int64', Date.now(), 'timestamp'));
+    query.parameter('name', mapToYdb('Utf8', name, 'name'));
+    query.parameter('hash', mapToYdb('Utf8', hash ?? null, 'hash'));
+    query.parameter('state', mapToYdb('Utf8', state, 'state'));
     await query;
   }
 
@@ -471,9 +471,9 @@ export class YdbMigrationRunner {
     const query = this.executor([
       `UPDATE ${quoteIdentifier(MIGRATIONS_TABLE)} SET \`state\` = $state, \`timestamp\` = $timestamp WHERE \`id\` = $id`,
     ] as unknown as TemplateStringsArray);
-    query.parameter('state', mapToYdb('Utf8', state));
-    query.parameter('timestamp', mapToYdb('Int64', Date.now()));
-    query.parameter('id', mapToYdb('Int64', id));
+    query.parameter('state', mapToYdb('Utf8', state, 'state'));
+    query.parameter('timestamp', mapToYdb('Int64', Date.now(), 'timestamp'));
+    query.parameter('id', mapToYdb('Int64', id, 'id'));
     await query;
   }
 
@@ -481,7 +481,7 @@ export class YdbMigrationRunner {
     const query = this.executor([
       `DELETE FROM ${quoteIdentifier(MIGRATIONS_TABLE)} WHERE \`id\` = $id`,
     ] as unknown as TemplateStringsArray);
-    query.parameter('id', mapToYdb('Int64', id));
+    query.parameter('id', mapToYdb('Int64', id, 'id'));
     await query;
   }
 

--- a/src/persistence/entity-persistence.ts
+++ b/src/persistence/entity-persistence.ts
@@ -338,7 +338,7 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
       const enumMeta = enums.find((e) => e.propertyKey === k);
       value = this.convertEnumOut(value, enumMeta);
       value = this.convertJsonOut(k, value);
-      query.parameter(k, mapToYdb(type, value));
+      query.parameter(k, mapToYdb(type, value, k));
     }
   }
 
@@ -1365,7 +1365,7 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
             const enumMeta = enums.find((e) => e.propertyKey === k);
             let value = this.convertEnumOut(row[k], enumMeta);
             value = this.convertJsonOut(k, value);
-            query.parameter(`${k}_${i}`, mapToYdb(dbSchema[k], value));
+            query.parameter(`${k}_${i}`, mapToYdb(dbSchema[k], value, k));
           }
         });
 
@@ -1558,7 +1558,7 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
     const sql = `DELETE FROM ${quoteIdentifier(meta.tableName)} WHERE ${whereClause} RETURNING *`;
     const query = exec([sql] as unknown as TemplateStringsArray);
     for (const f of pkFields) {
-      query.parameter(paramName(f), mapToYdb(dbSchema[f], filter[f]));
+      query.parameter(paramName(f), mapToYdb(dbSchema[f], filter[f], f));
     }
 
     const rows = await this.executeQuery<Record<string, any>[][]>(
@@ -1705,7 +1705,7 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
 
     const query = exec([sql] as unknown as TemplateStringsArray);
     values.forEach((value, i) => {
-      query.parameter(`p${i}`, mapToYdb(columnType, value));
+      query.parameter(`p${i}`, mapToYdb(columnType, value, column));
     });
 
     const rows = await this.executeQuery<Record<string, any>[][]>(

--- a/src/relations/entity-relations.ts
+++ b/src/relations/entity-relations.ts
@@ -111,7 +111,7 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
 
     const joinQuery = exec([sql] as unknown as TemplateStringsArray);
     ownerPks.forEach((value, i) => {
-      joinQuery.parameter(`p${i}`, mapToYdb(ownerPkType, value));
+      joinQuery.parameter(`p${i}`, mapToYdb(ownerPkType, value, ownerPkField));
     });
 
     const joinRows = await this.executeQuery(joinQuery, options);


### PR DESCRIPTION
Closes #105

## Проблема
- Потеря микросекунд при Date→Timestamp не задокументирована.
- Ошибки конвертации безымянные: `BigInt(4.5)` бросает голый RangeError без поля/типа/значения.
- `Int32` не проверял диапазон 2^31 — падало уже в драйвере.
- `toJsDate(garbage)` давал `Invalid Date`, которое уезжало в драйвер.

## Изменения
- **README + JSDoc `toJsDate`**: явно задокументирована миллисекундная точность `Timestamp` (JS Date хранит только мс, конвертация `getTime() * 1000n`; субмиллисекунды не сохраняются).
- **`mapToYdb(type, value, field?)`**: добавлен необязательный параметр `field` для контекста ошибок; вызовы в `entity-persistence`, `relations`, `migration-runner` прокидывают имена полей. Публичный API обратно совместим (двухаргументный вызов сохраняется).
- **Ошибки конвертации** оборачиваются в `TypeError` с полем, YDB-типом и безопасным представлением значения (`valuePreview` не раскрывает бинарные данные и длинные строки).
- **Валидация диапазонов**: `Int32` — `[-2^31, 2^31-1]` и целочисленность; `Int64` — `[-2^63, 2^63-1]`.
- **Валидация дат**: `Date`/`Datetime`/`Timestamp` отклоняют `Invalid Date` (мусорная строка, `NaN` мс, инвалидный `Date`) вместо передачи в драйвер.

## Тесты
- Граничные значения Int32/Int64 (min/max валидны; выше/ниже — ошибка).
- Дробные/NaN для целочисленных типов.
- Невалидные даты для всех трёх темпоральных типов.
- Контекст ошибки (поле, тип, значение) в сообщениях.
- Точность Timestamp: `value === BigInt(getTime()) * 1000n`, младшие разряды нулевые.

`yarn build`, `yarn test` (592/592), `yarn lint` (0 errors) — все зелёные.