### PR TITLE
fix(query): getOne() не мутирует билдер; явная семантика limit(0)/без лимита; reject дробного LIMIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,20 @@ await PhotoEntity.query().where({ is_public: true }).getCount(); // COUNT(*)
 const { sql, values } = await PhotoEntity.query().where({ is_public: true }).toYql(); // без выполнения
 ```
 
+Билдер переиспользуем: `getOne()`/`getMany()`/`toYql()` не меняют его состояние,
+один и тот же builder можно выполнять несколько раз (например, `getOne()`, затем
+`getMany()` с сохранённым лимитом).
+
+Явная семантика `limit()` (без молчаливого clamp в 1..1000):
+
+| вызов | итоговый `LIMIT` |
+| --- | --- |
+| лимит не задан | `100` — защитный дефолт (константа `DEFAULT_RETRIEVE_LIMIT`) |
+| `limit(0)` | `0` — гарантированно пустой результат |
+| `limit(n)`, 1 ≤ n ≤ 1000 | `n` |
+| `limit(n)`, n > 1000 | `1000` — защитный потолок (`MAX_RETRIEVE_LIMIT`) |
+| `limit(отрицательное)` | ошибка `Invalid LIMIT` |
+
 WHERE поддерживает операторы сравнения, логические группы `$or`/`$and` и JSON-операторы. Поля в WHERE/ORDER BY валидируются по метаданным сущности.
 
 ### WHERE-операторы

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ const { sql, values } = await PhotoEntity.query().where({ is_public: true }).toY
 | `limit(0)` | `0` — гарантированно пустой результат |
 | `limit(n)`, 1 ≤ n ≤ 1000 | `n` |
 | `limit(n)`, n > 1000 | `1000` — защитный потолок (`MAX_RETRIEVE_LIMIT`) |
-| `limit(отрицательное)` | ошибка `Invalid LIMIT` |
+| `limit(отрицательное / дробное / неконечное)` | ошибка `Invalid LIMIT` |
 
 WHERE поддерживает операторы сравнения, логические группы `$or`/`$and` и JSON-операторы. Поля в WHERE/ORDER BY валидируются по метаданным сущности.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,10 @@ export type { LifecycleHooks } from './decorators/lifecycle.decorator.js';
 export { YdbBaseEntity } from './entity/base-entity.js';
 export { YdbQueryBuilder } from './query/query-builder.js';
 export type { BuiltQuery, OrderDirection } from './query/query-builder.js';
+export {
+  DEFAULT_RETRIEVE_LIMIT,
+  MAX_RETRIEVE_LIMIT,
+} from './query/query-builder.js';
 
 // Репозитории / EntityManager (DI-вариант поверх Active Record)
 export {

--- a/src/query/query-builder.spec.ts
+++ b/src/query/query-builder.spec.ts
@@ -162,6 +162,85 @@ describe('YdbQueryBuilder', () => {
     expect(none).toBeNull();
   });
 
+  it('getOne does not mutate the builder: getMany after it keeps the original limit', async () => {
+    const sunset = {
+      uuid: '5ad91505-d4f6-4a81-ab65-9dbc68cf4ed5',
+      title: 'Sunset',
+      is_public: true,
+      rating: 4.5,
+    };
+    const dawn = {
+      uuid: 'a1e1d4b2-0000-4000-8000-0f0c0e0d0c0b',
+      title: 'Dawn',
+      is_public: true,
+      rating: 3.0,
+    };
+    const mock = mockRuntime([[sunset, dawn]]);
+
+    const builder = QbPhotoEntity.query()
+      .where({ is_public: true })
+      .orderBy('rating', 'DESC')
+      .limit(10);
+
+    const one = await builder.getOne();
+    expect(one).toBeInstanceOf(QbPhotoEntity);
+    expect(one?.title).toBe('Sunset');
+    expect(mock.queries[0].sql).toContain('LIMIT 1 OFFSET 0');
+
+    const many = await builder.getMany();
+    expect(mock.queries[1].sql).toContain('LIMIT 10 OFFSET 0');
+    expect(mock.queries[1].sql).toContain('ORDER BY `rating` DESC');
+    expect(many).toHaveLength(2);
+
+    const { sql } = await builder.toYql();
+    expect(sql).toContain('LIMIT 10 OFFSET 0');
+  });
+
+  it('limit(0) yields an empty result (LIMIT 0), not clamped to 1', async () => {
+    const mock = mockRuntime([[]]);
+
+    const result = await QbPhotoEntity.query()
+      .where({ is_public: true })
+      .limit(0)
+      .getMany();
+    expect(result).toEqual([]);
+    expect(mock.queries[0].sql).toContain('LIMIT 0 OFFSET 0');
+  });
+
+  it('getOne with limit(0) returns null and leaves the builder at limit(0)', async () => {
+    const mock = mockRuntime([[]]);
+    const builder = QbPhotoEntity.query().limit(0);
+
+    const one = await builder.getOne();
+    expect(one).toBeNull();
+    expect(mock.queries[0].sql).toContain('LIMIT 1 OFFSET 0');
+
+    const { sql } = await builder.toYql();
+    expect(sql).toContain('LIMIT 0 OFFSET 0');
+  });
+
+  it('omitted limit keeps the default safety limit of 100', async () => {
+    mockRuntime();
+    const { sql } = await QbPhotoEntity.query().toYql();
+    expect(sql).toContain('LIMIT 100 OFFSET 0');
+  });
+
+  it('normal positive limit passes through unchanged', async () => {
+    mockRuntime();
+    const { sql } = await QbPhotoEntity.query().limit(5).toYql();
+    expect(sql).toContain('LIMIT 5 OFFSET 0');
+  });
+
+  it('rejects negative limit explicitly instead of clamping it', async () => {
+    mockRuntime();
+    await expect(QbPhotoEntity.query().limit(-1).toYql()).rejects.toThrow(
+      /Invalid LIMIT: -1\. LIMIT must be a finite non-negative number\./,
+    );
+    await expect(QbPhotoEntity.query().limit(-100).getMany()).rejects.toThrow(
+      /Invalid LIMIT/,
+    );
+  });
+
   it('getCount builds COUNT query without LIMIT', async () => {
     const mock = mockRuntime([[{ cnt: 7 }]]);
 

--- a/src/query/query-builder.spec.ts
+++ b/src/query/query-builder.spec.ts
@@ -234,11 +234,40 @@ describe('YdbQueryBuilder', () => {
   it('rejects negative limit explicitly instead of clamping it', async () => {
     mockRuntime();
     await expect(QbPhotoEntity.query().limit(-1).toYql()).rejects.toThrow(
-      /Invalid LIMIT: -1\. LIMIT must be a finite non-negative number\./,
+      /Invalid LIMIT: -1\. LIMIT must be a finite non-negative integer\./,
     );
     await expect(QbPhotoEntity.query().limit(-100).getMany()).rejects.toThrow(
       /Invalid LIMIT/,
     );
+  });
+
+  it('rejects fractional positive limit instead of flooring it', async () => {
+    mockRuntime();
+    await expect(QbPhotoEntity.query().limit(1.9).toYql()).rejects.toThrow(
+      /Invalid LIMIT: 1\.9\. LIMIT must be a finite non-negative integer\./,
+    );
+    await expect(QbPhotoEntity.query().limit(0.5).getMany()).rejects.toThrow(
+      /Invalid LIMIT/,
+    );
+  });
+
+  it('rejects fractional negative limit', async () => {
+    mockRuntime();
+    await expect(QbPhotoEntity.query().limit(-1.9).toYql()).rejects.toThrow(
+      /Invalid LIMIT: -1\.9\. LIMIT must be a finite non-negative integer\./,
+    );
+    await expect(QbPhotoEntity.query().limit(-0.5).getMany()).rejects.toThrow(
+      /Invalid LIMIT/,
+    );
+  });
+
+  it('rejects non-finite limits', async () => {
+    mockRuntime();
+    for (const bad of [Infinity, -Infinity, NaN]) {
+      await expect(QbPhotoEntity.query().limit(bad).toYql()).rejects.toThrow(
+        /Invalid LIMIT: (Infinity|-Infinity|NaN)\. LIMIT must be a finite non-negative integer\./,
+      );
+    }
   });
 
   it('getCount builds COUNT query without LIMIT', async () => {

--- a/src/query/query-builder.ts
+++ b/src/query/query-builder.ts
@@ -21,11 +21,21 @@ type EntityClass<T extends YdbBaseEntity> = {
   new (): T;
 } & typeof YdbBaseEntity;
 
+/** Защитный лимит по умолчанию, когда limit не задан явно. */
+export const DEFAULT_RETRIEVE_LIMIT = 100;
+
+/** Защитный потолок для положительного LIMIT. */
+export const MAX_RETRIEVE_LIMIT = 1000;
+
 /**
  * Цепочный query builder поверх Active Record сущности.
  * Условия where/andWhere — только равенство, объединяются через AND
  * (повторное поле в andWhere перезаписывает предыдущее).
  * Зашифрованные поля с blind index поддерживаются так же, как в find/findAll.
+ *
+ * Билдер переиспользуем: методы-строители (where/orderBy/limit/... ) и методы
+ * выполнения (getMany/getOne/toYql) не мутируют состояние друг друга.
+ * Один и тот же билдер можно выполнить несколько раз — результат одинаковый.
  *
  * @example
  *   const photos = await PhotoEntity.query()
@@ -139,6 +149,20 @@ export class YdbQueryBuilder<T extends YdbBaseEntity> {
     return this;
   }
 
+  /**
+   * Ограничить количество возвращаемых строк (LIMIT).
+   *
+   * Явная семантика (без молчаливого clamp в диапазон 1..1000):
+   * - `limit(0)` — `LIMIT 0`: гарантированно пустой результат `[]`;
+   * - положительное значение `n` — до `n` строк, сверху обрезается до
+   *   MAX_RETRIEVE_LIMIT (защитный потолок);
+   * - лимит вообще не задан — действует защитный дефолт
+   *   DEFAULT_RETRIEVE_LIMIT (см. resolveLimit);
+   * - отрицательное / нечисловое значение — ошибка.
+   *
+   * Значение сохраняется в билдере и не меняется при выполнении:
+   * getOne()/getMany()/toYql() его читают, но не перезаписывают.
+   */
   limit(limit: number): this {
     this.limitValue = limit;
     return this;
@@ -179,9 +203,14 @@ export class YdbQueryBuilder<T extends YdbBaseEntity> {
     return this.getMany();
   }
 
-  /** Первая запись или null. */
+  /**
+   * Первая запись или null.
+   *
+   * Не мутирует исходный билдер: LIMIT 1 применяется к копии. Повторный
+   * getMany()/toYql() на этом же билдере сохранит заданный пользователем лимит.
+   */
   async getOne(): Promise<T | null> {
-    const result = await this.limit(1).getMany();
+    const result = await this.clone().limit(1).getMany();
     return result[0] ?? null;
   }
 
@@ -200,6 +229,20 @@ export class YdbQueryBuilder<T extends YdbBaseEntity> {
       dbSchema,
       this.queryOptions,
     );
+  }
+
+  /** Копия билдера: выполнение на копии не меняет состояние исходника. */
+  private clone(): YdbQueryBuilder<T> {
+    const copy = new YdbQueryBuilder<T>(this.entity);
+    copy.whereValues = { ...this.whereValues };
+    copy.orderClauses = this.orderClauses.map((o) => ({ ...o }));
+    copy.limitValue = this.limitValue;
+    copy.offsetValue = this.offsetValue;
+    copy.selectColumns = this.selectColumns
+      ? [...this.selectColumns]
+      : undefined;
+    copy.queryOptions = this.queryOptions;
+    return copy;
   }
 
   private async build(): Promise<CompiledQuery> {
@@ -268,10 +311,29 @@ export class YdbQueryBuilder<T extends YdbBaseEntity> {
     return Object.keys(dbSchema).join(', ');
   }
 
+  /**
+   * Итоговый LIMIT с явной семантикой:
+   * - лимит не задан (limit() и queryOptions.limit отсутствуют) —
+   *   защитный дефолт DEFAULT_RETRIEVE_LIMIT;
+   * - limit(0) — `0` (пустой результат), НЕ клампится в 1;
+   * - положительное значение — до MAX_RETRIEVE_LIMIT (потолок);
+   * - отрицательное или неконечное — ошибка.
+   */
   private resolveLimit(): number {
     const value = this.limitValue ?? this.queryOptions?.limit;
-    const num = Number.isFinite(value) ? Math.floor(value as number) : 100;
-    return Math.max(1, Math.min(num, 1000));
+    if (value === undefined) {
+      return DEFAULT_RETRIEVE_LIMIT;
+    }
+    if (!Number.isFinite(value) || value < 0) {
+      throw new Error(
+        `Invalid LIMIT: ${String(value)}. LIMIT must be a finite non-negative number.`,
+      );
+    }
+    const num = Math.floor(value);
+    if (num === 0) {
+      return 0;
+    }
+    return Math.min(num, MAX_RETRIEVE_LIMIT);
   }
 
   private resolveOffset(): number {

--- a/src/query/query-builder.ts
+++ b/src/query/query-builder.ts
@@ -154,11 +154,11 @@ export class YdbQueryBuilder<T extends YdbBaseEntity> {
    *
    * Явная семантика (без молчаливого clamp в диапазон 1..1000):
    * - `limit(0)` — `LIMIT 0`: гарантированно пустой результат `[]`;
-   * - положительное значение `n` — до `n` строк, сверху обрезается до
+   * - положительное целое значение `n` — до `n` строк, сверху обрезается до
    *   MAX_RETRIEVE_LIMIT (защитный потолок);
    * - лимит вообще не задан — действует защитный дефолт
    *   DEFAULT_RETRIEVE_LIMIT (см. resolveLimit);
-   * - отрицательное / нечисловое значение — ошибка.
+   * - отрицательное, дробное или неконечное значение — ошибка.
    *
    * Значение сохраняется в билдере и не меняется при выполнении:
    * getOne()/getMany()/toYql() его читают, но не перезаписывают.
@@ -316,20 +316,20 @@ export class YdbQueryBuilder<T extends YdbBaseEntity> {
    * - лимит не задан (limit() и queryOptions.limit отсутствуют) —
    *   защитный дефолт DEFAULT_RETRIEVE_LIMIT;
    * - limit(0) — `0` (пустой результат), НЕ клампится в 1;
-   * - положительное значение — до MAX_RETRIEVE_LIMIT (потолок);
-   * - отрицательное или неконечное — ошибка.
+   * - положительное целое значение — до MAX_RETRIEVE_LIMIT (потолок);
+   * - отрицательное, дробное или неконечное значение — ошибка.
    */
   private resolveLimit(): number {
     const value = this.limitValue ?? this.queryOptions?.limit;
     if (value === undefined) {
       return DEFAULT_RETRIEVE_LIMIT;
     }
-    if (!Number.isFinite(value) || value < 0) {
+    if (!Number.isFinite(value) || value < 0 || !Number.isInteger(value)) {
       throw new Error(
-        `Invalid LIMIT: ${String(value)}. LIMIT must be a finite non-negative number.`,
+        `Invalid LIMIT: ${String(value)}. LIMIT must be a finite non-negative integer.`,
       );
     }
-    const num = Math.floor(value);
+    const num = value;
     if (num === 0) {
       return 0;
     }


### PR DESCRIPTION
Fixes #104

## Проблема
- `getOne()` вызывал `this.limit(1)`, перманентно меняя `limitValue` билдера: последующий `getMany()`/`toYql()` на той же цепочке возвращал `LIMIT 1`.
- `resolveLimit()` жёстко клампил `Math.max(1, Math.min(n, 1000))`: `limit(0)` был недостижим (легальный способ получить пустой результат), а отсутствие лимита и `limit(0)` молча приводились к диапазону 1..1000.
- Дробные значения вроде `1.9` молча обрезались через `Math.floor()` — неоднозначно.

## Изменения
- `getOne()` теперь выполняется на **копии** билдера (`private clone()`): исходный билдер не мутирует, переиспользуем для `getMany()`/`toYql()` с сохранённым лимитом.
- Явная семантика `resolveLimit()` (без молчаливого clamp):
  - лимит не задан → защитный дефолт `100` (`DEFAULT_RETRIEVE_LIMIT`);
  - `limit(0)` → `LIMIT 0` (пустой результат, не клампится в 1);
  - положительное целое `n` → `min(n, 1000)` (защитный потолок `MAX_RETRIEVE_LIMIT`);
  - отрицательное / дробное / неконечное значение → ошибка `Invalid LIMIT`;
  - обязательно целое: дробные `1.9`/`-1.9`/`0.5` больше не молча обрезаются, а падают с `LIMIT must be a finite non-negative integer`.
- Константы `DEFAULT_RETRIEVE_LIMIT`/`MAX_RETRIEVE_LIMIT` экспортированы из `src/index.ts`.
- Семантика задокументирована в JSDoc и README.
- Регрессионные тесты: переиспользование билдера после `getOne()`, `limit(0)`, лимит по умолчанию, обычные положительные лимиты, верхняя граница 1000, ошибки на отрицательном и дробном LIMIT (`1.9`, `-1.9`, `0.5`, `Infinity`, `NaN`).

Затронут только QueryBuilder (`src/query/query-builder.ts`) — API `find`/`findAll` не менялся.

Проверено: `yarn test` (606 тестов), `yarn build`, `yarn lint` (0 ошибок).