### PR TITLE
fix(logger): логирование запросов в транзакциях и маскирование коротких секретов (#99)

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,8 +400,9 @@ YdbCoreModule.forRootAsync({
 ```
 
 - `logQueries: true` — используется `ConsoleQueryLogger` (вывод `[YDB] QUERY <ms>` с SQL и замаскированными параметрами).
-- `logQueries: <QueryLogger>` — собственный логгер: интерфейс `QueryLogger { log(entry: QueryLogEntry): void }`. `QueryLogEntry` содержит `sql`, `paramNames`, `maskedParams` (значения секретов и длинных строк маскируются), `durationMs` и опциональную `error`.
-- Аналогично работает standalone `createExecutor(driver, opts)` (учитывает `poolOptions` и `logQueries`). Утилита `wrapExecutorWithLogging(executor, logger)` позволяет обернуть executor логированием вручную.
+- `logQueries: <QueryLogger>` — собственный логгер: интерфейс `QueryLogger { log(entry: QueryLogEntry): void }`. `QueryLogEntry` содержит `sql`, `paramNames`, `maskedParams` (все значения маскируются), `durationMs` и опциональную `error`.
+- Аналогично работает standalone `createExecutor(driver, opts)` (учитывает `poolOptions` и `logQueries`). Утилита `wrapExecutorWithLogging(executor, logger)` позволяет обернуть executor логированием вручную — она же логирует каждый запрос внутри `runInTransaction`.
+- Маскирование параметров: секреты/PII по имени параметра (`password`, `token`, `secret`, `authorization`, `email`, credential, phone, card, blind index `{field}_bi` и т.п.) заменяются на `<redacted>` для значений любой длины; бинарные/зашифрованные данные логируются только длиной (`<bytes:N>`); остальные длинные строки обрезаются до 64 символов.
 
 ## Аутентификация (`auth_type`)
 

--- a/src/core/query-logger.ts
+++ b/src/core/query-logger.ts
@@ -27,8 +27,88 @@ export interface QueryLogger {
 /** Максимальная длина замаскированного значения параметра. */
 const MAX_PARAM_LENGTH = 64;
 
-/** Маскирование значения параметра: секреты скрыты, длинные строки обрезаны. */
-function maskValue(value: unknown): unknown {
+/** Плейсхолдер вместо значения секретного/PII параметра в логах. */
+const REDACTED = '<redacted>';
+
+/**
+ * Токены, по которым имя параметра признаётся чувствительным (секреты/PII).
+ * Матчинг по токенам имени (password, token, secret, email, authorization и
+ * т.п.) — короткие значения не должны попадать в лог открыто только потому,
+ * что не длиннее MAX_PARAM_LENGTH.
+ */
+const SENSITIVE_TOKENS = new Set([
+  'password',
+  'passwd',
+  'passphrase',
+  'pwd',
+  'token',
+  'tokens',
+  'secret',
+  'secrets',
+  'authorization',
+  'credential',
+  'credentials',
+  'apikey',
+  'accesskey',
+  'secretkey',
+  'privatekey',
+  'clientsecret',
+  'email',
+  'emails',
+  'phone',
+  'phone_number',
+  'telephone',
+  'mobile',
+  'cellphone',
+  'ssn',
+  'passport',
+  'cvv',
+  'cvc',
+  'card',
+  'cardnumber',
+  'pin',
+  'first_name',
+  'last_name',
+  'full_name',
+  'username',
+  'login',
+  'cookie',
+  'session',
+  'bearer',
+]);
+
+/**
+ * Чувствителен ли параметр по имени.
+ *
+ * Кроме явных токенов секретов/PII маскируются synthetic-колонки blind index
+ * (`{field}_bi`): их хеш детерминирован по plaintext, и по логам можно
+ * коррелировать значения/подбирать их частотным анализом.
+ */
+function isSensitiveParam(name: string): boolean {
+  const lower = name.toLowerCase();
+  if (/[-_]bi$/.test(lower)) return true;
+  const tokens = lower.split(/[^a-z0-9]+/).filter((t) => t.length > 0);
+  return tokens.some((t) => SENSITIVE_TOKENS.has(t));
+}
+
+/**
+ * Маскирование скалярного значения: ciphertext/бинарные данные — только длиной,
+ * чувствительные параметры — целиком, длинные строки обрезаются.
+ */
+function maskScalarValue(name: string, value: unknown): unknown {
+  if (value instanceof Uint8Array) {
+    // Бинарные/зашифрованные данные никогда не логируем дословно.
+    return `<bytes:${value.length}>`;
+  }
+  if (isSensitiveParam(name)) return REDACTED;
+  if (typeof value === 'string' && value.length > MAX_PARAM_LENGTH) {
+    return value.slice(0, MAX_PARAM_LENGTH) + '...';
+  }
+  return value;
+}
+
+/** Маскирование значения параметра по имени параметра. */
+function maskValue(name: string, value: unknown): unknown {
   if (value === null || value === undefined) return value;
   if (
     typeof value === 'object' &&
@@ -38,25 +118,9 @@ function maskValue(value: unknown): unknown {
     // YDB typed value { type: ..., value: ... }
     const inner = (value as any).value;
     if (inner === null || inner === undefined) return inner;
-    if (typeof inner === 'string') {
-      return inner.length > MAX_PARAM_LENGTH
-        ? inner.slice(0, MAX_PARAM_LENGTH) + '...'
-        : inner;
-    }
-    if (inner instanceof Uint8Array) {
-      return `<bytes:${inner.length}>`;
-    }
-    return inner;
+    return maskScalarValue(name, inner);
   }
-  if (value instanceof Uint8Array) {
-    return `<bytes:${value.length}>`;
-  }
-  if (typeof value === 'string') {
-    return value.length > MAX_PARAM_LENGTH
-      ? value.slice(0, MAX_PARAM_LENGTH) + '...'
-      : value;
-  }
-  return value;
+  return maskScalarValue(name, value);
 }
 
 /**
@@ -103,7 +167,7 @@ export function wrapExecutorWithLogging(
     const proxied: any = {
       parameter(name: string, value: unknown) {
         paramNames.push(name);
-        maskedParams[name] = maskValue(value);
+        maskedParams[name] = maskValue(name, value);
         originalParameter(name, value);
         // Возвращаем прокси, иначе цепочка parameter().parameter() сбегает
         // из прокси и последующие вызовы теряют логирование
@@ -146,7 +210,20 @@ export function wrapExecutorWithLogging(
     return proxied;
   };
 
-  wrapped.transaction = executor.transaction.bind(executor);
+  wrapped.transaction = () => {
+    const tx = executor.transaction();
+    return {
+      execute: (
+        fn: (trx: YdbExecutor, signal?: AbortSignal) => Promise<unknown>,
+      ) =>
+        tx.execute((trx: YdbExecutor, signal?: AbortSignal) => {
+          // Транзакционный executor оборачивается тем же логгером: каждый
+          // запрос внутри runInTransaction (и вложенных транзакций) логируется
+          // с той же семантикой, что и обычные запросы.
+          return fn(wrapExecutorWithLogging(trx, logger), signal);
+        }),
+    };
+  };
 
   return wrapped as YdbExecutor;
 }

--- a/test/query-logger.spec.ts
+++ b/test/query-logger.spec.ts
@@ -131,10 +131,79 @@ describe('wrapExecutorWithLogging', () => {
     const logging = wrapExecutorWithLogging(mock.executor, mockLogger);
 
     const q = logging(['INSERT INTO t'] as unknown as TemplateStringsArray);
-    q.parameter('secret', 'a'.repeat(200));
+    q.parameter('description', 'a'.repeat(200));
     await q;
 
-    expect(logEntries[0].maskedParams.secret).toBe('a'.repeat(64) + '...');
+    expect(logEntries[0].maskedParams.description).toBe('a'.repeat(64) + '...');
+  });
+
+  it('redacts short sensitive parameter values', async () => {
+    const mock = createMockExecutor([[]]);
+    const logging = wrapExecutorWithLogging(mock.executor, mockLogger);
+
+    const q = logging(['INSERT INTO t'] as unknown as TemplateStringsArray);
+    q.parameter('password', 'hunter2');
+    q.parameter('api_token', 'abc123');
+    q.parameter('authorization', 'Bearer x');
+    q.parameter('email_encrypted', 'ivan@example.com');
+    await q;
+
+    expect(logEntries[0].maskedParams.password).toBe('<redacted>');
+    expect(logEntries[0].maskedParams.api_token).toBe('<redacted>');
+    expect(logEntries[0].maskedParams.authorization).toBe('<redacted>');
+    expect(logEntries[0].maskedParams.email_encrypted).toBe('<redacted>');
+  });
+
+  it('redacts long sensitive parameter values', async () => {
+    const mock = createMockExecutor([[]]);
+    const logging = wrapExecutorWithLogging(mock.executor, mockLogger);
+
+    const q = logging(['INSERT INTO t'] as unknown as TemplateStringsArray);
+    q.parameter('secret', 'k'.repeat(500));
+    q.parameter('access_token', 't'.repeat(500));
+    await q;
+
+    expect(logEntries[0].maskedParams.secret).toBe('<redacted>');
+    expect(logEntries[0].maskedParams.access_token).toBe('<redacted>');
+  });
+
+  it('redacts blind index columns by suffix', async () => {
+    const mock = createMockExecutor([[]]);
+    const logging = wrapExecutorWithLogging(mock.executor, mockLogger);
+
+    const q = logging(['INSERT INTO t'] as unknown as TemplateStringsArray);
+    q.parameter('email_encrypted_bi', 'hash-of-plaintext');
+    q.parameter('author_email_bi', 'another-hash');
+    await q;
+
+    expect(logEntries[0].maskedParams.email_encrypted_bi).toBe('<redacted>');
+    expect(logEntries[0].maskedParams.author_email_bi).toBe('<redacted>');
+  });
+
+  it('redacts non-string sensitive values', async () => {
+    const mock = createMockExecutor([[]]);
+    const logging = wrapExecutorWithLogging(mock.executor, mockLogger);
+
+    const q = logging(['INSERT INTO t'] as unknown as TemplateStringsArray);
+    q.parameter('pin', 1234);
+    await q;
+
+    expect(logEntries[0].maskedParams.pin).toBe('<redacted>');
+  });
+
+  it('keeps non-sensitive short and long values unmasked/truncated', async () => {
+    const mock = createMockExecutor([[]]);
+    const logging = wrapExecutorWithLogging(mock.executor, mockLogger);
+
+    const q = logging(['INSERT INTO t'] as unknown as TemplateStringsArray);
+    q.parameter('title', 'Hello');
+    q.parameter('table_name', 't'.repeat(100));
+    q.parameter('hash', 'sha256hash');
+    await q;
+
+    expect(logEntries[0].maskedParams.title).toBe('Hello');
+    expect(logEntries[0].maskedParams.table_name).toBe('t'.repeat(64) + '...');
+    expect(logEntries[0].maskedParams.hash).toBe('sha256hash');
   });
 
   it('masks Uint8Array parameters', async () => {
@@ -167,5 +236,89 @@ describe('wrapExecutorWithLogging', () => {
     const logging = wrapExecutorWithLogging(mock.executor, mockLogger);
 
     expect(typeof (logging as any).transaction).toBe('function');
+  });
+
+  it('logs queries inside a transaction', async () => {
+    const mock = createMockExecutor([[{ cnt: 1 }]]);
+    const logging = wrapExecutorWithLogging(mock.executor, mockLogger);
+
+    await (logging as any).transaction().execute(async (trx: any) => {
+      const q = trx(['SELECT COUNT(*) FROM t'] as unknown);
+      q.parameter('flag', 1);
+      await q;
+    });
+
+    expect(logEntries).toHaveLength(1);
+    expect(logEntries[0].sql).toBe('SELECT COUNT(*) FROM t');
+    expect(logEntries[0].paramNames).toEqual(['flag']);
+    expect(logEntries[0].maskedParams).toEqual({ flag: 1 });
+    expect(logEntries[0].error).toBeUndefined();
+  });
+
+  it('logs queries across nested transactions', async () => {
+    const mock = createMockExecutor([[]]);
+    const logging = wrapExecutorWithLogging(mock.executor, mockLogger);
+
+    await (logging as any).transaction().execute(async (trx: any) => {
+      await trx(['SELECT 1'] as unknown);
+      await trx.transaction().execute(async (trx2: any) => {
+        await trx2(['SELECT 2'] as unknown);
+      });
+    });
+
+    expect(logEntries).toHaveLength(2);
+    expect(logEntries.map((e) => e.sql)).toEqual(['SELECT 1', 'SELECT 2']);
+  });
+
+  it('logs transaction queries that fail with the query error', async () => {
+    const failExecutor: any = jest.fn(() => ({
+      parameter: jest.fn().mockReturnThis(),
+      timeout: jest.fn().mockReturnThis(),
+      signal: jest.fn().mockReturnThis(),
+      cancel: jest.fn().mockReturnThis(),
+      then: (_onFulfilled: any, onRejected: any) =>
+        Promise.reject(new Error('tx query rejected')).then(
+          _onFulfilled,
+          onRejected,
+        ),
+    }));
+    failExecutor.transaction = () => ({
+      execute: (fn: any) => fn(failExecutor),
+    });
+
+    const logging = wrapExecutorWithLogging(failExecutor, mockLogger);
+
+    await expect(
+      (logging as any).transaction().execute(async (trx: any) => {
+        const q = trx(['SELECT 1'] as unknown);
+        q.parameter('p', 'v');
+        await q;
+      }),
+    ).rejects.toThrow('tx query rejected');
+
+    expect(logEntries).toHaveLength(1);
+    expect(logEntries[0].sql).toBe('SELECT 1');
+    expect(logEntries[0].error?.message).toBe('tx query rejected');
+  });
+
+  it('logs queries whose transaction body later fails (rollback)', async () => {
+    const mock = createMockExecutor([[]]);
+    const logging = wrapExecutorWithLogging(mock.executor, mockLogger);
+
+    await expect(
+      (logging as any).transaction().execute(async (trx: any) => {
+        const q = trx(['UPDATE t SET x = 1'] as unknown);
+        q.parameter('v', 2);
+        await q;
+        throw new Error('tx rollback');
+      }),
+    ).rejects.toThrow('tx rollback');
+
+    // Сам запрос прошёл успешно — он залогирован без ошибки, несмотря на
+    // последующий откат транзакции.
+    expect(logEntries).toHaveLength(1);
+    expect(logEntries[0].sql).toBe('UPDATE t SET x = 1');
+    expect(logEntries[0].maskedParams).toEqual({ v: 2 });
+    expect(logEntries[0].error).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Что сделано

Fixes #99. Две части:

### 1. Логирование запросов в транзакциях

Раньше `wrapExecutorWithLogging` пробрасывал `transaction()` без обёртки (`wrapped.transaction = executor.transaction.bind(executor)`), поэтому при включённом `logQueries` все запросы внутри `runInTransaction` исчезали из логов.

Теперь `wrapped.transaction()` оборачивает транзакционный executor тем же `wrapExecutorWithLogging(...)` с тем же логгером: каждый запрос внутри транзакции логируется с той же семантикой (`sql`, `paramNames`, `maskedParams`, `durationMs`, `error`), что и обычный запрос. Проксирование работает и для вложенных транзакций (рекурсивная обёртка каждого узла).

### 2. Маскирование секретов/PII по имени параметра, а не длине

Раньше `maskValue` резал/скрывал только строки длиннее 64 символов — короткие секреты/PII (`password: 'hunter2'`, `email`, `token`) попадали в лог открыто.

Теперь маскирование на уровне имени параметра:
- именные токены (`password`/`passwd`/`passphrase`, `token`, `secret`, `authorization`, `credential`, `api_key`-варианты, `email`, `phone`, `ssn`, `card`, `pin`, `username`, `session`, `bearer`, …) — значение любой длины заменяется на `<redacted>`;
- synthetic-колонки blind index `{field}_bi` — по суффиксу, не логируем детерминированный хеш plaintext;
- бинарные/зашифрованные значения — всегда только `<bytes:N>`, содержимое не логируется;
- длинные нечувствительные строки по-прежнему обрезаются до 64 символов (`...`);
- нечувствительные значения (id, названия, миграционные `hash`, числа и т.д.) логируются как раньше.

Публичный API (`QueryLogger`, `QueryLogEntry`, `ConsoleQueryLogger`, `wrapExecutorWithLogging`) и структура логов не изменились.

## Тесты

Добавлены регрессионные тесты в `test/query-logger.spec.ts`:
- запрос внутри транзакции логируется;
- вложенные транзакции логируются;
- упавший запрос внутри транзакции логируется с `error`;
- сбойное тело транзакции (rollback) после успешного запроса — сам запрос всё равно залогирован;
- короткие чувствительные значения (`password`, `api_token`, `authorization`, `email_encrypted`) не попадают в лог;
- длинные чувствительные значения — тоже `<redacted>`, а не обрезка;
- `{field}_bi` blind index маскируется;
- нечувствительные значения сохраняют прежнее поведение (в т.ч. обрезка длинных).

## Проверка

- `yarn test` — 615 passed
- `yarn build` — ok
- `yarn lint` — 0 errors