### PR TITLE
fix(credentials): reliability + security for AuthKeyCredentialsProvider (#97)

### DIFF
--- a/src/credentials/auth-key-credentials-provider.spec.ts
+++ b/src/credentials/auth-key-credentials-provider.spec.ts
@@ -1,0 +1,352 @@
+import {
+  describe,
+  expect,
+  it,
+  jest,
+  afterEach,
+  beforeEach,
+} from '@jest/globals';
+import { Logger } from '@nestjs/common';
+import {
+  AuthKeyCredentialsProvider,
+  type IamJWTKeyCredentials,
+} from './auth-key-credentials-provider.js';
+
+const TEST_PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC5gw6/xmAX10E/
+flvzGshLm7wS0WXoC8+Y15SQkOm/W0b2jFqV2hllYBNEDl0KOCx6QR2BKCI47iGh
+vX39dIgn6liTKfTfQFWaKTyDK0E2f4YfTNz9hNVF1eLTh3WsAhTnj004P6rJlMR5
+9Au7/2J8l+7keDgQz17tgA6vEBQ4mEXhofeB4ykEp0fmzdLDawMrEeBjOR8S4UMH
+hwbOKLuuaOojtkSQVZLxmVaAHyCA7Ju7N8PV1HPfnrxradKXQ7cqobHT4jnowqoj
+TQ7TbTozckym01MTX2J8Jtk3r/q1EoR/bWyfSvVXUN0pr50KU4myrtE9fo2nKmvU
+gWIFvPoJAgMBAAECggEACLz6od/nQNg705DRJfdZ/e29Aynn4fFEew+UiOa6i+/x
+vMVJswtN7O+EmM0QZt3UgoG0sRPB4OqenO6/E4Q8sZyhRXVRen6eSZ+toQQVk0qY
+d7r4Idzy6tIzWAFmco66i1m9qmudUNd4FcKAFv/llLbXYt2izm/mKcvBZU+dlDjL
+WXnDnsf/IvntBqyJI0LbPQ0ClmlzeISuZ88ZMNiG8f5iABBDoCLL/JD8PkMaIb9s
+AFWOURS+u+W5XwzdT5Or7L44AUIDmzjdCg06rhAXzRJmOQoVeLq/Pt0pUkXtYqss
+DmGRof66MUvkwCvCyLA5PmFtu8LaY/w2qLOopoIc8QKBgQDwFxlMc3UrOUUjIa9y
+DFygVcxD1bVzLBADKAlyUcdJGRtrmk+G5poN71WnFS8cienwyES/es0x+jntkLKH
+POM9xOPSN/w5gyJsNUyEi2v81MKPCH6L47zxnGIG/8hpQFl9pVUZw3Th85eazUzd
+TS5aHsJmz3DUmQivNM39eE1qHQKBgQDFzhchmUiY9K0xkvu6tZBgWln1f/5qTswI
+BYNNVoF5q/91ix7zXhEXbigV+soq3upOwLs8Mk4tMZEnBqYD6kJUYIFbTHOSVNXf
++pXAKRdklNJ2mGr14+cbkrHQsIt2iahMTNDr0JxsyM5m7U1bcO700H0IjwKuSbUM
+E4Z/0nOr3QKBgEa8t4Jz3givJfSU3yk+BShkPvuZgo19ZPZZHHdnKs0ZrZ+FZnr7
+hFYotta0gh3pcFi12LOFzeE0tU6OPFtmEBnJ4cm1HwYe4cx546KFpXpngS89NHOo
+1KlnBubDA9wmzncbeDhQAybzay574HKvY8G/oE1EPx0UPZ/JcguFH2HtAoGBALoI
+sz6ZUGryq7UVPQWD346PS04Wm+vVwhTFQpFJC6qoNjGRr4FJ9h8oLjFF1j/tuUZq
+A26BDX95v7+JhDfoaYu7281HIOb+PMxTe+Xnf6XMRgjeHrK2LlSDahMRB4lrvEpO
+cKtoXsX9MgohowCePU8oin+zKN1MWydJcdTj1IBNAoGBAIyaRAZ0szIoAVrZ4k/9
+6dnOUv1shMkWokQ42dt9PkscFnIjdXZujGDV7Rlk5B+r8yFnQKKq446D3ebQiEKD
+u0L/sfyIZ3w+ucgffya07LEJwKMsDi/+GE7aYutmQtFPlt21NtAOyDCLcG9piZza
+z0thcu5YY+GzrDxTH4TV4nPD
+-----END PRIVATE KEY-----`;
+
+const CREDENTIALS: IamJWTKeyCredentials = {
+  keyId: 'test-key-id',
+  serviceAccountId: 'test-service-account',
+  privateKey: TEST_PRIVATE_KEY,
+};
+
+const originalFetch = globalThis.fetch;
+
+function makeProvider(fetchTimeoutMs: number): AuthKeyCredentialsProvider {
+  return new AuthKeyCredentialsProvider(CREDENTIALS, { fetchTimeoutMs });
+}
+
+function okJsonResponse(body: Record<string, unknown>): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+function httpErrorResponse(status: number, body: string): Response {
+  return {
+    ok: false,
+    status,
+    text: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+/** Ошибка, с которой отклоняется fetch-промис при abort сигнала. */
+function abortError(signal: AbortSignal): Error {
+  const reason: unknown =
+    signal.reason ??
+    new DOMException('The operation was aborted.', 'AbortError');
+  const name =
+    typeof (reason as { name?: unknown })?.name === 'string'
+      ? (reason as { name: string }).name
+      : 'AbortError';
+  const error = new Error(
+    reason instanceof Error ? reason.message : String(reason),
+  );
+  error.name = name;
+  return error;
+}
+
+/** Mock fetch, который отклоняется сразу, как только сигнал abort-нула. */
+function abortAwareFetch(): jest.Mock {
+  return jest.fn(
+    (_url: string, init?: RequestInit) =>
+      new Promise<never>((_resolve, reject) => {
+        const signal = init?.signal;
+        if (!signal) {
+          reject(new Error('expected an abort signal'));
+          return;
+        }
+        if (signal.aborted) {
+          reject(abortError(signal));
+          return;
+        }
+        signal.addEventListener('abort', () => reject(abortError(signal)), {
+          once: true,
+        });
+      }),
+  );
+}
+
+function setFetchMock(mock: jest.Mock): void {
+  (globalThis as { fetch: unknown }).fetch = mock;
+}
+
+describe('AuthKeyCredentialsProvider (#97)', () => {
+  let errorSpy: jest.SpiedFunction<typeof Logger.prototype.error>;
+  let warnSpy: jest.SpiedFunction<typeof Logger.prototype.warn>;
+  let debugSpy: jest.SpiedFunction<typeof Logger.prototype.debug>;
+
+  beforeEach(() => {
+    errorSpy = jest
+      .spyOn(Logger.prototype, 'error')
+      .mockImplementation(() => {});
+    warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
+    debugSpy = jest
+      .spyOn(Logger.prototype, 'debug')
+      .mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+    debugSpy.mockRestore();
+    (globalThis as { fetch: unknown }).fetch = originalFetch;
+  });
+
+  it('keeps normal successful caching and refresh behavior', async () => {
+    const fetchMock = jest.fn(() =>
+      okJsonResponse({
+        iamToken: 'tok-cached',
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      }),
+    );
+    setFetchMock(fetchMock);
+
+    const provider = makeProvider(60_000);
+
+    expect(await provider.getToken()).toBe('tok-cached');
+    expect(await provider.getToken()).toBe('tok-cached');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails fast on invalid string expiresAt instead of poisoning the cache', async () => {
+    const fetchMock = jest.fn(() =>
+      okJsonResponse({ iamToken: 'tok-bad', expiresAt: 'not-a-date' }),
+    );
+    setFetchMock(fetchMock);
+
+    const provider = makeProvider(60_000);
+
+    await expect(provider.getToken()).rejects.toThrow(/Invalid expiresAt/);
+    // Детерминированная ошибка — без ретраев и без шторма на IAM API.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects NaN and negative numeric expiresAt', async () => {
+    const fetchMock = jest.fn(() =>
+      okJsonResponse({ iamToken: 'tok-num', expiresAt: NaN }),
+    );
+    setFetchMock(fetchMock);
+
+    const provider = makeProvider(60_000);
+
+    await expect(provider.getToken()).rejects.toThrow(
+      /Invalid numeric expiresAt/,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns and falls back to a default TTL when expiresAt is missing', async () => {
+    const fetchMock = jest.fn(() => okJsonResponse({ iamToken: 'tok-ns' }));
+    setFetchMock(fetchMock);
+
+    const provider = makeProvider(60_000);
+
+    expect(await provider.getToken()).toBe('tok-ns');
+    expect(await provider.getToken()).toBe('tok-ns');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const warnMessages = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(warnMessages).toContain('missing expiresAt');
+    expect(warnMessages).toContain('default token TTL');
+  });
+
+  it('interprets milliseconds-scale numeric expiresAt as milliseconds (#97)', async () => {
+    const expiresAtMs = Date.now() + 3600_000;
+    const fetchMock = jest.fn(() =>
+      okJsonResponse({ iamToken: 'tok-ms', expiresAt: expiresAtMs }),
+    );
+    setFetchMock(fetchMock);
+
+    const provider = makeProvider(60_000);
+
+    expect(await provider.getToken()).toBe('tok-ms');
+    expect(await provider.getToken()).toBe('tok-ms');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('interprets seconds-like numeric expiresAt as seconds, not 1970 (#97)', async () => {
+    const expiresAtSeconds = Math.floor(Date.now() / 1000) + 3600;
+    const fetchMock = jest.fn(() =>
+      okJsonResponse({ iamToken: 'tok-s', expiresAt: expiresAtSeconds }),
+    );
+    setFetchMock(fetchMock);
+
+    const provider = makeProvider(60_000);
+
+    expect(await provider.getToken()).toBe('tok-s');
+    expect(await provider.getToken()).toBe('tok-s');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts the IAM fetch after the configured timeout (#97)', async () => {
+    setFetchMock(abortAwareFetch());
+
+    const provider = makeProvider(30);
+
+    await expect(provider.getToken()).rejects.toThrow(/timed out after 30 ms/);
+  });
+
+  it('forwards an external abort signal to the IAM fetch (#97)', async () => {
+    setFetchMock(abortAwareFetch());
+
+    const provider = makeProvider(60_000);
+    const controller = new AbortController();
+
+    const pending = provider.getToken(false, controller.signal);
+    controller.abort();
+
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('invalidates the stale cached token after a failed force refresh (#97)', async () => {
+    const first = jest.fn(() =>
+      okJsonResponse({
+        iamToken: 'stale-token',
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      }),
+    );
+    setFetchMock(first);
+
+    const provider = makeProvider(60_000);
+    await expect(provider.getToken()).resolves.toBe('stale-token');
+
+    const failing = jest.fn(() => Promise.reject(new Error('IAM is down')));
+    setFetchMock(failing);
+
+    await expect(provider.getToken(true)).rejects.toThrow('IAM is down');
+
+    // Кеш обязан быть очищен: следующий вызов должен снова сходить в IAM,
+    // а не вернуть устаревший токен.
+    const fresh = jest.fn(() =>
+      okJsonResponse({
+        iamToken: 'fresh-token',
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      }),
+    );
+    setFetchMock(fresh);
+
+    await expect(provider.getToken()).resolves.toBe('fresh-token');
+    expect(fresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not log the IAM response body on HTTP errors (#97)', async () => {
+    const secretBody = 'super-secret-body-content';
+    const fetchMock = jest.fn(() => httpErrorResponse(500, secretBody));
+    setFetchMock(fetchMock);
+
+    const provider = makeProvider(60_000);
+
+    await expect(provider.getToken()).rejects.toThrow(/status 500/);
+
+    const errorLogs = errorSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(errorLogs).toContain('IAM token exchange failed with status 500');
+    expect(errorLogs).not.toContain(secretBody);
+  });
+
+  it('logs errors with the actual stack instead of arbitrary objects (#97)', async () => {
+    const fetchMock = jest.fn(() => httpErrorResponse(500, 'body'));
+    setFetchMock(fetchMock);
+
+    const provider = makeProvider(60_000);
+
+    await expect(provider.getToken()).rejects.toThrow(/status 500/);
+
+    const firstCall = errorSpy.mock.calls[0];
+    expect(String(firstCall[0])).toContain(
+      'IAM token exchange failed with status 500',
+    );
+    const stack = firstCall[1];
+    expect(typeof stack).toBe('string');
+    expect(stack).toContain('Error: IAM token exchange failed with status 500');
+  });
+
+  it('does not log the IAM payload or token material (#97)', async () => {
+    const token = 'SUPER_SECRET_IAM_TOKEN_VALUE';
+    const fetchMock = jest.fn(() =>
+      okJsonResponse({
+        iamToken: token,
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      }),
+    );
+    setFetchMock(fetchMock);
+
+    const provider = makeProvider(60_000);
+
+    await provider.getToken();
+
+    const allLogs = [
+      ...errorSpy.mock.calls,
+      ...warnSpy.mock.calls,
+      ...debugSpy.mock.calls,
+    ]
+      .map((c) => c.map((a) => String(a)).join(' '))
+      .join('\n');
+    expect(allLogs).not.toContain(token);
+  });
+
+  it('does not expose the payload when iamToken is missing (#97)', async () => {
+    const fetchMock = jest.fn(() =>
+      okJsonResponse({
+        expiresAt: '2026-01-01T00:00:00.000Z',
+        extraField: 'sensitive-extra',
+      }),
+    );
+    setFetchMock(fetchMock);
+
+    const provider = makeProvider(60_000);
+
+    await expect(provider.getToken()).rejects.toThrow(/no iamToken/);
+
+    const errorLogs = errorSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(errorLogs).toContain('no iamToken');
+    expect(errorLogs).not.toContain('2026-01-01');
+    expect(errorLogs).not.toContain('sensitive-extra');
+  });
+
+  it('rejects non-positive fetchTimeoutMs at construction (#97)', () => {
+    expect(
+      () => new AuthKeyCredentialsProvider(CREDENTIALS, { fetchTimeoutMs: 0 }),
+    ).toThrow(/positive number/);
+  });
+});

--- a/src/credentials/auth-key-credentials-provider.ts
+++ b/src/credentials/auth-key-credentials-provider.ts
@@ -7,11 +7,28 @@ import fs from 'node:fs';
 
 const IAM_TOKEN_URL = 'https://iam.api.cloud.yandex.net/iam/v1/tokens';
 
+/** Таймаут отдельного HTTP-запроса к IAM (обмен JWT на токен). */
+const IAM_FETCH_TIMEOUT_MS = 10_000;
+
 /**
  * Запас перед истечением токена: без него токен мог протухнуть
  * между проверкой в кеше и реальным запросом к API.
  */
 const TOKEN_EXPIRY_LEEWAY_MS = 60_000;
+
+/**
+ * Дефолтный TTL кеша, когда IAM-ответ не содержит expiresAt.
+ * Совпадает с фактическим TTL IAM-токенов (1 час), чтобы кеш работал
+ * без «вечного» или пустого срока действия.
+ */
+const DEFAULT_TOKEN_TTL_MS = 3600_000;
+
+/**
+ * Историческая граница для числового expiresAt: значение <= порога
+ * трактуется как секунды (unix), больше — как миллисекунды.
+ * Текущее unix-время ~1.7e9, миллисекунды — ~1.7e12.
+ */
+const SECONDS_TIMESTAMP_THRESHOLD = 100_000_000_000;
 
 export type IamJWTKeyCredentials = {
   keyId: string;
@@ -19,31 +36,108 @@ export type IamJWTKeyCredentials = {
   privateKey: string;
 };
 
+/** Опции провайдера AuthKeyCredentialsProvider. */
+export interface AuthKeyCredentialsProviderOptions {
+  /** Таймаут отдельного fetch-запроса к IAM, мс (по умолчанию 10 000). */
+  fetchTimeoutMs?: number;
+}
+
 /** Ответ IAM API обмена JWT на токен. */
 interface IamTokenResponse {
   iamToken?: string;
-  expiresAt?: string;
+  expiresAt?: unknown;
 }
 
-/** Парсит expiresAt (RFC3339-строка/число/Date) в Date. */
-function parseTimestamp(ts: unknown): Date {
-  if (!ts) return new Date(Date.now() + 3600_000);
-  if (ts instanceof Date) return ts;
-  if (typeof ts === 'string') return new Date(ts);
-  if (typeof ts === 'number') return new Date(ts);
-  return new Date(Date.now() + 3600_000);
+/** Маркер ошибки, которую не нужно ретраить (детерминированный ответ IAM). */
+const NON_RETRYABLE = Symbol('YdbOrmNonRetryableCredentialError');
+
+function markNonRetryable<E extends Error>(err: E): E {
+  (err as unknown as { [NON_RETRYABLE]?: boolean })[NON_RETRYABLE] = true;
+  return err;
+}
+
+function isNonRetryable(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    (err as { [NON_RETRYABLE]?: boolean })[NON_RETRYABLE] === true
+  );
+}
+
+/** Безопасное представление значения для сообщений об ошибке (без токенов). */
+function describeRawValue(value: unknown): string {
+  if (typeof value === 'string') return JSON.stringify(value.slice(0, 120));
+  if (typeof value === 'number') return String(value);
+  if (typeof value === 'bigint') return String(value);
+  if (value instanceof Date) return JSON.stringify(value.toISOString());
+  return typeof value;
+}
+
+function errorName(err: unknown): string {
+  if (typeof err === 'object' && err !== null) {
+    const name: unknown = (err as { name?: unknown }).name;
+    return typeof name === 'string' ? name : '';
+  }
+  return '';
+}
+
+/**
+ * Разбирает expiresAt из ответа IAM в Date с правильной семантикой
+ * секунды/миллисекунды. Возвращает null, если поле отсутствует.
+ * Невалидное значение — fail-fast Error (не Invalid Date и не NaN),
+ * чтобы кеш никогда не деградировал до «истекает никогда».
+ */
+function parseTimestamp(ts: unknown): Date | null {
+  if (ts === undefined || ts === null || ts === '') return null;
+
+  let date: Date;
+  if (ts instanceof Date) {
+    if (Number.isNaN(ts.getTime())) {
+      throw markNonRetryable(
+        new Error('Invalid expiresAt: Invalid Date instance'),
+      );
+    }
+    date = new Date(ts.getTime());
+  } else if (typeof ts === 'number') {
+    if (!Number.isFinite(ts) || ts < 0) {
+      throw markNonRetryable(
+        new Error(`Invalid numeric expiresAt: ${describeRawValue(ts)}`),
+      );
+    }
+    date = new Date(ts <= SECONDS_TIMESTAMP_THRESHOLD ? ts * 1000 : ts);
+  } else if (typeof ts === 'string') {
+    date = new Date(ts);
+  } else {
+    throw markNonRetryable(
+      new Error(`Invalid expiresAt: unexpected type ${typeof ts}`),
+    );
+  }
+
+  if (Number.isNaN(date.getTime())) {
+    throw markNonRetryable(
+      new Error(`Invalid expiresAt: ${describeRawValue(ts)}`),
+    );
+  }
+  return date;
 }
 
 export class AuthKeyCredentialsProvider extends CredentialsProvider {
   #promise: Promise<string> | null = null;
   #token: { value: string; expired_at: Date } | null = null;
   #credentials: IamJWTKeyCredentials;
+  #fetchTimeoutMs: number;
 
   private readonly logger = new Logger(AuthKeyCredentialsProvider.name);
 
-  constructor(credentials: IamJWTKeyCredentials) {
+  constructor(
+    credentials: IamJWTKeyCredentials,
+    options: AuthKeyCredentialsProviderOptions = {},
+  ) {
     super();
     this.#credentials = credentials;
+    this.#fetchTimeoutMs = options.fetchTimeoutMs ?? IAM_FETCH_TIMEOUT_MS;
+    if (!(this.#fetchTimeoutMs > 0)) {
+      throw new Error('fetchTimeoutMs must be a positive number');
+    }
   }
 
   static fromAuthorizedKeyFile(path: string): AuthKeyCredentialsProvider {
@@ -77,7 +171,7 @@ export class AuthKeyCredentialsProvider extends CredentialsProvider {
     }
 
     const retryConfig: RetryConfig = {
-      retry: (err) => err instanceof Error,
+      retry: (err) => err instanceof Error && !isNonRetryable(err),
       signal,
       budget: 5,
       strategy: backoff(10, 1000),
@@ -87,32 +181,65 @@ export class AuthKeyCredentialsProvider extends CredentialsProvider {
       const jwt = this.#generateJWT();
 
       this.logger.debug('Exchanging JWT for IAM token');
-      const response = await fetch(IAM_TOKEN_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ jwt }),
-        signal: signal ?? null,
-      });
+
+      let response: Response;
+      try {
+        response = await fetch(IAM_TOKEN_URL, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ jwt }),
+          signal: this.#withFetchTimeout(signal),
+        });
+      } catch (err) {
+        throw this.#normalizeFetchError(err);
+      }
+
       if (!response.ok) {
-        const body = await response.text();
-        this.logger.error(
-          `IAM token exchange failed: ${response.status} ${body}`,
-        );
-        throw new Error(
+        // Тело ответа в лог не пишем: там может быть чувствительное содержимое.
+        const error = new Error(
           `IAM token exchange failed with status ${response.status}`,
         );
+        this.logger.error(error.message, error.stack);
+        throw error;
       }
 
-      const token = (await response.json()) as IamTokenResponse;
-      if (!token.iamToken) {
-        this.logger.error('Missing IAM token in response:', token);
-        throw new Error('No IAM token in response');
+      let payload: IamTokenResponse;
+      try {
+        payload = (await response.json()) as IamTokenResponse;
+      } catch (err) {
+        // Не валидный JSON — детерминированная ошибка, доверять телу нельзя.
+        const error = markNonRetryable(
+          new Error('IAM token exchange failed: response is not valid JSON', {
+            cause: err,
+          }),
+        );
+        this.logger.error(error.message, error.stack);
+        throw error;
       }
 
-      const expiresAt = parseTimestamp(token.expiresAt);
+      if (typeof payload.iamToken !== 'string' || payload.iamToken === '') {
+        const error = markNonRetryable(
+          new Error('IAM token exchange failed: no iamToken in response'),
+        );
+        this.logger.error(error.message, error.stack);
+        throw error;
+      }
+
+      const parsed = parseTimestamp(payload.expiresAt);
+      let expiresAt: Date;
+      if (parsed === null) {
+        const fallback = new Date(Date.now() + DEFAULT_TOKEN_TTL_MS);
+        this.logger.warn(
+          `IAM response is missing expiresAt; assuming default token TTL ` +
+            `${DEFAULT_TOKEN_TTL_MS} ms (until ${fallback.toISOString()})`,
+        );
+        expiresAt = fallback;
+      } else {
+        expiresAt = parsed;
+      }
 
       this.#token = {
-        value: token.iamToken,
+        value: payload.iamToken,
         expired_at: expiresAt,
       };
 
@@ -121,11 +248,58 @@ export class AuthKeyCredentialsProvider extends CredentialsProvider {
       );
 
       return this.#token.value;
-    }).finally(() => {
-      this.#promise = null;
-    });
+    })
+      .catch((err) => {
+        // Рефреш не удался — устаревший токен из кеша больше не выдаём.
+        this.#token = null;
+        throw err;
+      })
+      .finally(() => {
+        this.#promise = null;
+      });
 
     return this.#promise;
+  }
+
+  #withFetchTimeout(signal?: AbortSignal): AbortSignal {
+    const timeout = AbortSignal.timeout(this.#fetchTimeoutMs);
+    return signal ? AbortSignal.any([signal, timeout]) : timeout;
+  }
+
+  #normalizeFetchError(err: unknown): Error {
+    const errName = errorName(err);
+
+    if (errName === 'TimeoutError') {
+      const error = new Error(
+        `IAM token exchange timed out after ${this.#fetchTimeoutMs} ms`,
+      );
+      error.name = 'TimeoutError';
+      this.logger.error(error.message, error.stack);
+      return error;
+    }
+    if (errName === 'AbortError') {
+      const message =
+        err instanceof Error && err.message
+          ? err.message
+          : 'IAM token exchange aborted';
+      const error = new Error(message);
+      error.name = 'AbortError';
+      if (err instanceof Error && err.stack) error.stack = err.stack;
+      // Внешняя отмена — debug, а не error.
+      this.logger.debug(error.message, error.stack);
+      return error;
+    }
+
+    const baseMessage =
+      err instanceof Error
+        ? err.message
+        : typeof err === 'object' && err !== null && 'message' in err
+          ? String((err as { message?: unknown }).message)
+          : String(err);
+    const error = new Error(`IAM token exchange failed: ${baseMessage}`);
+    if (err instanceof Error && err.stack) error.stack = err.stack;
+    this.logger.error(error.message, error.stack);
+    return error;
   }
 
   #generateJWT(): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -216,4 +216,7 @@ export type { YdbCliConfig } from './cli/config.js';
 
 // Credentials
 export { AuthKeyCredentialsProvider } from './credentials/auth-key-credentials-provider.js';
-export type { IamJWTKeyCredentials } from './credentials/auth-key-credentials-provider.js';
+export type {
+  AuthKeyCredentialsProviderOptions,
+  IamJWTKeyCredentials,
+} from './credentials/auth-key-credentials-provider.js';


### PR DESCRIPTION
Реализация issue #97.

- Fail-fast на невалидный expiresAt (string/number/Date): Invalid Date → NaN сравнение больше не выключает кеш токена (раньше шторм JWT-обмена на каждый getToken без лога).
- Корректная семантика секунды/миллисекунды для числового expiresAt (порог 1e11); раньше секунды трактовались как миллисекунды → дата уезжала в 1970.
- Отсутствие expiresAt → warn + безопасный дефолтный TTL (1h).
- fetch: bounded timeout по умолчанию 10s (настраивается fetchTimeoutMs), проброс внешнего AbortSignal.
- Логи ошибок с реальным стеком вместо передачи токена; статус HTTP без тела ответа; тело и IAM-токен не логируются.
- Инвалидация устаревшего кеша после неудавшегося рефреша.
- Детерминированные ошибки ответа не ретраются, сеть/5х сохраняет retry.
- Регрессионные тесты.

Проверено: yarn build, yarn lint, yarn test (629 тестов, 0 ошибок).

Fixes #97.