### PR TITLE
fix(schema): describeTable различает not-found и другие SCHEME_ERROR; фактические типы вместо typeId=0; валидация tableName в @YdbEntity (#91)

### DIFF
--- a/src/core/sql-utils.ts
+++ b/src/core/sql-utils.ts
@@ -6,6 +6,22 @@ export function validateIdentifier(name: string, context: string): void {
   }
 }
 
+/**
+ * Валидация имени таблицы сущности (@YdbEntity). Правила те же, что и у
+ * quoteIdentifier: ASCII-буквы/цифры/подчёркивание, первый символ — буква
+ * или подчёркивание. Вызывается в декораторе, поэтому невалидное имя
+ * падает при загрузке модуля — до того, как из него соберут путь для
+ * DescribeTable или DDL (#91).
+ */
+export function validateTableName(name: string): void {
+  if (typeof name !== 'string' || !IDENTIFIER_REGEX.test(name)) {
+    throw new Error(
+      `@YdbEntity: invalid table name ${JSON.stringify(name)} — ` +
+        `must match /^[a-zA-Z_][a-zA-Z0-9_]*$/ (ASCII letters, digits, underscore)`,
+    );
+  }
+}
+
 /** Экранирование идентификаторов YQL (backticks) */
 export function quoteIdentifier(name: string): string {
   validateIdentifier(name, 'identifier');

--- a/src/decorators/entity.decorator.spec.ts
+++ b/src/decorators/entity.decorator.spec.ts
@@ -1,0 +1,104 @@
+import 'reflect-metadata';
+import { jest } from '@jest/globals';
+import { YdbEntity } from './entity.decorator.js';
+import { getYdbEntityMetadata } from '../metadata/entity-metadata.js';
+import { getRegisteredYdbEntities } from '../metadata/entity-registry.js';
+
+// Валидация имени таблицы в @YdbEntity (#91): невалидное имя должно падать
+// при декорировании (загрузке модуля), а не на первом DescribeTable/DDL,
+// где из него уже собрали путь до первой ошибки квотинга.
+
+describe('@YdbEntity table name validation (#91)', () => {
+  /** Декорирует класс именем name — декоратор отрабатывает немедленно. */
+  function decorate(name: string): void {
+    @YdbEntity(name)
+    class DecoratorValidationEntity {}
+    void DecoratorValidationEntity;
+  }
+
+  it.each(['users', '_private', 'Users2', 'a'])(
+    'accepts valid table name "%s"',
+    (name) => {
+      const before = getRegisteredYdbEntities().length;
+      expect(() => decorate(name)).not.toThrow();
+      // Валидная сущность попадает в глобальный реестр
+      expect(getRegisteredYdbEntities().length).toBe(before + 1);
+    },
+  );
+
+  it.each([
+    ['empty string', ''],
+    ['dash', 'bad-name'],
+    ['space', 'my table'],
+    ['dot', 'schema.table'],
+    ['slash', 'dir/table'],
+    ['starting digit', '1users'],
+    ['cyrillic', 'пользователи'],
+    ['SQL injection attempt', '`users`; DROP TABLE users'],
+  ])('rejects invalid table name (%s)', (_label, name) => {
+    const before = getRegisteredYdbEntities().length;
+    // Строки в toThrow сопоставляются с текстом ошибки как подстроки
+    expect(() => decorate(name)).toThrow('@YdbEntity: invalid table name');
+    expect(() => decorate(name)).toThrow(JSON.stringify(name));
+    expect(() => decorate(name)).toThrow('/^[a-zA-Z_][a-zA-Z0-9_]*$/');
+    // Невалидная сущность не должна попасть в глобальный реестр
+    expect(getRegisteredYdbEntities().length).toBe(before);
+  });
+
+  it.each([
+    ['null', null],
+    ['number', 42],
+    ['object', {}],
+  ] as const)('rejects non-string name (%s)', (_label, name) => {
+    expect(() => decorate(name as unknown as string)).toThrow(
+      '@YdbEntity: invalid table name',
+    );
+  });
+
+  it('does not write entity metadata for invalid table name', () => {
+    let thrown: unknown;
+    try {
+      @YdbEntity('bad-name')
+      class InvalidNameEntity {}
+      void InvalidNameEntity;
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    // Декоратор упал до defineMetadata — метаданных сущности нет.
+    // Проверяем через свежий WeakMap-кеш метаданных на классе-обёртке.
+    const holder: { target?: new (...args: any[]) => any } = {};
+    try {
+      @YdbEntity('also bad')
+      class AnotherInvalidEntity {}
+      holder.target = AnotherInvalidEntity;
+    } catch {
+      // ожидаемо
+    }
+    expect(holder.target).toBeUndefined();
+  });
+
+  it('metadata of valid entity contains its table name', () => {
+    @YdbEntity('validated_users')
+    class ValidatedUsersEntity {}
+
+    expect(getYdbEntityMetadata(ValidatedUsersEntity)?.tableName).toBe(
+      'validated_users',
+    );
+  });
+
+  it('validation runs eagerly at decoration time (#91)', () => {
+    const spy = jest.fn<(message: string) => void>();
+    expect(() => {
+      try {
+        decorate('bad/name');
+      } catch (error) {
+        spy((error as Error).message);
+        throw error;
+      }
+    }).toThrow('@YdbEntity: invalid table name');
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('must match /^[a-zA-Z_][a-zA-Z0-9_]*$/'),
+    );
+  });
+});

--- a/src/decorators/entity.decorator.ts
+++ b/src/decorators/entity.decorator.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 import { YdbPrimitive } from '../core/types.js';
+import { validateTableName } from '../core/sql-utils.js';
 import {
   YDB_ENTITY_KEY,
   YDB_COLUMNS_KEY,
@@ -9,9 +10,15 @@ import { registerYdbEntity } from '../metadata/entity-registry.js';
 /**
  * Декоратор класса. Задаёт имя таблицы в YDB.
  * Класс также попадает в глобальный реестр сущностей (см. entity-registry).
+ *
+ * Имя таблицы валидируется сразу при декорировании (#91): из него
+ * собирается путь для DescribeTable и DDL, поэтому невалидное имя
+ * должно падать при загрузке модуля, а не на первом обращении к БД.
  */
 export function YdbEntity(tableName: string): ClassDecorator {
   return (target) => {
+    validateTableName(tableName);
+
     Reflect.defineMetadata(YDB_ENTITY_KEY, tableName, target);
     registerYdbEntity(target as unknown as new (...args: any[]) => any);
 

--- a/src/schema/schema-sync.spec.ts
+++ b/src/schema/schema-sync.spec.ts
@@ -8,7 +8,7 @@ import {
   DescribeTableResultSchema,
   ValueSinceUnixEpochModeSettings_Unit,
 } from '@ydbjs/api/table';
-import { StatusIds_StatusCode } from '@ydbjs/api/operation';
+import { IssueMessageSchema, StatusIds_StatusCode } from '@ydbjs/api/operation';
 import { YdbEntity } from '../decorators/entity.decorator.js';
 import { YdbColumn, YdbPrimaryColumn } from '../decorators/column.decorator.js';
 import { YdbEncrypted } from '../decorators/encryption.decorator.js';
@@ -123,6 +123,16 @@ class TestNumericTtlEntity extends YdbBaseEntity {
   // Uint32 нет в YdbPrimitive — числовые TTL-типы проверяются отдельно
   @YdbColumn('Uint32' as never)
   expires_at: number;
+}
+
+// Сущность для проверки не-примитивных типов в БД (#91)
+@YdbEntity('test_unsupported_types')
+class TestUnsupportedTypesEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @YdbColumn('Utf8')
+  price: string;
 }
 
 @YdbEntity('test_photos')
@@ -1352,5 +1362,415 @@ describe('YdbSchemaSyncer.describeTable TTL parsing (#88)', () => {
     const desc = await syncer.describeTable('test_sessions');
 
     expect(desc?.ttl).toBeUndefined();
+  });
+});
+
+// Регресс-тесты #91: describeTable различает «таблицы нет» и другие
+// SCHEME_ERROR, а не-примитивные типы не деградируют до «typeId=0».
+describe('YdbSchemaSyncer.describeTable: not-found vs other errors (#91)', () => {
+  const sessionResult = anyPack(
+    CreateSessionResultSchema,
+    create(CreateSessionResultSchema, { sessionId: 'session-nf-1' }),
+  );
+
+  const issueMsg = (
+    message: string,
+    children?: ReturnType<typeof issueMsg>[],
+  ) =>
+    create(IssueMessageSchema, {
+      message,
+      severity: 1,
+      ...(children?.length ? { issues: children } : {}),
+    });
+
+  function makeDescribeTableSyncer(describeResponse: unknown): {
+    syncer: YdbSchemaSyncer;
+    executedSql: () => string[];
+  } {
+    const tableClient = {
+      createSession: jest.fn(() =>
+        Promise.resolve({ operation: { result: sessionResult } }),
+      ),
+      describeTable: jest.fn(() => Promise.resolve(describeResponse)),
+      deleteSession: jest.fn(() => Promise.resolve({})),
+    };
+    const driver = {
+      database: '/local',
+      createClient: jest.fn(() => tableClient),
+    };
+    const executor = jest.fn(() => Promise.resolve([]));
+    return {
+      syncer: new YdbSchemaSyncer(
+        driver as never,
+        executor as unknown as YdbExecutor,
+      ),
+      executedSql: () =>
+        (executor as unknown as jest.Mock).mock.calls.map((c: any) =>
+          String(c[0]?.[0] ?? ''),
+        ),
+    };
+  }
+
+  it('returns null on NOT_FOUND status', async () => {
+    const { syncer } = makeDescribeTableSyncer({
+      operation: { status: StatusIds_StatusCode.NOT_FOUND },
+    });
+
+    await expect(syncer.describeTable('missing_table')).resolves.toBeNull();
+  });
+
+  it('returns null when SCHEME_ERROR reports that the path does not exist', async () => {
+    const { syncer } = makeDescribeTableSyncer({
+      operation: {
+        status: StatusIds_StatusCode.SCHEME_ERROR,
+        issues: [issueMsg("path '/local/missing_table' does not exist")],
+      },
+    });
+
+    await expect(syncer.describeTable('missing_table')).resolves.toBeNull();
+  });
+
+  it('returns null for «not found» nested inside issue tree', async () => {
+    const { syncer } = makeDescribeTableSyncer({
+      operation: {
+        status: StatusIds_StatusCode.SCHEME_ERROR,
+        issues: [
+          issueMsg('Scheme error', [
+            issueMsg("Path '/local/missing_table' not found"),
+          ]),
+        ],
+      },
+    });
+
+    await expect(syncer.describeTable('missing_table')).resolves.toBeNull();
+  });
+
+  it('propagates permission-style SCHEME_ERROR with context instead of returning null', async () => {
+    const { syncer } = makeDescribeTableSyncer({
+      operation: {
+        status: StatusIds_StatusCode.SCHEME_ERROR,
+        issues: [issueMsg('Access denied: no permissions for path')],
+      },
+    });
+
+    await expect(syncer.describeTable('secret_table')).rejects.toThrow(
+      'DescribeTable failed for "/local/secret_table": ' +
+        'status=SCHEME_ERROR; Access denied: no permissions for path',
+    );
+  });
+
+  it('treats issues-less SCHEME_ERROR as an error, not as missing table', async () => {
+    // ydb-platform/ydb#7791: DescribeTable может не прислать issues вовсе.
+    // Без текста «не существует» это нельзя считать not-found (#91).
+    const { syncer } = makeDescribeTableSyncer({
+      operation: { status: StatusIds_StatusCode.SCHEME_ERROR },
+    });
+
+    await expect(syncer.describeTable('maybe_table')).rejects.toThrow(
+      'status=SCHEME_ERROR (no issues reported)',
+    );
+  });
+
+  it('propagates non-scheme failures with readable status name', async () => {
+    const { syncer } = makeDescribeTableSyncer({
+      operation: {
+        status: StatusIds_StatusCode.UNAUTHORIZED,
+        issues: [issueMsg('Token expired')],
+      },
+    });
+
+    await expect(syncer.describeTable('users')).rejects.toThrow(
+      'DescribeTable failed for "/local/users": status=UNAUTHORIZED; Token expired',
+    );
+  });
+
+  it('does not attempt CREATE TABLE when DescribeTable failed for a reason other than not-found (#91)', async () => {
+    const { syncer, executedSql } = makeDescribeTableSyncer({
+      operation: {
+        status: StatusIds_StatusCode.SCHEME_ERROR,
+        issues: [issueMsg("path '/local/test_users': Access denied")],
+      },
+    });
+
+    await expect(syncer.sync([TestUserEntity])).rejects.toThrow(
+      /Access denied/,
+    );
+
+    // Ни CREATE TABLE, ни какого-либо другого DDL
+    expect(executedSql()).toEqual([]);
+  });
+
+  it('still creates table on a genuine NOT_FOUND (#91)', async () => {
+    const { syncer, executedSql } = makeDescribeTableSyncer({
+      operation: { status: StatusIds_StatusCode.NOT_FOUND },
+    });
+
+    await syncer.sync([TestUserEntity]);
+
+    expect(executedSql()).toEqual([
+      generateCreateTableYql(buildExpectedTableSchema(meta(TestUserEntity))),
+    ]);
+  });
+});
+
+describe('DescribeTable non-primitive column types (#91)', () => {
+  const sessionResult = anyPack(
+    CreateSessionResultSchema,
+    create(CreateSessionResultSchema, { sessionId: 'session-types-1' }),
+  );
+
+  function makeTypeSyncer(
+    columns: Array<{
+      name: string;
+      type: unknown;
+    }>,
+  ): YdbSchemaSyncer {
+    const tableClient = {
+      createSession: jest.fn(() =>
+        Promise.resolve({ operation: { result: sessionResult } }),
+      ),
+      describeTable: jest.fn(() =>
+        Promise.resolve({
+          operation: {
+            status: StatusIds_StatusCode.SUCCESS,
+            result: anyPack(
+              DescribeTableResultSchema,
+              create(DescribeTableResultSchema, {
+                columns: columns as never,
+                primaryKey: ['uuid'],
+                indexes: [],
+              }),
+            ),
+          },
+        }),
+      ),
+      deleteSession: jest.fn(() => Promise.resolve({})),
+    };
+    const driver = {
+      database: '/local',
+      createClient: jest.fn(() => tableClient),
+    };
+    return new YdbSchemaSyncer(driver as never, {} as YdbExecutor);
+  }
+
+  it('collects decimal/list/pg columns into unsupportedColumns instead of typeId=0', async () => {
+    const syncer = makeTypeSyncer([
+      {
+        name: 'uuid',
+        type: { type: { case: 'typeId', value: Type_PrimitiveTypeId.UUID } },
+      },
+      {
+        name: 'price',
+        type: {
+          type: { case: 'decimalType', value: { precision: 22, scale: 9 } },
+        },
+      },
+      {
+        name: 'tags',
+        type: {
+          type: {
+            case: 'listType',
+            value: {
+              item: {
+                type: { case: 'typeId', value: Type_PrimitiveTypeId.UTF8 },
+              },
+            },
+          },
+        },
+      },
+      {
+        name: 'ext_id',
+        type: {
+          type: {
+            case: 'pgType',
+            value: { typeName: 'int4', oid: 23, typeModifier: '' },
+          },
+        },
+      },
+    ]);
+
+    const desc = await syncer.describeTable('mixed_table');
+
+    // Примитивная колонка осталась в columns…
+    expect(desc?.columns.get('uuid')).toBe(Type_PrimitiveTypeId.UUID);
+    // …а не-примитивные ушли в unsupportedColumns с фактическим типом
+    expect(desc?.columns.has('price')).toBe(false);
+    expect(desc?.unsupportedColumns).toEqual(
+      new Map([
+        ['price', 'decimal(22,9)'],
+        ['tags', 'list<utf8>'],
+        ['ext_id', 'pg<int4>'],
+      ]),
+    );
+  });
+
+  it('keeps Optional wrapper in the rendered type description', async () => {
+    const syncer = makeTypeSyncer([
+      {
+        name: 'amount',
+        type: {
+          type: {
+            case: 'optionalType',
+            value: {
+              item: {
+                type: {
+                  case: 'decimalType',
+                  value: { precision: 22, scale: 9 },
+                },
+              },
+            },
+          },
+        },
+      },
+    ]);
+
+    const desc = await syncer.describeTable('optional_decimal');
+
+    expect(desc?.unsupportedColumns?.get('amount')).toBe('decimal(22,9)?');
+  });
+
+  it('checkTableSchema treats unsupported declared column as type mismatch with actual type', () => {
+    const expected = buildExpectedTableSchema(meta(TestUnsupportedTypesEntity));
+    const existing: YdbTableDescription = {
+      columns: new Map([['uuid', Type_PrimitiveTypeId.UUID]]),
+      primaryKey: ['uuid'],
+      indexes: [],
+      unsupportedColumns: new Map([['price', 'decimal(22,9)']]),
+    };
+
+    const check = checkTableSchema(expected, existing);
+
+    expect(check.missingColumns).toEqual([]);
+    expect(check.typeMismatches).toEqual([
+      { column: 'price', expected: 'Utf8', actual: 'decimal(22,9)' },
+    ]);
+    expect(checkToIssues(check)).toEqual([
+      {
+        tableName: 'test_unsupported_types',
+        kind: 'type-mismatch',
+        message:
+          'Table "test_unsupported_types" column "price" type mismatch: ' +
+          'expected Utf8, actual decimal(22,9)',
+      },
+    ]);
+  });
+
+  it('reports undeclared non-primitive columns as extra columns', () => {
+    const existing: YdbTableDescription = {
+      ...description(
+        [
+          ['uuid', Type_PrimitiveTypeId.UUID],
+          ['name', Type_PrimitiveTypeId.UTF8],
+          ['secret', Type_PrimitiveTypeId.STRING],
+          ['is_active', Type_PrimitiveTypeId.BOOL],
+          ['secret_bi', Type_PrimitiveTypeId.UTF8],
+        ],
+        ['uuid'],
+        [
+          {
+            name: 'test_users__secret_bi',
+            columns: ['secret_bi'],
+            unique: false,
+          },
+          {
+            name: 'test_users__active_name',
+            columns: ['is_active', 'name'],
+            unique: false,
+          },
+        ],
+      ),
+      unsupportedColumns: new Map([['legacy_amount', 'list<utf8>?']]),
+    };
+
+    const check = checkTableSchema(
+      buildExpectedTableSchema(meta(TestUserEntity)),
+      existing,
+    );
+
+    expect(check.extraColumns).toEqual(['legacy_amount']);
+  });
+
+  it('verify reports unsupported column type with actual type info, not typeId=0', async () => {
+    const syncer = makeTypeSyncer([
+      {
+        name: 'uuid',
+        type: { type: { case: 'typeId', value: Type_PrimitiveTypeId.UUID } },
+      },
+      {
+        name: 'price',
+        type: {
+          type: { case: 'decimalType', value: { precision: 22, scale: 9 } },
+        },
+      },
+    ]);
+
+    const issues = await syncer.verify([TestUnsupportedTypesEntity]);
+
+    expect(issues).toEqual([
+      {
+        tableName: 'test_unsupported_types',
+        kind: 'type-mismatch',
+        message:
+          'Table "test_unsupported_types" column "price" type mismatch: ' +
+          'expected Utf8, actual decimal(22,9)',
+      },
+    ]);
+  });
+
+  it('sync throws on unsupported column type and executes no DDL', async () => {
+    const tableClient = {
+      createSession: jest.fn(() =>
+        Promise.resolve({ operation: { result: sessionResult } }),
+      ),
+      describeTable: jest.fn(() =>
+        Promise.resolve({
+          operation: {
+            status: StatusIds_StatusCode.SUCCESS,
+            result: anyPack(
+              DescribeTableResultSchema,
+              create(DescribeTableResultSchema, {
+                columns: [
+                  {
+                    name: 'uuid',
+                    type: {
+                      type: {
+                        case: 'typeId',
+                        value: Type_PrimitiveTypeId.UUID,
+                      },
+                    },
+                  },
+                  {
+                    name: 'price',
+                    type: {
+                      type: {
+                        case: 'decimalType',
+                        value: { precision: 22, scale: 9 },
+                      },
+                    },
+                  },
+                ] as never,
+                primaryKey: ['uuid'],
+                indexes: [],
+              }),
+            ),
+          },
+        }),
+      ),
+      deleteSession: jest.fn(() => Promise.resolve({})),
+    };
+    const driver = {
+      database: '/local',
+      createClient: jest.fn(() => tableClient),
+    };
+    const executor = jest.fn(() => Promise.resolve([]));
+    const syncer = new YdbSchemaSyncer(
+      driver as never,
+      executor as unknown as YdbExecutor,
+    );
+
+    await expect(syncer.sync([TestUnsupportedTypesEntity])).rejects.toThrow(
+      /column type mismatch \(price: expected Utf8, actual decimal\(22,9\)\)/,
+    );
+    expect((executor as unknown as jest.Mock).mock.calls).toEqual([]);
   });
 });

--- a/src/schema/schema-sync.ts
+++ b/src/schema/schema-sync.ts
@@ -75,6 +75,13 @@ export interface YdbTableDescription {
    * Сравнивается с метаданными @YdbTtl при verify/миграциях (#88).
    */
   ttl?: YdbTableTtl;
+  /**
+   * Колонки БД с не-примитивными типами (Decimal/List/Pg и т.п.), которые
+   * нельзя выразить typeId (#91): имя → человекочитаемое описание типа.
+   * Такие колонки всегда считаются расхождением типов — но с честным
+   * описанием фактического типа вместо бессмысленного «typeId=0».
+   */
+  unsupportedColumns?: Map<string, string>;
 }
 
 /** Результат проверки существующей таблицы против ожидаемой схемы. */
@@ -164,6 +171,14 @@ for (const [name, typeId] of Object.entries(TTL_NUMERIC_TYPE_IDS)) {
     TYPE_ID_TO_PRIMITIVE.set(typeId, name as YdbPrimitive);
   }
 }
+
+/**
+ * Текст issues, однозначно говорящий, что путь/таблица не существует (#91).
+ * Только такой SCHEME_ERROR трактуется как «таблицы нет»; остальные
+ * (права доступа, битый путь и т.п.) пробрасываются наружу. Реальные
+ * сообщения YDB: «path '/db/tbl' does not exist», «Path ... not found».
+ */
+const NOT_FOUND_ISSUE_RE = /does not exist|not found/i;
 
 /** Enum Unit из TtlSettings → YdbTtlUnit (см. @YdbTtl). */
 const TTL_UNIT_BY_PROTO: Record<
@@ -418,8 +433,21 @@ export function checkTableSchema(
 ): SchemaCheckResult {
   const missingColumns: [string, YdbPrimitive][] = [];
   const typeMismatches: SchemaCheckResult['typeMismatches'] = [];
+  const unsupportedColumns = existing.unsupportedColumns;
 
   for (const [name, type] of Object.entries(expected.columns)) {
+    // Не-примитивный тип в БД (#91): по typeId сравнивать нельзя —
+    // сообщаем расхождение с фактическим типом (decimal(22,9), list<...>),
+    // а не с бессмысленным typeId=0.
+    const actualUnsupported = unsupportedColumns?.get(name);
+    if (actualUnsupported !== undefined) {
+      typeMismatches.push({
+        column: name,
+        expected: type,
+        actual: actualUnsupported,
+      });
+      continue;
+    }
     const actualTypeId = existing.columns.get(name);
     if (actualTypeId === undefined) {
       missingColumns.push([name, type]);
@@ -440,9 +468,13 @@ export function checkTableSchema(
   }
 
   const expectedColumns = new Set(Object.keys(expected.columns));
-  const extraColumns = [...existing.columns.keys()].filter(
-    (name) => !expectedColumns.has(name),
-  );
+  // Колонка БД живёт либо в columns, либо в unsupportedColumns — но
+  // описания могут прийти и из внешнего кода, поэтому дедуплицируем.
+  const extraColumns = [
+    ...existing.columns.keys(),
+    ...(unsupportedColumns?.keys() ?? []),
+  ].filter((name) => !expectedColumns.has(name));
+  const uniqueExtraColumns = [...new Set(extraColumns)];
 
   const primaryKeyMatches =
     expected.primaryKey.length === existing.primaryKey.length &&
@@ -515,7 +547,7 @@ export function checkTableSchema(
     tableName: expected.tableName,
     missingColumns,
     typeMismatches,
-    extraColumns,
+    extraColumns: uniqueExtraColumns,
     primaryKeyMatches,
     missingIndexes,
     extraIndexes,
@@ -836,7 +868,13 @@ export class YdbSchemaSyncer {
   /**
    * DescribeTable через Table service (query service не отдаёт метаданные
    * колонок). Сессия создаётся на один вызов и сразу закрывается.
-   * Возвращает null, если таблицы не существует.
+   *
+   * Возвращает null только если таблицы действительно нет (#91): отдельный
+   * статус NOT_FOUND либо SCHEME_ERROR, в issues которого явно сказано, что
+   * путь/таблица не существует. Любой другой SCHEME_ERROR (нет прав,
+   * битый путь и т.п.) пробрасывается наружу с контекстом — раньше он
+   * тоже превращался в null, из-за чего sync делал CREATE TABLE уже
+   * существующей таблицы, а verify докладывал ложный missing-table.
    * Публичный: используется также генератором миграций (migration:generate).
    */
   async describeTable(tableName: string): Promise<YdbTableDescription | null> {
@@ -857,13 +895,20 @@ export class YdbSchemaSyncer {
       const operation = response.operation;
 
       if (!operation || operation.status !== StatusIds_StatusCode.SUCCESS) {
-        if (operation?.status === StatusIds_StatusCode.SCHEME_ERROR) {
-          return null;
-        }
+        const issueText = this.formatIssues(operation?.issues);
+        const notFound =
+          operation?.status === StatusIds_StatusCode.NOT_FOUND ||
+          (operation?.status === StatusIds_StatusCode.SCHEME_ERROR &&
+            NOT_FOUND_ISSUE_RE.test(issueText));
+        if (notFound) return null;
+
+        const statusName = operation
+          ? (StatusIds_StatusCode[operation.status] ?? operation.status)
+          : 'unknown';
         throw new Error(
           `DescribeTable failed for "${path}": ` +
-            `status=${operation?.status ?? 'unknown'} ` +
-            this.formatIssues(operation?.issues),
+            `status=${statusName}` +
+            (issueText ? `; ${issueText}` : ' (no issues reported)'),
         );
       }
 
@@ -874,9 +919,18 @@ export class YdbSchemaSyncer {
         throw new Error(`DescribeTable returned no result for "${path}"`);
       }
 
+      // Колонки с не-примитивными типами (Decimal/List/Pg и т.п.) нельзя
+      // выразить typeId — они уходят в unsupportedColumns с честным
+      // описанием типа, а не с бессмысленным typeId=0 (#91).
       const columns = new Map<string, Type_PrimitiveTypeId>();
+      const unsupportedColumns = new Map<string, string>();
       for (const column of result.columns) {
-        columns.set(column.name, this.extractPrimitiveTypeId(column.type));
+        const typeId = this.extractPrimitiveTypeId(column.type);
+        if (typeId === null) {
+          unsupportedColumns.set(column.name, this.formatYdbType(column.type));
+          continue;
+        }
+        columns.set(column.name, typeId);
       }
 
       const indexes = result.indexes.map((idx) => ({
@@ -890,6 +944,7 @@ export class YdbSchemaSyncer {
         primaryKey: [...result.primaryKey],
         indexes,
         ttl: this.extractTtl(result.ttlSettings),
+        ...(unsupportedColumns.size ? { unsupportedColumns } : {}),
       };
     } finally {
       await client.deleteSession({ sessionId }).catch((error: unknown) => {
@@ -900,8 +955,13 @@ export class YdbSchemaSyncer {
     }
   }
 
-  /** Снимает Optional-обёртки и возвращает примитивный typeId. */
-  private extractPrimitiveTypeId(type?: Type): Type_PrimitiveTypeId {
+  /**
+   * Снимает Optional-обёртки и возвращает примитивный typeId.
+   * null — тип не-примитивный (Decimal/List/Pg/…): сравнивать его по typeId
+   * нельзя, фактическое описание кладётся в unsupportedColumns (#91),
+   * а не подставляется бессмысленный PRIMITIVE_TYPE_ID_UNSPECIFIED (=0).
+   */
+  private extractPrimitiveTypeId(type?: Type): Type_PrimitiveTypeId | null {
     let current = type;
     while (current?.type.case === 'optionalType') {
       current = current.type.value.item;
@@ -909,7 +969,58 @@ export class YdbSchemaSyncer {
     if (current?.type.case === 'typeId') {
       return current.type.value;
     }
-    return Type_PrimitiveTypeId.PRIMITIVE_TYPE_ID_UNSPECIFIED;
+    return null;
+  }
+
+  /**
+   * Компактное человекочитаемое описание типа из DescribeTable (#91):
+   * decimal(22,9), list<utf8>, pg<int4> и т.п. Используется в сообщениях
+   * о расхождении типов вместо бессмысленного «typeId=0».
+   */
+  private formatYdbType(type?: Type): string {
+    let current = type;
+    let optional = false;
+    while (current?.type.case === 'optionalType') {
+      current = current.type.value.item;
+      optional = true;
+    }
+
+    const inner = this.formatNonOptionalYdbType(current);
+    return optional ? `${inner}?` : inner;
+  }
+
+  private formatNonOptionalYdbType(type?: Type): string {
+    const t = type?.type;
+    switch (t?.case) {
+      case 'typeId': {
+        const name =
+          TYPE_ID_TO_PRIMITIVE.get(t.value) ?? Type_PrimitiveTypeId[t.value];
+        return name ? name.toLowerCase() : `typeId=${t.value}`;
+      }
+      case 'decimalType':
+        return `decimal(${t.value.precision},${t.value.scale})`;
+      case 'listType':
+        return `list<${this.formatYdbType(t.value.item)}>`;
+      case 'tupleType':
+        return `tuple<${t.value.elements.map((i) => this.formatYdbType(i)).join(', ')}>`;
+      case 'dictType':
+        return (
+          `dict<${this.formatYdbType(t.value.key)}, ` +
+          `${this.formatYdbType(t.value.payload)}>`
+        );
+      case 'structType':
+        return `struct<${t.value.members
+          .map((m) => `${m.name}: ${this.formatYdbType(m.type)}`)
+          .join(', ')}>`;
+      case 'pgType':
+        return t.value.typeName
+          ? `pg<${t.value.typeName}>`
+          : `pg(oid=${t.value.oid})`;
+      default:
+        // variantType/taggedType/voidType/… — имя proto-case уже содержит
+        // фактическую информацию о типе.
+        return t?.case ?? 'unknown';
+    }
   }
 
   /**

--- a/test/nestjs/schema-sync.spec.ts
+++ b/test/nestjs/schema-sync.spec.ts
@@ -8,7 +8,7 @@ import {
   CreateSessionResultSchema,
   TableServiceDefinition,
 } from '@ydbjs/api/table';
-import { StatusIds_StatusCode } from '@ydbjs/api/operation';
+import { StatusIds_StatusCode, IssueMessageSchema } from '@ydbjs/api/operation';
 import {
   YdbCoreModule,
   YdbModule,
@@ -27,8 +27,9 @@ import { createMockExecutor } from '../helpers/mock-executor.js';
 class TestFeatureModule {}
 
 /**
- * Фейковый драйвер: DescribeTable всегда отвечает SCHEME_ERROR
- * (таблицы не существует) → sync должен создать все таблицы.
+ * Фейковый драйвер: DescribeTable отвечает «таблица не существует» —
+ * SCHEME_ERROR с явным текстом в issues (#91: только такой SCHEME_ERROR
+ * трактуется как not-found) → sync должен создать все таблицы.
  */
 function createFakeDriver() {
   const sessionResult = anyPack(
@@ -44,7 +45,15 @@ function createFakeDriver() {
     ),
     describeTable: jest.fn(() =>
       Promise.resolve({
-        operation: { status: StatusIds_StatusCode.SCHEME_ERROR },
+        operation: {
+          status: StatusIds_StatusCode.SCHEME_ERROR,
+          issues: [
+            create(IssueMessageSchema, {
+              message: "path '/local/<table>' does not exist",
+              severity: 1,
+            }),
+          ],
+        },
       }),
     ),
     deleteSession: jest.fn(() => Promise.resolve({})),


### PR DESCRIPTION
Closes #91

## Проблема

`describeTable()` возвращал `null` при **любом** `SCHEME_ERROR`:

1. **Ложный not-found**: при отсутствии прав на путь или другой схемной ошибке sync делал `CREATE TABLE` уже существующей таблицы, а `verify` докладывал ложный `missing-table`.
2. **`typeId=0`**: не-примитивные типы колонок (Decimal/List/Pg/…) не выражаются `PrimitiveTypeId`, из-за чего сравнение типов давало бессмысленное «actual typeId=0».
3. **Невалидный tableName**: `@YdbEntity` принимал произвольную строку — путь для DescribeTable/DDL собирался из мусорных символов до первой ошибки квотинга.

## Решение

### 1. describeTable: только настоящий not-found → `null`
- статус `NOT_FOUND` (400140) → `null`;
- `SCHEME_ERROR`, в issues которого (включая вложенные) есть явное «does not exist» / «not found» → `null`;
- любой другой `SCHEME_ERROR` (права доступа, битый путь), включая `SCHEME_ERROR` без issues (см. ydb-platform/ydb#7791 — issues могут отсутствовать, и молча считать это not-found нельзя), и прочие статусы пробрасываются наружу с контекстом: путь, человекочитаемое имя статуса (`SCHEME_ERROR` вместо `400070`) и текст issues.
- `sync` теперь не делает `CREATE TABLE`, если DescribeTable упал по причине, отличной от not-found; на настоящем not-found поведение прежнее (таблица создаётся).

### 2. Не-примитивные типы без «typeId=0»
- `YdbTableDescription` получил необязательное поле `unsupportedColumns?: Map<string, string>` (имя → описание типа); обратная совместимость сохранена.
- `describeTable` кладёт такие колонки туда с компактным описанием: `decimal(22,9)`, `list<utf8>`, `pg<int4>`, `tuple<...>`, `dict<...>`, `struct<...>`, Optional как суффикс `?`.
- `checkTableSchema` / `verify` / `sync` сообщают расхождение с фактическим типом: `expected Utf8, actual decimal(22,9)`; необъявленные не-примитивные колонки по-прежнему попадают в extra-columns.

### 3. Валидация имени таблицы
- Новая `validateTableName()` (`core/sql-utils.ts`, правила идентичны `quoteIdentifier`);
- `@YdbEntity` вызывает её при декорировании: невалидное имя падает при загрузке модуля — до любого DescribeTable/DDL; невалидная сущность не попадает в глобальный реестр.

## Тесты

- `src/decorators/entity.decorator.spec.ts` (новый): валидные/невалидные/не-строковые имена, реестр и метаданные.
- `src/schema/schema-sync.spec.ts`: NOT_FOUND-статус; SCHEME_ERROR с текстом «does not exist/not found» (в т.ч. вложенные issues); permission-style SCHEME_ERROR → ошибка с контекстом; SCHEME_ERROR без issues → ошибка; UNAUTHORIZED → читаемый статус; **sync не выполняет ни одного DDL при ошибке DescribeTable вне not-found**; sync создаёт таблицу на настоящем NOT_FOUND; разбор decimal/list/pg/Optional в `unsupportedColumns`; mismatch/extra-column/verify/sync сообщения с фактическим типом.
- `test/nestjs/schema-sync.spec.ts`: фейковый драйвер переведён на реалистичный not-found ответ (SCHEME_ERROR + текст «does not exist»).

## Проверки

- `yarn test` — 661 тестов, 43 сюиты ✅
- `yarn build` ✅
- `yarn lint` — 0 errors, 94 warnings (все существовавшие до изменений) ✅