### PR TITLE
fix(metadata): осознанная семантика наследования метаданных сущностей (#92)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,30 @@ await UserEntity.findAll({
 - `@YdbTtl({ interval, column, unit? })` — декларативный TTL таблицы (класс-декоратор, один раз на класс). `interval` — ISO 8601 duration (`"PT2H"`, `"P30D"`); `column` — обязательная колонка, объявленная через `@YdbColumn` (типы `Date`/`Datetime`/`Timestamp` без `unit`, либо числовые `Uint32`/`Uint64`/`DyNumber` — тогда обязателен `unit`); `unit` — единица для числовой колонки (`seconds` | `milliseconds` | `microseconds` | `nanoseconds`). Генерирует секцию `WITH (TTL = Interval(...) ON column)` в CREATE TABLE. Ошибки формата бросаются сразу при декорировании, несовместимость со схемой сущности — при инициализации модуля.
 - `@BeforeInsert` / `@AfterInsert` / `@BeforeUpdate` / `@AfterFind` / `@BeforeRemove` — lifecycle-хуки (метод-декораторы без скобок). Подробности и гарантии вызовов — в разделе [Lifecycle hooks](#lifecycle-hooks).
 
+### Наследование метаданных
+
+Правила наследования декораторов между родительским и дочерним классами (#92):
+
+- **`@YdbEntity` не наследуется.** Сущностью является только класс, непосредственно декорированный `@YdbEntity`. Подкласс без собственного `@YdbEntity` — не сущность: он не наследует tableName родителя, не попадает в реестр и в expected-схемы schema sync/миграций, а Active Record-вызовы на нём падают с понятной ошибкой «is not decorated with @YdbEntity». Передавать такой класс в `forFeature`/`configureEntities`/список entities нельзя.
+- **Колонки наследуются** (`@YdbColumn`, `@YdbPrimaryColumn`, `@YdbEncrypted`, `@YdbSecurityAAD`, `@YdbJson`, `@YdbEnum`, timestamp-декораторы, lifecycle-хуки): дочерний класс получает объединение метаданных предков, переопределение на наследнике не меняет родителя (copy-on-write). Повторы и переопределения: `@YdbEnum` — last-write-wins, AAD/PK — дедупликация по имени поля.
+- **`@YdbIndex` и `@YdbTtl` не наследуются** — они привязаны к физической таблице класса. Класс со своим `@YdbEntity` начинает без индексов и TTL и объявляет свои явно; это гарантирует, что индексы/TTL родителя (возможно, по чужим или переопределённым колонкам) никогда не попадут в DDL дочерней таблицы.
+- **`@EagerLoad` наследуется объединением**: связи родителя сохраняются, список ребёнка дополняет их без повторов (первое объявление выигрывает).
+- **Дубликат tableName у двух разных сущностей** (например, родитель и наследник, декорированные одним именем) — ошибка `Duplicate table name "..."` при построении схемы (`buildExpectedSchemas`): sync/verify/`migration:generate` всегда работают с ровно одной ожидаемой схемой на таблицу.
+
+```ts
+@YdbEntity('events')
+@YdbTtl({ interval: 'P30D', column: 'created_at' })
+class EventEntity extends YdbBaseEntity { /* ... */ }
+
+// Своя таблица: колонки родителя наследуются, TTL/индексы — нет
+@YdbEntity('audit_events')
+class AuditEventEntity extends EventEntity { /* ... */ }
+
+// Ошибка: Duplicate table name "events"
+@YdbEntity('events')
+class BrokenChildEntity extends EventEntity { /* ... */ }
+```
+
 ```ts
 @YdbEntity('photos')
 @EagerLoad(['tags'])

--- a/src/decorators/index.decorator.ts
+++ b/src/decorators/index.decorator.ts
@@ -22,6 +22,13 @@ export interface YdbIndexMetadata {
  * можно вешать несколько раз. Попадает в CREATE TABLE при schema sync
  * и в migration:generate.
  *
+ * Семантика наследования (#92): индекс привязан к таблице того класса,
+ * на котором объявлен, и НЕ наследуется по цепочке прототипов. Класс
+ * с собственным @YdbEntity начинает с пустого списка индексов и объявляет
+ * свои явно — иначе родительские индексы по чужим колонкам попали бы
+ * в CREATE TABLE дочерней таблицы и уронили DDL. Повтор @YdbIndex на
+ * наследнике не мутирует список индексов родителя (copy-on-write).
+ *
  * @example
  *   @YdbEntity('photos')
  *   @YdbIndex({ columns: ['author_email_bi'] })
@@ -30,16 +37,19 @@ export interface YdbIndexMetadata {
  */
 export function YdbIndex(options: YdbIndexOptions): ClassDecorator {
   return (target) => {
+    // Только собственные метаданные класса: иначе при декорировании
+    // наследника сюда затесались бы индексы родителя (#92).
     const existing: YdbIndexMetadata[] =
-      Reflect.getMetadata(YDB_INDEXES_KEY, target) || [];
+      Reflect.getOwnMetadata(YDB_INDEXES_KEY, target) || [];
     // Класс-декораторы применяются снизу вверх — unshift сохраняет порядок объявления.
     const indexes: YdbIndexMetadata[] = [{ ...options }, ...existing];
     Reflect.defineMetadata(YDB_INDEXES_KEY, indexes, target);
   };
 }
 
+/** Собственные индексы класса (не наследуются от родителя, #92). */
 export function getYdbIndexesMetadata(target: any): YdbIndexMetadata[] {
-  return Reflect.getMetadata(YDB_INDEXES_KEY, target) || [];
+  return Reflect.getOwnMetadata(YDB_INDEXES_KEY, target) || [];
 }
 
 /** Имя индекса по умолчанию: `{table}__{col1}_{col2}` — группируется сортировкой. */

--- a/src/decorators/ttl.decorator.ts
+++ b/src/decorators/ttl.decorator.ts
@@ -197,6 +197,13 @@ export interface YdbTtlMetadata {
  * Можно применить только один раз на класс.
  * Генерирует секцию WITH (TTL = Interval(...) ON column) после CREATE TABLE (...).
  *
+ * Семантика наследования (#92): TTL привязан к таблице того класса, на котором
+ * объявлен, и НЕ наследуется по цепочке прототипов — класс с собственным
+ * @YdbEntity объявляет свой TTL явно (или не имеет его), поэтому родительский
+ * TTL по чужой колонке не попадает в DDL дочерней таблицы. Повторное
+ * применение на наследнике разрешено: guard «один раз» смотрит только
+ * собственные метаданные класса и не считает TTL родителя своим.
+ *
  * Ошибки формата (interval, column, unit) бросаются сразу при декорировании.
  * Ошибки относительно схемы сущности (неизвестная колонка, несовместимый тип,
  * лишний/недостающий unit) обнаруживаются при инициализации модуля
@@ -210,7 +217,9 @@ export interface YdbTtlMetadata {
  */
 export function YdbTtl(options: YdbTtlOptions): ClassDecorator {
   return (target) => {
-    const existing = Reflect.getMetadata(YDB_TTL_KEY, target);
+    // Только собственные метаданные класса (#92): TTL родителя не должен
+    // блокировать объявление собственного TTL у наследника.
+    const existing = Reflect.getOwnMetadata(YDB_TTL_KEY, target);
     if (existing) {
       throw new Error(
         `@YdbTtl can only be applied once to class "${target.name}"`,
@@ -221,10 +230,11 @@ export function YdbTtl(options: YdbTtlOptions): ClassDecorator {
   };
 }
 
+/** Собственный TTL класса (не наследуется от родителя, #92). */
 export function getYdbTtlMetadata(
   target: new (...args: any[]) => any,
 ): YdbTtlMetadata | undefined {
-  return Reflect.getMetadata(YDB_TTL_KEY, target);
+  return Reflect.getOwnMetadata(YDB_TTL_KEY, target);
 }
 
 /** Проверяет опции декоратора без учёта схемы сущности (вызывается из @YdbTtl). */

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,6 +161,7 @@ export { YdbCoreModule } from './module/ydb-core.module.js';
 export {
   YdbSchemaSyncer,
   buildExpectedTableSchema,
+  buildExpectedSchemas,
   generateCreateTableYql,
   generateTtlWithClause,
   generateAddColumnsYql,

--- a/src/metadata/entity-metadata.ts
+++ b/src/metadata/entity-metadata.ts
@@ -38,6 +38,15 @@ const metadataCache = new WeakMap<object, YdbEntityMetadata<any>>();
 
 /**
  * Извлекает метаданные, собранные декораторами @YdbEntity / @YdbColumn.
+ *
+ * Имя таблицы читается только из СОБСТВЕННЫХ метаданных класса
+ * (Reflect.getOwnMetadata, #92): сущностью является только класс,
+ * непосредственно декорированный @YdbEntity. Подкласс без собственного
+ * @YdbEntity — не сущность: он не наследует tableName родителя и потому
+ * не регистрируется вторым классом на его таблицу (иначе buildExpectedSchemas
+ * вернул бы дубликаты, а sync патчил одну таблицу дважды). Колонки, PK,
+ * шифрование, AAD, JSON и enum при этом продолжают наследоваться по цепочке
+ * прототипов с copy-on-write (см. декораторы свойств).
  */
 export function getYdbEntityMetadata<T>(
   target: new (...args: any[]) => T,
@@ -45,7 +54,7 @@ export function getYdbEntityMetadata<T>(
   const cached = metadataCache.get(target);
   if (cached) return cached as YdbEntityMetadata<T>;
 
-  const tableName: string | undefined = Reflect.getMetadata(
+  const tableName: string | undefined = Reflect.getOwnMetadata(
     YDB_ENTITY_KEY,
     target,
   );

--- a/src/schema/schema-sync.ts
+++ b/src/schema/schema-sync.ts
@@ -277,20 +277,47 @@ export function buildExpectedJoinTableSchema(
   };
 }
 
-/** Собирает ожидаемые схемы всех таблиц сущностей и их many-to-many join-таблиц. */
+/**
+ * Собирает ожидаемые схемы всех таблиц сущностей и их many-to-many join-таблиц.
+ *
+ * Гарантия «одна таблица — одна ожидаемая схема» (#92):
+ *  - повтор класса в списке дедуплицируется;
+ *  - класс без собственного @YdbEntity пропускается (не сущность — см.
+ *    getYdbEntityMetadata), поэтому подкласс не порождает вторую схему
+ *    для таблицы родителя;
+ *  - две разные сущности с одним tableName — ошибка: иначе sync патчил бы
+ *    одну таблицу двумя разными схемами, а verify выдавал противоречивые
+ *    issues. Коллизия обнаруживается здесь — до любого обращения к БД.
+ */
 export function buildExpectedSchemas(
   entities: (new (...args: any[]) => any)[],
 ): ExpectedTableSchema[] {
   const schemas: ExpectedTableSchema[] = [];
+  const seenEntities = new Set<new (...args: any[]) => any>();
+  const tableOwners = new Map<string, new (...args: any[]) => any>();
 
   for (const entity of entities) {
+    if (seenEntities.has(entity)) continue;
+    seenEntities.add(entity);
+
     const meta = getYdbEntityMetadata(entity);
-    if (meta) {
-      schemas.push(buildExpectedTableSchema(meta));
+    if (!meta) continue;
+
+    const owner = tableOwners.get(meta.tableName);
+    if (owner && owner !== entity) {
+      throw new Error(
+        `Duplicate table name "${meta.tableName}": entities ${owner.name} ` +
+          `and ${entity.name} both map to it — each entity class must declare ` +
+          `its own table via @YdbEntity (a subclass without its own ` +
+          `@YdbEntity is not an entity and must not be passed as one).`,
+      );
     }
+    tableOwners.set(meta.tableName, entity);
+
+    schemas.push(buildExpectedTableSchema(meta));
   }
 
-  for (const joinTable of getManyToManyJoinTables(entities)) {
+  for (const joinTable of getManyToManyJoinTables([...seenEntities])) {
     schemas.push(buildExpectedJoinTableSchema(joinTable));
   }
 

--- a/test/metadata-inheritance.spec.ts
+++ b/test/metadata-inheritance.spec.ts
@@ -1,0 +1,475 @@
+import 'reflect-metadata';
+import { jest } from '@jest/globals';
+import {
+  YdbEntity,
+  YdbColumn,
+  YdbPrimaryColumn,
+  YdbBaseEntity,
+  YdbIndex,
+  YdbTtl,
+  YdbEncrypted,
+  EagerLoad,
+  getYdbEntityMetadata,
+  getYdbIndexesMetadata,
+  getYdbTtlMetadata,
+  getEagerRelations,
+  getRegisteredYdbEntities,
+  buildExpectedTableSchema,
+  buildExpectedSchemas,
+  generateCreateTableYql,
+  validateEntityMetadata,
+  YdbSchemaSyncer,
+} from '../src/index.js';
+import type { ExpectedTableSchema } from '../src/index.js';
+import { createMockExecutor } from './helpers/mock-executor.js';
+import type { YdbExecutor } from '../src/index.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Регресс-тесты #92: семантика наследования метаданных.
+//
+// Правила (зафиксированы здесь и в README):
+//  1. Сущностью является только класс с СОБСТВЕННЫМ @YdbEntity. Подкласс без
+//     своего декоратора — не сущность: не наследует tableName родителя,
+//     не попадает в реестр и в expected-схемы (иначе — дубликаты таблиц
+//     в sync/verify/migration).
+//  2. Колонки/PK/AAD/enum наследуются с copy-on-write (как и раньше).
+//  3. @YdbIndex и @YdbTtl привязаны к таблице класса и НЕ наследуются:
+//     класс со своей таблицей объявляет их явно. Унаследованные «по цепочке»
+//     индексы/TTL родителя раньше попадали в DDL дочерней таблицы и могли
+//     ссылаться на чужие колонки (например, secret_bi или переопределённый
+//     тип TTL-колонки) — уроняя CREATE TABLE.
+//  4. @EagerLoad наследуется объединением списков (семантика #107).
+//  5. Две разные сущности с одним tableName — ошибка при построении схемы.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Родитель: индексы, TTL, шифрованное поле с blind index. */
+@YdbEntity('mih_parent')
+@YdbIndex({ columns: ['email'] })
+@YdbTtl({ interval: 'PT2H', column: 'expires_at' })
+class ParentEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid!: string;
+
+  @YdbColumn('Utf8')
+  email!: string;
+
+  @YdbEncrypted({ blindIndex: true })
+  @YdbColumn('Utf8')
+  secret!: string;
+
+  @YdbColumn('Datetime')
+  expires_at!: Date;
+}
+
+/**
+ * Ребёнок со своей таблицей и дополнительной колонкой. Колонки родителя
+ * (включая шифрование) наследуются как прежде — меняется только имя таблицы.
+ */
+@YdbEntity('mih_child_plain')
+class PlainChildEntity extends ParentEntity {
+  @YdbColumn('Utf8')
+  nickname!: string;
+}
+
+/**
+ * Ребёнок переопределяет тип TTL-колонки родителя на несовместимый с TTL.
+ * Раньше унаследованный по цепочке @YdbTtl валидировался против схемы
+ * ребёнка и ронял buildExpectedTableSchema («unsupported type Int32»),
+ * а без валидации — генерировал невалидный DDL. Теперь TTL не наследуется.
+ */
+@YdbEntity('mih_child_retyped')
+class RetypedTtlChildEntity extends ParentEntity {
+  // Тип колонки в БД переопределяется декоратором (TS-тип фикстуры не важен)
+  @YdbColumn('Int32')
+  declare expires_at: Date;
+}
+
+/** Многоуровневая иерархия: gp -> mid -> leaf. */
+@YdbEntity('mih_gp')
+class GrandParentEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid!: string;
+
+  @YdbColumn('Utf8')
+  base_field!: string;
+}
+
+@YdbEntity('mih_mid')
+@YdbIndex({ columns: ['base_field'] })
+@YdbTtl({ interval: 'P1D', column: 'mid_expires_at' })
+class MiddleEntity extends GrandParentEntity {
+  @YdbColumn('Datetime')
+  mid_expires_at!: Date;
+}
+
+@YdbEntity('mih_leaf')
+class LeafEntity extends MiddleEntity {
+  @YdbColumn('Int32')
+  leaf_field!: number;
+}
+
+/** Подкласс БЕЗ собственного @YdbEntity — не сущность (#92). */
+class UndecoratedSubEntity extends ParentEntity {
+  @YdbColumn('Int32')
+  extra!: number;
+}
+
+/** Ребёнок объявляет собственные индекс и TTL поверх родительских. */
+@YdbEntity('mih_override_child')
+@YdbIndex({ columns: ['nickname'], name: 'mih_override_child__nick' })
+@YdbTtl({ interval: 'P7D', column: 'expires_at' })
+class OverrideChildEntity extends ParentEntity {
+  @YdbColumn('Utf8')
+  nickname!: string;
+}
+
+/** @EagerLoad: сохранение семантики #107 при собственных таблицах. */
+@YdbEntity('mih_eager_parent')
+@EagerLoad(['parentRel'])
+class EagerParentEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid!: string;
+}
+
+@YdbEntity('mih_eager_child')
+@EagerLoad(['childRel'])
+class EagerChildEntity extends EagerParentEntity {}
+
+/** Дубликат tableName: родитель и ребёнок декорированы одной таблицей. */
+@YdbEntity('mih_dup_table')
+class DupParentEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid!: string;
+}
+
+@YdbEntity('mih_dup_table')
+class DupChildEntity extends DupParentEntity {}
+
+/** Дубликат tableName: две независимые сущности. */
+@YdbEntity('mih_clash')
+class ClashAEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid!: string;
+}
+
+@YdbEntity('mih_clash')
+class ClashBEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid!: string;
+}
+
+/** Независимая валидная сущность — контроль отсутствия ложных срабатываний. */
+@YdbEntity('mih_independent')
+class IndependentEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid!: string;
+
+  @YdbColumn('Bool')
+  active!: boolean;
+}
+
+const meta = (entity: new (...args: any[]) => any) => {
+  const m = getYdbEntityMetadata(entity);
+  if (!m) throw new Error(`no metadata for ${entity.name}`);
+  return m;
+};
+
+const ctx = {
+  encryptionProviderConfigured: true,
+  blindIndexProviderConfigured: true,
+};
+
+describe('metadata inheritance (#92)', () => {
+  describe('собственный @YdbEntity обязателен', () => {
+    it('подкласс без собственного @YdbEntity не является сущностью', () => {
+      expect(getYdbEntityMetadata(UndecoratedSubEntity)).toBeUndefined();
+    });
+
+    it('подкласс без @YdbEntity не регистрируется в глобальном реестре', () => {
+      const registered = getRegisteredYdbEntities();
+      expect(registered).toContain(ParentEntity);
+      expect(registered).not.toContain(UndecoratedSubEntity);
+    });
+
+    it('buildExpectedSchemas не создаёт вторую схему для таблицы родителя', () => {
+      const schemas = buildExpectedSchemas([
+        ParentEntity,
+        UndecoratedSubEntity,
+      ]);
+      const names = schemas.map((s) => s.tableName);
+      // Ровно одна схема на таблицу, несмотря на два класса в списке
+      expect(names).toEqual(['mih_parent']);
+    });
+
+    it('validateEntityMetadata ясно сообщает про отсутствие @YdbEntity', () => {
+      expect(validateEntityMetadata(UndecoratedSubEntity, ctx)).toEqual([
+        'Class UndecoratedSubEntity is not decorated with @YdbEntity',
+      ]);
+    });
+
+    it('Active Record на подклассе без @YdbEntity падает с понятной ошибкой', async () => {
+      const mock = createMockExecutor([[]]);
+      UndecoratedSubEntity.setExecutor(mock.executor);
+
+      await expect(UndecoratedSubEntity.findAll()).rejects.toThrow(
+        'Entity UndecoratedSubEntity is not decorated with @YdbEntity',
+      );
+
+      UndecoratedSubEntity.setExecutor(undefined);
+    });
+  });
+
+  describe('одиночное наследование: колонки наследуются, таблица — своя', () => {
+    it('ребёнок наследует схему/PK родителя и имеет своё имя таблицы', () => {
+      const m = meta(PlainChildEntity);
+      expect(m.tableName).toBe('mih_child_plain');
+      expect(m.schema).toMatchObject({
+        uuid: 'Uuid',
+        email: 'Utf8',
+        // Шифрованное поле родителя (Bytes + secret_bi) наследуется как прежде
+        secret: 'Bytes',
+        nickname: 'Utf8',
+        expires_at: 'Datetime',
+      });
+      expect(m.primaryKeys).toEqual(['uuid']);
+      expect(buildExpectedTableSchema(m).columns.secret_bi).toBe('Utf8');
+    });
+  });
+
+  describe('многоуровневое наследование', () => {
+    it('колонки накапливаются по уровням, у каждого класса своя таблица', () => {
+      expect(meta(GrandParentEntity).tableName).toBe('mih_gp');
+      expect(meta(MiddleEntity).tableName).toBe('mih_mid');
+      expect(meta(LeafEntity).tableName).toBe('mih_leaf');
+
+      expect(Object.keys(meta(LeafEntity).schema).sort()).toEqual([
+        'base_field',
+        'leaf_field',
+        'mid_expires_at',
+        'uuid',
+      ]);
+      expect(meta(GrandParentEntity).schema).not.toHaveProperty('leaf_field');
+    });
+  });
+
+  describe('@YdbIndex не наследуется', () => {
+    it('у класса со своей таблицей нет индексов родителя', () => {
+      expect(getYdbIndexesMetadata(ParentEntity)).toHaveLength(1);
+      expect(getYdbIndexesMetadata(PlainChildEntity)).toEqual([]);
+      expect(buildExpectedTableSchema(meta(PlainChildEntity)).indexes).toEqual(
+        [],
+      );
+    });
+
+    it('индекс среднего уровня не протекает на grandparent и leaf', () => {
+      expect(getYdbIndexesMetadata(MiddleEntity)).toHaveLength(1);
+      expect(getYdbIndexesMetadata(GrandParentEntity)).toEqual([]);
+      expect(getYdbIndexesMetadata(LeafEntity)).toEqual([]);
+    });
+
+    it('унаследованный TTL больше не валидируется против схемы ребёнка и не попадает в DDL', () => {
+      // RetypedTtlChildEntity переопределяет тип колонки expires_at на Int32:
+      // если бы TTL родителя наследовался, buildExpectedTableSchema упал бы
+      // с «unsupported type Int32», а без валидации — сгенерировал бы
+      // невалидный DDL. Теперь у ребёнка просто нет TTL.
+      expect(() =>
+        buildExpectedTableSchema(meta(RetypedTtlChildEntity)),
+      ).not.toThrow();
+      expect(
+        buildExpectedTableSchema(meta(RetypedTtlChildEntity)).ttl,
+      ).toBeUndefined();
+
+      const yql = generateCreateTableYql(
+        buildExpectedTableSchema(meta(PlainChildEntity)),
+      );
+      expect(yql).not.toContain('TTL =');
+    });
+  });
+
+  describe('@YdbTtl не наследуется', () => {
+    it('у класса со своей таблицей нет TTL родителя — схема строится без ошибок', () => {
+      expect(getYdbTtlMetadata(PlainChildEntity)).toBeUndefined();
+      expect(
+        buildExpectedTableSchema(meta(PlainChildEntity)).ttl,
+      ).toBeUndefined();
+
+      // TTL среднего уровня не протекает на grandparent и leaf
+      expect(getYdbTtlMetadata(GrandParentEntity)).toBeUndefined();
+      expect(getYdbTtlMetadata(LeafEntity)).toBeUndefined();
+      expect(getYdbTtlMetadata(MiddleEntity)).toBeDefined();
+    });
+
+    it('наследник может объявить СВОЙ TTL (guard «один раз» смотрит только свои метаданные)', () => {
+      expect(() =>
+        buildExpectedTableSchema(meta(OverrideChildEntity)),
+      ).not.toThrow();
+
+      const childSchema = buildExpectedTableSchema(meta(OverrideChildEntity));
+      expect(childSchema.ttl).toEqual({
+        interval: 'P7D',
+        column: 'expires_at',
+      });
+      expect(childSchema.indexes).toEqual([
+        {
+          name: 'mih_override_child__nick',
+          columns: ['nickname'],
+          unique: false,
+        },
+      ]);
+
+      // Метаданные родителя не тронуты (copy-on-write)
+      expect(getYdbTtlMetadata(ParentEntity)).toEqual({
+        interval: 'PT2H',
+        column: 'expires_at',
+      });
+      expect(getYdbIndexesMetadata(ParentEntity)).toEqual([
+        { columns: ['email'] },
+      ]);
+    });
+  });
+
+  describe('@EagerLoad: семантика #107 сохранена', () => {
+    it('связи родителя и ребёнка объединяются, у каждого класса своя таблица', () => {
+      expect(getEagerRelations(EagerParentEntity)).toEqual(['parentRel']);
+      expect(getEagerRelations(EagerChildEntity)).toEqual([
+        'parentRel',
+        'childRel',
+      ]);
+      expect(meta(EagerChildEntity).tableName).toBe('mih_eager_child');
+    });
+  });
+
+  describe('copy-on-write', () => {
+    it('добавление колонок/индексов/TTL у наследника не мутирует метаданные родителя', () => {
+      const parentSchema = buildExpectedTableSchema(meta(ParentEntity));
+
+      // OverrideChildEntity уже декорирован выше — родитель не изменился
+      expect(parentSchema.columns).not.toHaveProperty('nickname');
+      expect(parentSchema.indexes).toEqual([
+        { name: 'mih_parent__email', columns: ['email'], unique: false },
+      ]);
+      expect(parentSchema.ttl).toEqual({
+        interval: 'PT2H',
+        column: 'expires_at',
+      });
+
+      // И у промежуточных уровней многоуровневой иерархии тоже
+      expect(
+        buildExpectedTableSchema(meta(GrandParentEntity)).columns,
+      ).not.toHaveProperty('leaf_field');
+      expect(
+        buildExpectedTableSchema(meta(MiddleEntity)).columns,
+      ).not.toHaveProperty('leaf_field');
+    });
+  });
+
+  describe('дубликаты tableName детектируются', () => {
+    it('родитель и ребёнок с одной таблицей — ошибка с именами классов', () => {
+      expect(() =>
+        buildExpectedSchemas([DupParentEntity, DupChildEntity]),
+      ).toThrow(
+        'Duplicate table name "mih_dup_table": entities DupParentEntity ' +
+          'and DupChildEntity both map to it',
+      );
+    });
+
+    it('две независимые сущности с одной таблицей — та же ошибка', () => {
+      expect(() => buildExpectedSchemas([ClashAEntity, ClashBEntity])).toThrow(
+        'Duplicate table name "mih_clash"',
+      );
+    });
+
+    it('повтор одного и того же класса в списке дедуплицируется', () => {
+      const schemas = buildExpectedSchemas([
+        IndependentEntity,
+        IndependentEntity,
+      ]);
+      expect(schemas).toHaveLength(1);
+      expect(schemas[0].tableName).toBe('mih_independent');
+    });
+  });
+
+  describe('одна консистентная ожидаемая схема на таблицу', () => {
+    let schemas: ExpectedTableSchema[];
+
+    beforeEach(() => {
+      schemas = buildExpectedSchemas([
+        ParentEntity,
+        UndecoratedSubEntity,
+        LeafEntity,
+        IndependentEntity,
+        IndependentEntity,
+      ]);
+    });
+
+    it('имена таблиц уникальны', () => {
+      const names = schemas.map((s) => s.tableName);
+      expect(new Set(names).size).toBe(names.length);
+      // UndecoratedSubEntity не добавляет вторую схему для mih_parent
+      expect(names.sort()).toEqual([
+        'mih_independent',
+        'mih_leaf',
+        'mih_parent',
+      ]);
+    });
+
+    it('sync выполняет CREATE TABLE ровно один раз на таблицу', async () => {
+      const executor = jest.fn(() =>
+        Promise.resolve([]),
+      ) as unknown as YdbExecutor;
+      const syncer = new YdbSchemaSyncer({} as never, executor);
+      jest.spyOn(syncer, 'describeTable').mockResolvedValue(null);
+
+      await syncer.sync([ParentEntity, UndecoratedSubEntity]);
+
+      const executedSql = (): string[] =>
+        (executor as unknown as jest.Mock).mock.calls.map(
+          (c: any) => c[0][0] as string,
+        );
+      expect(executedSql()).toEqual([
+        generateCreateTableYql(buildExpectedTableSchema(meta(ParentEntity))),
+      ]);
+    });
+
+    it('verify выдаёт ровно один набор issues на таблицу', async () => {
+      const executor = jest.fn(() =>
+        Promise.resolve([]),
+      ) as unknown as YdbExecutor;
+      const syncer = new YdbSchemaSyncer({} as never, executor);
+      jest.spyOn(syncer, 'describeTable').mockResolvedValue(null);
+
+      const issues = await syncer.verify([
+        ParentEntity,
+        UndecoratedSubEntity,
+        IndependentEntity,
+      ]);
+
+      expect(issues).toEqual([
+        {
+          tableName: 'mih_parent',
+          kind: 'missing-table',
+          message: 'Table "mih_parent" does not exist',
+        },
+        {
+          tableName: 'mih_independent',
+          kind: 'missing-table',
+          message: 'Table "mih_independent" does not exist',
+        },
+      ]);
+    });
+  });
+
+  describe('валидные независимые сущности не затронуты', () => {
+    it('метаданные независимой сущности строятся как прежде', () => {
+      const schema = buildExpectedTableSchema(meta(IndependentEntity));
+      expect(schema).toEqual({
+        tableName: 'mih_independent',
+        columns: { uuid: 'Uuid', active: 'Bool' },
+        primaryKey: ['uuid'],
+        indexes: [],
+        ttl: undefined,
+      });
+      expect(validateEntityMetadata(IndependentEntity, ctx)).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #92.

Зафиксирована и задокументирована семантика наследования метаданных декораторов; устранены оба бага из issue:

### 1. Подкласс без собственного \`@YdbEntity\` — не сущность
- \`getYdbEntityMetadata\` читает tableName через \`Reflect.getOwnMetadata\`: имя таблицы больше не наследуется по цепочке прототипов.
- Такой подкласс не регистрируется вторым классом на таблицу родителя: не попадает в реестр и в expected-схемы, а Active Record / \`validateEntityMetadata\` дают понятную ошибку «is not decorated with @YdbEntity».
- Коллизии tableName между **декорированными** сущностями (родитель+наследник с одной таблицей, две независимые сущности) детектируются в \`buildExpectedSchemas\` ошибкой \`Duplicate table name "..." \`(с именами классов) — вместо молчаливых дубликатов схем/DDL. Повторы одного класса дедуплицируются.
- Итог: schema sync/verify/`migration:generate` всегда работают ровно с одной ожидаемой схемой на таблицу (покрыто тестами через \`sync\`/\`verify\`).

### 2. \`@YdbIndex\`/\`@YdbTtl\` привязаны к таблице и не наследуются
- Декораторы и геттеры (\`getYdbIndexesMetadata\`, \`getYdbTtlMetadata\`) читают только собственные метаданные класса.
- Раньше индексы/TTL родителя протекали в дочернюю таблицу: индекс по чужой колонке (например, отсутствующей \`secret_bi\`) ломал CREATE TABLE, а унаследованный TTL по переопределённой колонке ронял \`buildExpectedTableSchema\`.
- Guard «@YdbTtl можно применить один раз» теперь смотрит только свои метаданные — наследник может объявить собственный TTL.

### Сохранено
- Наследование колонок/PK/AAD/JSON/enum с copy-on-write — как прежде; изменение метаданных ребёнка никогда не мутирует родителя (тесты).
- Семантика \`@EagerLoad\` из #107: объединение списков родитель+ребёнок без повторов (регресс-тесты).
- \`buildExpectedSchemas\` экспортирован из публичного API (issue сформулирован в его терминах).

## Testing
- Новый suite \`test/metadata-inheritance.spec.ts\` (22 теста): одно- и многоуровневое наследование, отсутствие регистрации недекорированного подкласса, дубликаты tableName, ненаследование индексов/TTL (в т.ч. кейс невалидного DDL), собственные override индекса/TTL, copy-on-write, независимые валидные сущности, единственность ожидаемых схем для sync/verify.
- \`yarn test\` — 682 passed; \`yarn build\` — ok; \`yarn lint\` — 0 errors.
- README: новый раздел «Наследование метаданных» с правилами и примерами.