### PR TITLE
fix(schema): join-таблицы many-to-many строятся по фактическим PK обеих сущностей (#90)

### DIFF
--- a/src/decorators/relation.decorators.ts
+++ b/src/decorators/relation.decorators.ts
@@ -1,4 +1,5 @@
 import 'reflect-metadata';
+import { YdbPrimitive } from '../core/types.js';
 import { YdbBaseEntity } from '../entity/base-entity.js';
 import { getYdbEntityMetadata } from '../metadata/entity-metadata.js';
 
@@ -32,11 +33,31 @@ export interface ManyToManyJoinTable {
   tableName: string;
   joinColumn: string;
   inverseJoinColumn: string;
+  /**
+   * YDB-тип колонки, ссылающейся на владельца (#90): выводится из
+   * фактического PK owner-сущности, а не жёстко Uuid.
+   */
+  joinColumnType?: YdbPrimitive;
+  /** YDB-тип колонки, ссылающейся на inverse-сущность (аналогично #90). */
+  inverseJoinColumnType?: YdbPrimitive;
   ownerEntity: typeof YdbBaseEntity;
   ownerTableName: string;
   ownerProperty: string;
   inverseEntity: typeof YdbBaseEntity;
   inverseTableName: string;
+}
+
+/**
+ * Имя join-колонки по умолчанию: `{tableName}_{pkProperty}` (#90).
+ * Для PK с именем `uuid` это историческое `{tableName}_uuid` — существующие
+ * связи сохраняют имена; для не-uuid PK имя выводится из реального свойства
+ * PK вместо молчаливого предположения о `_uuid`.
+ */
+export function defaultJoinColumnName(
+  tableName: string,
+  pkProperty: string,
+): string {
+  return `${tableName}_${pkProperty}`;
 }
 
 function defineRelation(prototype: object, metadata: RelationMetadata): void {
@@ -185,9 +206,53 @@ export function getManyToManyJoinTables(
         );
       }
 
-      const joinColumn = joinTable.joinColumn ?? `${meta.tableName}_uuid`;
+      // Рантайм-модель many-to-many связывает строки ровно по одному
+      // значению PK с каждой стороны; составной PK породил бы join-таблицу,
+      // не совпадающую с тем, что читает relations-код, — отказываем явно (#90).
+      if (meta.primaryKeys.length > 1) {
+        throw new Error(
+          `Cannot build many-to-many join table "${joinTable.tableName}" ` +
+            `for entity ${Entity.name}: composite primary keys ` +
+            `(${meta.primaryKeys.join(', ')}) are not supported in ` +
+            `many-to-many relations. Declare a single-column @YdbPrimaryColumn.`,
+        );
+      }
+      if (inverseMeta.primaryKeys.length > 1) {
+        throw new Error(
+          `Cannot build many-to-many join table "${joinTable.tableName}" ` +
+            `for entity ${InverseEntity.name}: composite primary keys ` +
+            `(${inverseMeta.primaryKeys.join(', ')}) are not supported in ` +
+            `many-to-many relations. Declare a single-column @YdbPrimaryColumn.`,
+        );
+      }
+
+      const ownerPk = meta.primaryKeys[0];
+      const inversePk = inverseMeta.primaryKeys[0];
+
+      const ownerPkType = meta.schema[ownerPk];
+      if (!ownerPkType) {
+        throw new Error(
+          `Cannot build many-to-many join table for entity ${Entity.name}: ` +
+            `primary key column "${ownerPk}" is not declared via @YdbColumn. ` +
+            `Declare it or mark another column with @YdbPrimaryColumn.`,
+        );
+      }
+      const inversePkType = inverseMeta.schema[inversePk];
+      if (!inversePkType) {
+        throw new Error(
+          `Cannot build many-to-many join table for entity ${InverseEntity.name}: ` +
+            `primary key column "${inversePk}" is not declared via @YdbColumn. ` +
+            `Declare it or mark another column with @YdbPrimaryColumn.`,
+        );
+      }
+
+      // Имена по умолчанию выводятся из фактических PK-колонок (#90):
+      // для PK "uuid" это прежние `{table}_uuid`, для остальных — `{table}_{pk}`.
+      const joinColumn =
+        joinTable.joinColumn ?? defaultJoinColumnName(meta.tableName, ownerPk);
       const inverseJoinColumn =
-        joinTable.inverseJoinColumn ?? `${inverseMeta.tableName}_uuid`;
+        joinTable.inverseJoinColumn ??
+        defaultJoinColumnName(inverseMeta.tableName, inversePk);
 
       if (seen.has(joinTable.tableName)) continue;
       seen.add(joinTable.tableName);
@@ -196,6 +261,8 @@ export function getManyToManyJoinTables(
         tableName: joinTable.tableName,
         joinColumn,
         inverseJoinColumn,
+        joinColumnType: ownerPkType,
+        inverseJoinColumnType: inversePkType,
         ownerEntity: Entity as typeof YdbBaseEntity,
         ownerTableName: meta.tableName,
         ownerProperty: relation.propertyKey,

--- a/src/decorators/relation.decorators.ts
+++ b/src/decorators/relation.decorators.ts
@@ -2,6 +2,7 @@ import 'reflect-metadata';
 import { YdbPrimitive } from '../core/types.js';
 import { YdbBaseEntity } from '../entity/base-entity.js';
 import { getYdbEntityMetadata } from '../metadata/entity-metadata.js';
+import { getRegisteredYdbEntities } from '../metadata/entity-registry.js';
 
 export const YDB_RELATIONS_KEY = 'ydb:relations';
 export const YDB_JOIN_TABLES_KEY = 'ydb:joinTables';
@@ -160,6 +161,113 @@ export function getYdbJoinTableMetadata(target: any): JoinTableMetadata[] {
 }
 
 /**
+ * Резолвит ОДНО объявление join-таблицы: владелец + конкретная m2m-связь
+ * с @JoinTable. Валидирует PK обеих сторон, выводит имена колонок по
+ * умолчанию из фактических PK и их YDB-типы (#90).
+ *
+ * Единственная точка резолва объявления: используется и генерацией схемы
+ * (getManyToManyJoinTables), и рантайм-резолвом relations (#139) —
+ * алгоритм открытия/валидации нигде не дублируется.
+ *
+ * undefined — связь не many-to-many, у сущности нет метаданных или
+ * у этой связи нет собственной @JoinTable.
+ */
+export function resolveRelationJoinTableDefinition(
+  Entity: new (...args: any[]) => any,
+  relation: RelationMetadata,
+): ManyToManyJoinTable | undefined {
+  if (relation.type !== 'many-to-many') return undefined;
+
+  const meta = getYdbEntityMetadata(Entity);
+  if (!meta) return undefined;
+
+  const joinTable = getYdbJoinTableMetadata(Entity).find(
+    (jt) => jt.propertyKey === relation.propertyKey,
+  );
+  if (!joinTable) return undefined;
+
+  const InverseEntity = relation.target();
+  const inverseMeta = getYdbEntityMetadata(InverseEntity);
+  if (!inverseMeta) {
+    throw new Error(
+      `ManyToMany relation "${relation.propertyKey}" on ${Entity.name} ` +
+        `targets ${InverseEntity.name}, which is not decorated with @YdbEntity`,
+    );
+  }
+
+  if (meta.primaryKeys.length === 0) {
+    throw new Error(
+      `Cannot build many-to-many join table for entity ${Entity.name}: ` +
+        `no primary key is declared. Mark at least one column with @YdbPrimaryColumn.`,
+    );
+  }
+  if (inverseMeta.primaryKeys.length === 0) {
+    throw new Error(
+      `Cannot build many-to-many join table for entity ${InverseEntity.name}: ` +
+        `no primary key is declared. Mark at least one column with @YdbPrimaryColumn.`,
+    );
+  }
+
+  // Рантайм-модель many-to-many связывает строки ровно по одному
+  // значению PK с каждой стороны; составной PK породил бы join-таблицу,
+  // не совпадающую с тем, что читает relations-код, — отказываем явно (#90).
+  if (meta.primaryKeys.length > 1) {
+    throw new Error(
+      `Cannot build many-to-many join table "${joinTable.tableName}" ` +
+        `for entity ${Entity.name}: composite primary keys ` +
+        `(${meta.primaryKeys.join(', ')}) are not supported in ` +
+        `many-to-many relations. Declare a single-column @YdbPrimaryColumn.`,
+    );
+  }
+  if (inverseMeta.primaryKeys.length > 1) {
+    throw new Error(
+      `Cannot build many-to-many join table "${joinTable.tableName}" ` +
+        `for entity ${InverseEntity.name}: composite primary keys ` +
+        `(${inverseMeta.primaryKeys.join(', ')}) are not supported in ` +
+        `many-to-many relations. Declare a single-column @YdbPrimaryColumn.`,
+    );
+  }
+
+  const ownerPk = meta.primaryKeys[0];
+  const inversePk = inverseMeta.primaryKeys[0];
+
+  const ownerPkType = meta.schema[ownerPk];
+  if (!ownerPkType) {
+    throw new Error(
+      `Cannot build many-to-many join table for entity ${Entity.name}: ` +
+        `primary key column "${ownerPk}" is not declared via @YdbColumn. ` +
+        `Declare it or mark another column with @YdbPrimaryColumn.`,
+    );
+  }
+  const inversePkType = inverseMeta.schema[inversePk];
+  if (!inversePkType) {
+    throw new Error(
+      `Cannot build many-to-many join table for entity ${InverseEntity.name}: ` +
+        `primary key column "${inversePk}" is not declared via @YdbColumn. ` +
+        `Declare it or mark another column with @YdbPrimaryColumn.`,
+    );
+  }
+
+  // Имена по умолчанию выводятся из фактических PK-колонок (#90):
+  // для PK "uuid" это прежние `{table}_uuid`, для остальных — `{table}_{pk}`.
+  return {
+    tableName: joinTable.tableName,
+    joinColumn:
+      joinTable.joinColumn ?? defaultJoinColumnName(meta.tableName, ownerPk),
+    inverseJoinColumn:
+      joinTable.inverseJoinColumn ??
+      defaultJoinColumnName(inverseMeta.tableName, inversePk),
+    joinColumnType: ownerPkType,
+    inverseJoinColumnType: inversePkType,
+    ownerEntity: Entity as typeof YdbBaseEntity,
+    ownerTableName: meta.tableName,
+    ownerProperty: relation.propertyKey,
+    inverseEntity: InverseEntity,
+    inverseTableName: inverseMeta.tableName,
+  };
+}
+
+/**
  * Возвращает join-таблицы many-to-many, владельцами которых являются переданные сущности.
  * Обратная сторона (без @JoinTable) не порождает отдельную таблицу.
  *
@@ -176,102 +284,11 @@ export function getManyToManyJoinTables(
   const groups = new Map<string, ManyToManyJoinTable[]>();
 
   for (const Entity of entities) {
-    const meta = getYdbEntityMetadata(Entity);
-    if (!meta) continue;
-
     const relations = getYdbRelationsMetadata(Entity);
-    const joinTables = getYdbJoinTableMetadata(Entity);
 
     for (const relation of relations) {
-      if (relation.type !== 'many-to-many') continue;
-
-      const joinTable = joinTables.find(
-        (jt) => jt.propertyKey === relation.propertyKey,
-      );
-      if (!joinTable) continue;
-
-      const InverseEntity = relation.target();
-      const inverseMeta = getYdbEntityMetadata(InverseEntity);
-      if (!inverseMeta) {
-        throw new Error(
-          `ManyToMany relation "${relation.propertyKey}" on ${Entity.name} ` +
-            `targets ${InverseEntity.name}, which is not decorated with @YdbEntity`,
-        );
-      }
-
-      if (meta.primaryKeys.length === 0) {
-        throw new Error(
-          `Cannot build many-to-many join table for entity ${Entity.name}: ` +
-            `no primary key is declared. Mark at least one column with @YdbPrimaryColumn.`,
-        );
-      }
-      if (inverseMeta.primaryKeys.length === 0) {
-        throw new Error(
-          `Cannot build many-to-many join table for entity ${InverseEntity.name}: ` +
-            `no primary key is declared. Mark at least one column with @YdbPrimaryColumn.`,
-        );
-      }
-
-      // Рантайм-модель many-to-many связывает строки ровно по одному
-      // значению PK с каждой стороны; составной PK породил бы join-таблицу,
-      // не совпадающую с тем, что читает relations-код, — отказываем явно (#90).
-      if (meta.primaryKeys.length > 1) {
-        throw new Error(
-          `Cannot build many-to-many join table "${joinTable.tableName}" ` +
-            `for entity ${Entity.name}: composite primary keys ` +
-            `(${meta.primaryKeys.join(', ')}) are not supported in ` +
-            `many-to-many relations. Declare a single-column @YdbPrimaryColumn.`,
-        );
-      }
-      if (inverseMeta.primaryKeys.length > 1) {
-        throw new Error(
-          `Cannot build many-to-many join table "${joinTable.tableName}" ` +
-            `for entity ${InverseEntity.name}: composite primary keys ` +
-            `(${inverseMeta.primaryKeys.join(', ')}) are not supported in ` +
-            `many-to-many relations. Declare a single-column @YdbPrimaryColumn.`,
-        );
-      }
-
-      const ownerPk = meta.primaryKeys[0];
-      const inversePk = inverseMeta.primaryKeys[0];
-
-      const ownerPkType = meta.schema[ownerPk];
-      if (!ownerPkType) {
-        throw new Error(
-          `Cannot build many-to-many join table for entity ${Entity.name}: ` +
-            `primary key column "${ownerPk}" is not declared via @YdbColumn. ` +
-            `Declare it or mark another column with @YdbPrimaryColumn.`,
-        );
-      }
-      const inversePkType = inverseMeta.schema[inversePk];
-      if (!inversePkType) {
-        throw new Error(
-          `Cannot build many-to-many join table for entity ${InverseEntity.name}: ` +
-            `primary key column "${inversePk}" is not declared via @YdbColumn. ` +
-            `Declare it or mark another column with @YdbPrimaryColumn.`,
-        );
-      }
-
-      // Имена по умолчанию выводятся из фактических PK-колонок (#90):
-      // для PK "uuid" это прежние `{table}_uuid`, для остальных — `{table}_{pk}`.
-      const joinColumn =
-        joinTable.joinColumn ?? defaultJoinColumnName(meta.tableName, ownerPk);
-      const inverseJoinColumn =
-        joinTable.inverseJoinColumn ??
-        defaultJoinColumnName(inverseMeta.tableName, inversePk);
-
-      const definition: ManyToManyJoinTable = {
-        tableName: joinTable.tableName,
-        joinColumn,
-        inverseJoinColumn,
-        joinColumnType: ownerPkType,
-        inverseJoinColumnType: inversePkType,
-        ownerEntity: Entity as typeof YdbBaseEntity,
-        ownerTableName: meta.tableName,
-        ownerProperty: relation.propertyKey,
-        inverseEntity: InverseEntity,
-        inverseTableName: inverseMeta.tableName,
-      };
+      const definition = resolveRelationJoinTableDefinition(Entity, relation);
+      if (!definition) continue;
 
       const group = groups.get(definition.tableName);
       if (!group) {
@@ -293,6 +310,44 @@ export function getManyToManyJoinTables(
   }
 
   return [...groups.values()].map(([first]) => first);
+}
+
+/**
+ * Глобальная сверка объявления join-таблицы со всеми зарегистрированными
+ * сущностями (#139): если то же имя таблицы объявлено другой связью
+ * с другим физическим описанием — ошибка с перечислением определений.
+ *
+ * Вызывается рантайм-резолвом relations, чтобы конфликт, который отвергла
+ * бы schema sync/verify/миграции, не проходил молча при чтении: локально
+ * для пары (owner, inverse) объявление может быть единственным, но имя
+ * таблицы уже занято расходящимся объявлением в другом месте модели.
+ */
+export function assertNoForeignJoinTableConflicts(
+  canonical: ManyToManyJoinTable,
+): void {
+  for (const Entity of getRegisteredYdbEntities()) {
+    const relations = getYdbRelationsMetadata(Entity);
+    for (const relation of relations) {
+      // Сломанные нерелевантные объявления не должны ронять чтение другой
+      // связи: их отвергнет полное сканирование модели (schema sync/verify/
+      // миграции) с той же ошибкой. Роняет сверку только реальный конфликт
+      // имён таблиц.
+      let other: ManyToManyJoinTable | undefined;
+      try {
+        other = resolveRelationJoinTableDefinition(Entity, relation);
+      } catch {
+        continue;
+      }
+      if (!other || other.tableName !== canonical.tableName) continue;
+      // Эквивалентные (например, зеркальные) объявления разрешены.
+      if (joinTableDefinitionsEquivalent(canonical, other)) continue;
+      throw new Error(
+        formatJoinTableConflict([canonical, other]) +
+          `\nDetected while resolving runtime relation access — the same ` +
+          `conflict would fail schema sync/verify/migration generation.`,
+      );
+    }
+  }
 }
 
 /**

--- a/src/decorators/relation.decorators.ts
+++ b/src/decorators/relation.decorators.ts
@@ -162,12 +162,18 @@ export function getYdbJoinTableMetadata(target: any): JoinTableMetadata[] {
 /**
  * Возвращает join-таблицы many-to-many, владельцами которых являются переданные сущности.
  * Обратная сторона (без @JoinTable) не порождает отдельную таблицу.
+ *
+ * Одно имя join-таблицы может быть объявлено несколько раз (например,
+ * зеркально на обеих сторонах связи или при повторе класса во входном
+ * списке). Повторные объявления безопасно дедуплицируются только при
+ * идентичном физическом описании (#139); расходящиеся — ошибка со списком
+ * всех определений: иначе sync/migrations молча построили бы схему по
+ * первому объявлению, а relations-код читал бы по другому.
  */
 export function getManyToManyJoinTables(
   entities: (new (...args: any[]) => any)[],
 ): ManyToManyJoinTable[] {
-  const result: ManyToManyJoinTable[] = [];
-  const seen = new Set<string>();
+  const groups = new Map<string, ManyToManyJoinTable[]>();
 
   for (const Entity of entities) {
     const meta = getYdbEntityMetadata(Entity);
@@ -254,10 +260,7 @@ export function getManyToManyJoinTables(
         joinTable.inverseJoinColumn ??
         defaultJoinColumnName(inverseMeta.tableName, inversePk);
 
-      if (seen.has(joinTable.tableName)) continue;
-      seen.add(joinTable.tableName);
-
-      result.push({
+      const definition: ManyToManyJoinTable = {
         tableName: joinTable.tableName,
         joinColumn,
         inverseJoinColumn,
@@ -268,9 +271,118 @@ export function getManyToManyJoinTables(
         ownerProperty: relation.propertyKey,
         inverseEntity: InverseEntity,
         inverseTableName: inverseMeta.tableName,
-      });
+      };
+
+      const group = groups.get(definition.tableName);
+      if (!group) {
+        groups.set(definition.tableName, [definition]);
+      } else if (
+        !group.some((d) => joinTableDefinitionsEquivalent(d, definition))
+      ) {
+        group.push(definition);
+      }
     }
   }
 
-  return result;
+  // Расходящиеся объявления одного имени таблицы — конфликт: физическую
+  // таблицу нельзя построить двумя разными способами (#139).
+  for (const group of groups.values()) {
+    if (group.length > 1) {
+      throw new Error(formatJoinTableConflict(group));
+    }
+  }
+
+  return [...groups.values()].map(([first]) => first);
+}
+
+/**
+ * Сравнивает два описания join-таблицы как ФИЗИЧЕСКУЮ таблицу (#139):
+ * совпадают пары «сущность → имя колонки + тип», направление объявления
+ * не важно (зеркальные декларации на обеих сторонах эквивалентны).
+ * Типы выводятся из PK конкретных сущностей, поэтому сравнение покрывает
+ * и семантику PK; идентичность сущностей гарантирует одинаковый источник
+ * имён/типов по умолчанию.
+ */
+export function joinTableDefinitionsEquivalent(
+  a: Pick<
+    ManyToManyJoinTable,
+    | 'ownerEntity'
+    | 'joinColumn'
+    | 'joinColumnType'
+    | 'inverseEntity'
+    | 'inverseJoinColumn'
+    | 'inverseJoinColumnType'
+  >,
+  b: Pick<
+    ManyToManyJoinTable,
+    | 'ownerEntity'
+    | 'joinColumn'
+    | 'joinColumnType'
+    | 'inverseEntity'
+    | 'inverseJoinColumn'
+    | 'inverseJoinColumnType'
+  >,
+): boolean {
+  const sameSide = (
+    e1: typeof YdbBaseEntity,
+    c1: string | undefined,
+    t1: YdbPrimitive | undefined,
+    e2: typeof YdbBaseEntity,
+    c2: string | undefined,
+    t2: YdbPrimitive | undefined,
+  ) => e1 === e2 && c1 === c2 && t1 === t2;
+
+  return (
+    (sameSide(
+      a.ownerEntity,
+      a.joinColumn,
+      a.joinColumnType,
+      b.ownerEntity,
+      b.joinColumn,
+      b.joinColumnType,
+    ) &&
+      sameSide(
+        a.inverseEntity,
+        a.inverseJoinColumn,
+        a.inverseJoinColumnType,
+        b.inverseEntity,
+        b.inverseJoinColumn,
+        b.inverseJoinColumnType,
+      )) ||
+    (sameSide(
+      a.ownerEntity,
+      a.joinColumn,
+      a.joinColumnType,
+      b.inverseEntity,
+      b.inverseJoinColumn,
+      b.inverseJoinColumnType,
+    ) &&
+      sameSide(
+        a.inverseEntity,
+        a.inverseJoinColumn,
+        a.inverseJoinColumnType,
+        b.ownerEntity,
+        b.joinColumn,
+        b.joinColumnType,
+      ))
+  );
+}
+
+/** Человекочитаемое описание одного определения join-таблицы (для ошибок). */
+function formatJoinTableDefinition(d: ManyToManyJoinTable): string {
+  return (
+    `- ${d.ownerEntity.name}.${d.ownerProperty} -> ${d.inverseEntity.name} ` +
+    `(columns: ${d.joinColumn}:${d.joinColumnType}, ` +
+    `${d.inverseJoinColumn}:${d.inverseJoinColumnType})`
+  );
+}
+
+function formatJoinTableConflict(group: ManyToManyJoinTable[]): string {
+  return (
+    `Conflicting definitions for many-to-many join table ` +
+    `"${group[0].tableName}" (${group.length} declarations):\n` +
+    group.map(formatJoinTableDefinition).join('\n') +
+    `\nAll @JoinTable declarations sharing a table name must describe the ` +
+    `same physical table: identical columns, types and entity pairs.`
+  );
 }

--- a/src/relations/entity-relations.ts
+++ b/src/relations/entity-relations.ts
@@ -1,12 +1,17 @@
 import type { YdbBaseEntity } from '../entity/base-entity.js';
 import type { YdbEntityConstructor } from '../persistence/entity-persistence.js';
-import { getYdbEntityMetadata } from '../metadata/entity-metadata.js';
 import {
+  getYdbEntityMetadata,
+  type YdbEntityMetadata,
+} from '../metadata/entity-metadata.js';
+import {
+  defaultJoinColumnName,
   getYdbJoinTableMetadata,
   getYdbRelationsMetadata,
 } from '../decorators/relation.decorators.js';
 import type { QueryOptions } from '../core/query-options.js';
 import type { YdbExecutor } from '../core/interfaces.js';
+import type { YdbPrimitive } from '../core/types.js';
 import type {
   YdbBlindIndexProvider,
   YdbEncryptionProvider,
@@ -98,10 +103,7 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
     }
 
     const inParams = ownerPks.map((_, i) => `$p${i}`).join(', ');
-    const ownerPkField = getPrimaryKey(joinTable.ownerEntity);
-    const ownerPkType =
-      getYdbEntityMetadata(joinTable.ownerEntity)?.schema[ownerPkField] ??
-      'Uuid';
+    const ownerPkType = joinTable.ownerColumnType;
 
     const sql =
       `SELECT ${quoteIdentifier(joinTable.ownerColumn)}, ` +
@@ -111,7 +113,10 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
 
     const joinQuery = exec([sql] as unknown as TemplateStringsArray);
     ownerPks.forEach((value, i) => {
-      joinQuery.parameter(`p${i}`, mapToYdb(ownerPkType, value, ownerPkField));
+      joinQuery.parameter(
+        `p${i}`,
+        mapToYdb(ownerPkType, value, joinTable.ownerColumn),
+      );
     });
 
     const joinRows = await this.executeQuery(joinQuery, options);
@@ -396,6 +401,12 @@ interface ResolvedJoinTable {
   tableName: string;
   ownerColumn: string;
   inverseColumn: string;
+  /**
+   * YDB-тип owner-колонки join-таблицы (#90): тип PK owner-сущности.
+   * Схема join-таблицы (schema sync) выводит те же имена и типы, поэтому
+   * чтение всегда совместимо со сгенерированной таблицей.
+   */
+  ownerColumnType: YdbPrimitive;
   ownerEntity: typeof YdbBaseEntity;
   inverseEntity: typeof YdbBaseEntity;
 }
@@ -409,6 +420,12 @@ function resolveManyToManyJoinTable(
   const inverseMeta = getYdbEntityMetadata(inverseEntity);
   if (!ownerMeta || !inverseMeta) return undefined;
 
+  // Рантайм-модель many-to-many поддерживает только одно-колоночные PK —
+  // тот же контракт, что требует schema sync при генерации join-таблицы (#90).
+  const ownerPk = m2mPrimaryKey(ownerMeta, 'owner');
+  const inversePk = m2mPrimaryKey(inverseMeta, 'inverse');
+  const ownerColumnType = m2mPrimaryKeyType(ownerMeta, 'owner');
+
   const ownJoinTables = getYdbJoinTableMetadata(owner);
   const own = ownJoinTables.find(
     (jt) => jt.propertyKey === relation.propertyKey,
@@ -417,8 +434,12 @@ function resolveManyToManyJoinTable(
   if (own) {
     return {
       tableName: own.tableName,
-      ownerColumn: own.joinColumn ?? `${ownerMeta.tableName}_uuid`,
-      inverseColumn: own.inverseJoinColumn ?? `${inverseMeta.tableName}_uuid`,
+      ownerColumn:
+        own.joinColumn ?? defaultJoinColumnName(ownerMeta.tableName, ownerPk),
+      inverseColumn:
+        own.inverseJoinColumn ??
+        defaultJoinColumnName(inverseMeta.tableName, inversePk),
+      ownerColumnType,
       ownerEntity: owner,
       inverseEntity,
     };
@@ -435,8 +456,13 @@ function resolveManyToManyJoinTable(
     if (inv) {
       return {
         tableName: inv.tableName,
-        ownerColumn: inv.inverseJoinColumn ?? `${ownerMeta.tableName}_uuid`,
-        inverseColumn: inv.joinColumn ?? `${inverseMeta.tableName}_uuid`,
+        ownerColumn:
+          inv.inverseJoinColumn ??
+          defaultJoinColumnName(ownerMeta.tableName, ownerPk),
+        inverseColumn:
+          inv.joinColumn ??
+          defaultJoinColumnName(inverseMeta.tableName, inversePk),
+        ownerColumnType,
         ownerEntity: owner,
         inverseEntity,
       };
@@ -444,4 +470,40 @@ function resolveManyToManyJoinTable(
   }
 
   return undefined;
+}
+
+/** Единственный PK сущности; составной или отсутствующий — явная ошибка (#90). */
+function m2mPrimaryKey(
+  meta: YdbEntityMetadata,
+  side: 'owner' | 'inverse',
+): string {
+  if (!meta.primaryKeys?.length) {
+    throw new Error(
+      `Cannot resolve many-to-many ${side} side for entity ${meta.target.name}: ` +
+        `no primary key is declared`,
+    );
+  }
+  if (meta.primaryKeys.length > 1) {
+    throw new Error(
+      `Cannot resolve many-to-many relation for entity ${meta.target.name}: ` +
+        `composite primary keys (${meta.primaryKeys.join(', ')}) are not supported ` +
+        `in many-to-many relations. Declare a single-column @YdbPrimaryColumn.`,
+    );
+  }
+  return meta.primaryKeys[0];
+}
+
+function m2mPrimaryKeyType(
+  meta: YdbEntityMetadata,
+  side: 'owner' | 'inverse',
+): YdbPrimitive {
+  const pk = m2mPrimaryKey(meta, side);
+  const type = meta.schema[pk];
+  if (!type) {
+    throw new Error(
+      `Primary key column "${pk}" of entity ${meta.target.name} ` +
+        `is not declared via @YdbColumn`,
+    );
+  }
+  return type;
 }

--- a/src/relations/entity-relations.ts
+++ b/src/relations/entity-relations.ts
@@ -1,12 +1,8 @@
 import type { YdbBaseEntity } from '../entity/base-entity.js';
 import type { YdbEntityConstructor } from '../persistence/entity-persistence.js';
+import { getYdbEntityMetadata } from '../metadata/entity-metadata.js';
 import {
-  getYdbEntityMetadata,
-  type YdbEntityMetadata,
-} from '../metadata/entity-metadata.js';
-import {
-  defaultJoinColumnName,
-  getYdbJoinTableMetadata,
+  getManyToManyJoinTables,
   getYdbRelationsMetadata,
 } from '../decorators/relation.decorators.js';
 import type { QueryOptions } from '../core/query-options.js';
@@ -396,6 +392,11 @@ function getPrimaryKey(target: typeof YdbBaseEntity): string {
 /**
  * Находит метаданные join-таблицы для many-to-many,
  * ориентированные относительно запрашиваемой сущности (owner).
+ *
+ * Валидация и разрешение конфликтов выполняются тем же кодом, что и при
+ * генерации схемы: getManyToManyJoinTables для пары сущностей. Поэтому
+ * рантайм не может молча выбрать одно из расходящихся объявлений таблицы —
+ * он упадёт с той же ошибкой конфликта, что и schema sync/migrations (#139).
  */
 interface ResolvedJoinTable {
   tableName: string;
@@ -420,90 +421,41 @@ function resolveManyToManyJoinTable(
   const inverseMeta = getYdbEntityMetadata(inverseEntity);
   if (!ownerMeta || !inverseMeta) return undefined;
 
-  // Рантайм-модель many-to-many поддерживает только одно-колоночные PK —
-  // тот же контракт, что требует schema sync при генерации join-таблицы (#90).
-  const ownerPk = m2mPrimaryKey(ownerMeta, 'owner');
-  const inversePk = m2mPrimaryKey(inverseMeta, 'inverse');
-  const ownerColumnType = m2mPrimaryKeyType(ownerMeta, 'owner');
+  // Все объявления join-таблиц, видимые для пары (владелец, inverse):
+  // здесь же проверяются PK и конфликты объявлений одного имени (#90/#139).
+  const definitions = getManyToManyJoinTables([owner, inverseEntity]);
 
-  const ownJoinTables = getYdbJoinTableMetadata(owner);
-  const own = ownJoinTables.find(
-    (jt) => jt.propertyKey === relation.propertyKey,
+  // Декларация на самом владельце для этой связи.
+  const own = definitions.find(
+    (d) => d.ownerEntity === owner && d.ownerProperty === relation.propertyKey,
   );
-
   if (own) {
     return {
       tableName: own.tableName,
-      ownerColumn:
-        own.joinColumn ?? defaultJoinColumnName(ownerMeta.tableName, ownerPk),
-      inverseColumn:
-        own.inverseJoinColumn ??
-        defaultJoinColumnName(inverseMeta.tableName, inversePk),
-      ownerColumnType,
+      ownerColumn: own.joinColumn,
+      inverseColumn: own.inverseJoinColumn,
+      ownerColumnType: own.joinColumnType as YdbPrimitive,
       ownerEntity: owner,
       inverseEntity,
     };
   }
 
-  const inverseRelations = getYdbRelationsMetadata(inverseEntity).filter(
-    (r) => r.type === 'many-to-many' && r.target() === owner,
+  // Зеркальная декларация на обратной стороне: колонки разворачиваются —
+  // joinColumn объявления принадлежит inverse-сущности, inverseJoinColumn — владельцу.
+  const inverseOwned = definitions.find(
+    (d) => d.ownerEntity === inverseEntity && d.inverseEntity === owner,
   );
-  for (const invRel of inverseRelations) {
-    const invJoinTables = getYdbJoinTableMetadata(inverseEntity);
-    const inv = invJoinTables.find(
-      (jt) => jt.propertyKey === invRel.propertyKey,
-    );
-    if (inv) {
-      return {
-        tableName: inv.tableName,
-        ownerColumn:
-          inv.inverseJoinColumn ??
-          defaultJoinColumnName(ownerMeta.tableName, ownerPk),
-        inverseColumn:
-          inv.joinColumn ??
-          defaultJoinColumnName(inverseMeta.tableName, inversePk),
-        ownerColumnType,
-        ownerEntity: owner,
-        inverseEntity,
-      };
-    }
+  if (inverseOwned) {
+    return {
+      tableName: inverseOwned.tableName,
+      ownerColumn: inverseOwned.inverseJoinColumn,
+      inverseColumn: inverseOwned.joinColumn,
+      // Тип owner-колонки = тип PK владельца = тип её колонки в объявлении.
+      ownerColumnType: inverseOwned.inverseJoinColumnType as YdbPrimitive,
+      ownerEntity: owner,
+      inverseEntity,
+    };
   }
 
   return undefined;
-}
-
-/** Единственный PK сущности; составной или отсутствующий — явная ошибка (#90). */
-function m2mPrimaryKey(
-  meta: YdbEntityMetadata,
-  side: 'owner' | 'inverse',
-): string {
-  if (!meta.primaryKeys?.length) {
-    throw new Error(
-      `Cannot resolve many-to-many ${side} side for entity ${meta.target.name}: ` +
-        `no primary key is declared`,
-    );
-  }
-  if (meta.primaryKeys.length > 1) {
-    throw new Error(
-      `Cannot resolve many-to-many relation for entity ${meta.target.name}: ` +
-        `composite primary keys (${meta.primaryKeys.join(', ')}) are not supported ` +
-        `in many-to-many relations. Declare a single-column @YdbPrimaryColumn.`,
-    );
-  }
-  return meta.primaryKeys[0];
-}
-
-function m2mPrimaryKeyType(
-  meta: YdbEntityMetadata,
-  side: 'owner' | 'inverse',
-): YdbPrimitive {
-  const pk = m2mPrimaryKey(meta, side);
-  const type = meta.schema[pk];
-  if (!type) {
-    throw new Error(
-      `Primary key column "${pk}" of entity ${meta.target.name} ` +
-        `is not declared via @YdbColumn`,
-    );
-  }
-  return type;
 }

--- a/src/relations/entity-relations.ts
+++ b/src/relations/entity-relations.ts
@@ -2,6 +2,7 @@ import type { YdbBaseEntity } from '../entity/base-entity.js';
 import type { YdbEntityConstructor } from '../persistence/entity-persistence.js';
 import { getYdbEntityMetadata } from '../metadata/entity-metadata.js';
 import {
+  assertNoForeignJoinTableConflicts,
   getManyToManyJoinTables,
   getYdbRelationsMetadata,
 } from '../decorators/relation.decorators.js';
@@ -299,20 +300,23 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
       } else if (rel.type === 'many-to-many') {
         const pkField = getPrimaryKey(constructor);
 
+        // Резолв зависит только от метаданных класса — один раз на связь,
+        // а не на каждый элемент (внутри проверяются конфликты объявлений).
+        const joinTable = resolveManyToManyJoinTable(constructor, rel);
+        if (!joinTable) {
+          throw new Error(
+            `Cannot load many-to-many relation "${name}": ` +
+              `join table is not defined on ${constructor.name}. ` +
+              `Mark the owning side with @JoinTable.`,
+          );
+        }
+
         for (const item of items) {
           const pkValue = (item as any)[pkField];
           if (pkValue === undefined) {
             throw new Error(
               `Cannot load many-to-many relation "${name}": ` +
                 `primary key "${pkField}" is undefined on ${constructor.name}`,
-            );
-          }
-          const joinTable = resolveManyToManyJoinTable(constructor, rel);
-          if (!joinTable) {
-            throw new Error(
-              `Cannot load many-to-many relation "${name}": ` +
-                `join table is not defined on ${constructor.name}. ` +
-                `Mark the owning side with @JoinTable.`,
             );
           }
           const related = await this.loadManyToManyRelation(
@@ -430,6 +434,7 @@ function resolveManyToManyJoinTable(
     (d) => d.ownerEntity === owner && d.ownerProperty === relation.propertyKey,
   );
   if (own) {
+    assertNoForeignJoinTableConflicts(own);
     return {
       tableName: own.tableName,
       ownerColumn: own.joinColumn,
@@ -446,6 +451,7 @@ function resolveManyToManyJoinTable(
     (d) => d.ownerEntity === inverseEntity && d.inverseEntity === owner,
   );
   if (inverseOwned) {
+    assertNoForeignJoinTableConflicts(inverseOwned);
     return {
       tableName: inverseOwned.tableName,
       ownerColumn: inverseOwned.inverseJoinColumn,

--- a/src/schema/schema-sync.spec.ts
+++ b/src/schema/schema-sync.spec.ts
@@ -149,6 +149,90 @@ class TestPhotoEntity extends YdbBaseEntity {
   tags?: TestTagEntity[];
 }
 
+// #90: many-to-many с не-uuid PK (кастомные имена свойств)
+@YdbEntity('test_articles')
+class TestArticleEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  article_id: string;
+
+  @YdbColumn('Utf8')
+  title: string;
+
+  @ManyToMany(() => TestAuthorEntity, (author) => author.articles)
+  @JoinTable('test_article_author')
+  authors?: TestAuthorEntity[];
+}
+
+@YdbEntity('test_authors')
+class TestAuthorEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  author_id: string;
+
+  @YdbColumn('Utf8')
+  name: string;
+
+  @ManyToMany(() => TestArticleEntity, (article) => article.authors)
+  articles?: TestArticleEntity[];
+}
+
+// #90: разные PK-типы на сторонах связи (Int64 ↔ Utf8) + явные имена колонок
+@YdbEntity('test_orders')
+class TestOrderEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Int64')
+  order_id: bigint;
+
+  @YdbColumn('Utf8')
+  title: string;
+
+  @ManyToMany(() => TestSkuEntity, (sku) => sku.orders)
+  @JoinTable('test_order_sku', {
+    joinColumn: 'order_ref',
+    inverseJoinColumn: 'sku_code',
+  })
+  skus?: TestSkuEntity[];
+}
+
+@YdbEntity('test_skus')
+class TestSkuEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  sku: string;
+
+  @YdbColumn('Utf8')
+  label: string;
+
+  @ManyToMany(() => TestOrderEntity, (order) => order.skus)
+  orders?: TestOrderEntity[];
+}
+
+// #90: составной PK на стороне owner — явный отказ
+@YdbEntity('test_m2m_comp_users')
+class TestCompositeUserEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  tenant_id: string;
+
+  @YdbPrimaryColumn('Uuid')
+  user_uuid: string;
+
+  @YdbColumn('Utf8')
+  name: string;
+
+  @ManyToMany(() => TestCompositeRoleEntity, (role) => role.users)
+  @JoinTable('test_composite_user_role')
+  roles?: TestCompositeRoleEntity[];
+}
+
+@YdbEntity('test_m2m_comp_roles')
+class TestCompositeRoleEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  role_uuid: string;
+
+  @YdbColumn('Utf8')
+  name: string;
+
+  @ManyToMany(() => TestCompositeUserEntity, (user) => user.roles)
+  users?: TestCompositeUserEntity[];
+}
+
 const meta = (entity: new (...args: any[]) => any) => {
   const m = getYdbEntityMetadata(entity);
   if (!m) throw new Error('no metadata');
@@ -218,6 +302,97 @@ describe('buildExpectedJoinTableSchema', () => {
       test_tags_uuid: 'Uuid',
     });
     expect(schema.primaryKey).toEqual(['test_photos_uuid', 'test_tags_uuid']);
+  });
+
+  it('derives column names from actual PK property names, not {table}_uuid (#90)', () => {
+    const joinTables = getManyToManyJoinTables([
+      TestArticleEntity,
+      TestAuthorEntity,
+    ]);
+    expect(joinTables).toHaveLength(1);
+
+    const [jt] = joinTables;
+    // PK называются article_id/author_id — дефолтные имена выводятся из них
+    expect(jt.joinColumn).toBe('test_articles_article_id');
+    expect(jt.inverseJoinColumn).toBe('test_authors_author_id');
+
+    const schema = buildExpectedJoinTableSchema(jt);
+    expect(schema.columns).toEqual({
+      test_articles_article_id: 'Uuid',
+      test_authors_author_id: 'Uuid',
+    });
+    expect(schema.primaryKey).toEqual([
+      'test_articles_article_id',
+      'test_authors_author_id',
+    ]);
+  });
+
+  it('derives non-uuid PK types (Int64 owner, Utf8 inverse) and keeps explicit column names (#90)', () => {
+    const joinTables = getManyToManyJoinTables([
+      TestOrderEntity,
+      TestSkuEntity,
+    ]);
+    expect(joinTables).toHaveLength(1);
+
+    const [jt] = joinTables;
+    expect(jt.joinColumn).toBe('order_ref');
+    expect(jt.inverseJoinColumn).toBe('sku_code');
+    expect(jt.joinColumnType).toBe('Int64');
+    expect(jt.inverseJoinColumnType).toBe('Utf8');
+
+    const schema = buildExpectedJoinTableSchema(jt);
+    expect(schema.columns).toEqual({
+      order_ref: 'Int64',
+      sku_code: 'Utf8',
+    });
+    expect(schema.primaryKey).toEqual(['order_ref', 'sku_code']);
+  });
+
+  it('derives types from entity metadata when join-table struct carries none (#90)', () => {
+    const [jt] = getManyToManyJoinTables([TestOrderEntity, TestSkuEntity]);
+    const bare = {
+      ...jt,
+      joinColumnType: undefined,
+      inverseJoinColumnType: undefined,
+    };
+    const schema = buildExpectedJoinTableSchema(bare);
+
+    expect(schema.columns).toEqual({ order_ref: 'Int64', sku_code: 'Utf8' });
+  });
+
+  it('rejects composite primary keys with a clear error instead of a broken schema (#90)', () => {
+    expect(() =>
+      getManyToManyJoinTables([
+        TestCompositeUserEntity,
+        TestCompositeRoleEntity,
+      ]),
+    ).toThrow(/composite primary keys.*not supported in.*many-to-many/s);
+  });
+});
+
+describe('buildExpectedJoinTableSchema DDL compatibility (#90)', () => {
+  it('generates CREATE TABLE matching the columns the relations code reads', () => {
+    const schemas = buildExpectedSchemas([TestOrderEntity, TestSkuEntity]);
+    const jt = schemas.find((s) => s.tableName === 'test_order_sku');
+    expect(jt).toBeDefined();
+
+    const yql = generateCreateTableYql(jt!);
+    expect(yql).toBe(
+      'CREATE TABLE `test_order_sku` (\n' +
+        '  `order_ref` Int64,\n' +
+        '  `sku_code` Utf8,\n' +
+        '  PRIMARY KEY (`order_ref`, `sku_code`)\n' +
+        ')',
+    );
+  });
+
+  it('keeps default uuid-based names for uuid-PK entities (backward compatibility)', () => {
+    const schemas = buildExpectedSchemas([TestPhotoEntity, TestTagEntity]);
+    const jt = schemas.find((s) => s.tableName === 'test_photo_tag');
+    expect(jt?.columns).toEqual({
+      test_photos_uuid: 'Uuid',
+      test_tags_uuid: 'Uuid',
+    });
   });
 });
 

--- a/src/schema/schema-sync.spec.ts
+++ b/src/schema/schema-sync.spec.ts
@@ -35,6 +35,7 @@ import {
 } from './schema-sync.js';
 import {
   getManyToManyJoinTables,
+  joinTableDefinitionsEquivalent,
   ManyToMany,
   JoinTable,
 } from '../decorators/relation.decorators.js';
@@ -233,6 +234,92 @@ class TestCompositeRoleEntity extends YdbBaseEntity {
   users?: TestCompositeUserEntity[];
 }
 
+// #90/#139: зеркальные декларации одной join-таблицы на обеих сторонах —
+// физически эквивалентны, дедуплицируются безопасно
+@YdbEntity('test_sym_lefts')
+class TestSymLeftEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Int64')
+  left_id: bigint;
+
+  @YdbColumn('Utf8')
+  title: string;
+
+  @ManyToMany(() => TestSymRightEntity, (right) => right.lefts)
+  @JoinTable('test_sym_join', {
+    joinColumn: 'left_ref',
+    inverseJoinColumn: 'right_code',
+  })
+  rights?: TestSymRightEntity[];
+}
+
+@YdbEntity('test_sym_rights')
+class TestSymRightEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  right_code: string;
+
+  @YdbColumn('Utf8')
+  label: string;
+
+  @ManyToMany(() => TestSymLeftEntity, (left) => left.rights)
+  @JoinTable('test_sym_join', {
+    joinColumn: 'right_code',
+    inverseJoinColumn: 'left_ref',
+  })
+  lefts?: TestSymLeftEntity[];
+}
+
+// #139: конфликтующие объявления одного имени таблицы
+// (разные пары сущностей с разными PK-типами)
+@YdbEntity('test_dup_orders')
+class TestDupOrderEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Int64')
+  order_id: bigint;
+
+  @YdbColumn('Utf8')
+  title: string;
+
+  @ManyToMany(() => TestDupItemEntity, (item) => item.orders)
+  @JoinTable('test_duplicated_join')
+  items?: TestDupItemEntity[];
+}
+
+@YdbEntity('test_dup_items')
+class TestDupItemEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  item_uuid: string;
+
+  @YdbColumn('Utf8')
+  label: string;
+
+  @ManyToMany(() => TestDupOrderEntity, (order) => order.items)
+  orders?: TestDupOrderEntity[];
+}
+
+@YdbEntity('test_dup_users')
+class TestDupUserEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Int64')
+  user_id: bigint;
+
+  @YdbColumn('Utf8')
+  name: string;
+
+  @ManyToMany(() => TestDupGroupEntity, (group) => group.users)
+  @JoinTable('test_duplicated_join')
+  groups?: TestDupGroupEntity[];
+}
+
+@YdbEntity('test_dup_groups')
+class TestDupGroupEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Int64')
+  group_id: bigint;
+
+  @YdbColumn('Utf8')
+  name: string;
+
+  @ManyToMany(() => TestDupUserEntity, (user) => user.groups)
+  users?: TestDupUserEntity[];
+}
+
 const meta = (entity: new (...args: any[]) => any) => {
   const m = getYdbEntityMetadata(entity);
   if (!m) throw new Error('no metadata');
@@ -367,6 +454,80 @@ describe('buildExpectedJoinTableSchema', () => {
         TestCompositeRoleEntity,
       ]),
     ).toThrow(/composite primary keys.*not supported in.*many-to-many/s);
+  });
+});
+
+describe('duplicate join-table declarations (#139)', () => {
+  it('deduplicates the same entity class passed twice', () => {
+    const joinTables = getManyToManyJoinTables([
+      TestPhotoEntity,
+      TestPhotoEntity,
+      TestTagEntity,
+    ]);
+    expect(joinTables).toHaveLength(1);
+    expect(joinTables[0].tableName).toBe('test_photo_tag');
+  });
+
+  it('deduplicates mirrored declarations on both sides of a relation', () => {
+    const joinTables = getManyToManyJoinTables([
+      TestSymLeftEntity,
+      TestSymRightEntity,
+    ]);
+    // Оба объявления описывают одну физическую таблицу — остаётся одно
+    expect(joinTables).toHaveLength(1);
+
+    const jt = joinTables[0];
+    expect(jt.tableName).toBe('test_sym_join');
+    // Первое объявление (от left): колонка left → left_ref (Int64)
+    expect(jt.joinColumn).toBe('left_ref');
+    expect(jt.joinColumnType).toBe('Int64');
+    expect(jt.inverseJoinColumn).toBe('right_code');
+    expect(jt.inverseJoinColumnType).toBe('Utf8');
+
+    const schema = buildExpectedJoinTableSchema(jt);
+    expect(schema.columns).toEqual({ left_ref: 'Int64', right_code: 'Utf8' });
+  });
+
+  it('throws listing all definitions when declarations conflict', () => {
+    let error: Error | undefined;
+    try {
+      getManyToManyJoinTables([
+        TestDupOrderEntity,
+        TestDupItemEntity,
+        TestDupUserEntity,
+        TestDupGroupEntity,
+      ]);
+    } catch (e) {
+      error = e as Error;
+    }
+
+    expect(error).toBeDefined();
+    expect(error!.message).toContain(
+      'Conflicting definitions for many-to-many join table "test_duplicated_join"',
+    );
+    // В ошибке перечислены оба определения с сущностями и колонками/типами
+    expect(error!.message).toContain('TestDupOrderEntity.items');
+    expect(error!.message).toContain(
+      'test_dup_orders_order_id:Int64, test_dup_items_item_uuid:Uuid',
+    );
+    expect(error!.message).toContain('TestDupUserEntity.groups');
+    expect(error!.message).toContain(
+      'test_dup_users_user_id:Int64, test_dup_groups_group_id:Int64',
+    );
+  });
+
+  it('treats mirrored declarations with different column names as conflicting', () => {
+    // test_sym_join объявлен зеркально корректно; проверим, что подмена
+    // имени колонки на одной стороне даёт конфликт
+    const [fromLeft] = getManyToManyJoinTables([TestSymLeftEntity]);
+    const [fromRight] = getManyToManyJoinTables([TestSymRightEntity]);
+
+    const skewedRight = {
+      ...fromRight,
+      joinColumn: 'skewed_column',
+    };
+    expect(joinTableDefinitionsEquivalent(fromLeft, skewedRight)).toBe(false);
+    expect(joinTableDefinitionsEquivalent(fromLeft, fromRight)).toBe(true);
   });
 });
 

--- a/src/schema/schema-sync.ts
+++ b/src/schema/schema-sync.ts
@@ -262,19 +262,73 @@ export function buildExpectedTableSchema(
   };
 }
 
-/** Ожидаемая схема join-таблицы many-to-many. */
+/**
+ * Ожидаемая схема join-таблицы many-to-many.
+ *
+ * Типы колонок выводятся из фактических PK-метаданных обеих сущностей (#90):
+ * getManyToManyJoinTables заполняет joinColumnType/inverseJoinColumnType;
+ * для структур, собранных вручную без типов, они выводятся из
+ * ownerEntity/inverseEntity здесь — молчаливое предположение Uuid запрещено.
+ */
 export function buildExpectedJoinTableSchema(
   joinTable: ManyToManyJoinTable,
 ): ExpectedTableSchema {
+  const joinColumnType =
+    joinTable.joinColumnType ??
+    joinTablePkColumnType(joinTable.ownerEntity, 'owner');
+  const inverseJoinColumnType =
+    joinTable.inverseJoinColumnType ??
+    joinTablePkColumnType(joinTable.inverseEntity, 'inverse');
+
   return {
     tableName: joinTable.tableName,
     columns: {
-      [joinTable.joinColumn]: 'Uuid',
-      [joinTable.inverseJoinColumn]: 'Uuid',
+      [joinTable.joinColumn]: joinColumnType,
+      [joinTable.inverseJoinColumn]: inverseJoinColumnType,
     },
     primaryKey: [joinTable.joinColumn, joinTable.inverseJoinColumn],
     indexes: [],
   };
+}
+
+/**
+ * Тип PK-колонки сущности для join-таблицы (#90).
+ * Ровно один PK, объявленный через @YdbPrimaryColumn; иначе — явная ошибка,
+ * чтобы sync/CLI не сгенерировали схему, несовместимую с relations-кодом.
+ */
+function joinTablePkColumnType(
+  entity: ManyToManyJoinTable['ownerEntity'],
+  side: 'owner' | 'inverse',
+): YdbPrimitive {
+  const meta = getYdbEntityMetadata(entity);
+  if (!meta) {
+    throw new Error(
+      `Cannot derive ${side} join-table column type: ` +
+        `${entity.name} is not decorated with @YdbEntity`,
+    );
+  }
+  if (meta.primaryKeys.length === 0) {
+    throw new Error(
+      `Cannot derive ${side} join-table column type for entity ${entity.name}: ` +
+        `no primary key is declared. Mark at least one column with @YdbPrimaryColumn.`,
+    );
+  }
+  if (meta.primaryKeys.length > 1) {
+    throw new Error(
+      `Cannot derive ${side} join-table column type for entity ${entity.name}: ` +
+        `composite primary keys (${meta.primaryKeys.join(', ')}) are not supported ` +
+        `in many-to-many relations.`,
+    );
+  }
+  const pk = meta.primaryKeys[0];
+  const type = meta.schema[pk];
+  if (!type) {
+    throw new Error(
+      `Cannot derive ${side} join-table column type for entity ${entity.name}: ` +
+        `primary key column "${pk}" is not declared via @YdbColumn.`,
+    );
+  }
+  return type;
 }
 
 /**

--- a/test/helpers/mock-executor.ts
+++ b/test/helpers/mock-executor.ts
@@ -16,13 +16,26 @@ export interface MockExecutor {
  * Мок YdbExecutor: записывает SQL и параметры, резолвится заданными строками.
  * transaction().execute(fn) вызывает fn с тем же моком в роли trx.
  * Сети нет — используется в тестах NestJS-интеграции через overrideProvider.
+ *
+ * options.sequential — каждый запрос получает СВОЙ набор result sets
+ * (rows[0] — первый запрос, rows[1] — второй и т.д.; последний элемент
+ * повторяется для лишних запросов). По умолчанию все запросы получают
+ * один и тот же массив result sets.
  */
-export function createMockExecutor(rows: any[][] = [[]]): MockExecutor {
+export function createMockExecutor(
+  rows: any[][] = [[]],
+  options?: { sequential?: boolean },
+): MockExecutor {
   const queries: RecordedQuery[] = [];
+  let callIndex = 0;
 
   const executor: any = jest.fn((strings: TemplateStringsArray) => {
     const recorded: RecordedQuery = { sql: strings[0], params: {} };
     queries.push(recorded);
+
+    const resultRows = options?.sequential
+      ? (rows[Math.min(callIndex++, rows.length - 1)] ?? [])
+      : rows;
 
     const query: any = {
       parameter(name: string, value: unknown) {
@@ -39,7 +52,7 @@ export function createMockExecutor(rows: any[][] = [[]]): MockExecutor {
         return query;
       },
       then(onFulfilled: any, onRejected: any) {
-        return Promise.resolve(rows).then(onFulfilled, onRejected);
+        return Promise.resolve(resultRows).then(onFulfilled, onRejected);
       },
     };
     return query;

--- a/test/many-to-many-foreign-conflict.spec.ts
+++ b/test/many-to-many-foreign-conflict.spec.ts
@@ -1,0 +1,147 @@
+import 'reflect-metadata';
+import {
+  YdbEntity,
+  YdbColumn,
+  YdbPrimaryColumn,
+  YdbBaseEntity,
+  ManyToMany,
+  JoinTable,
+  EagerLoad,
+} from '../src/index.js';
+import { getManyToManyJoinTables } from '../src/decorators/relation.decorators.js';
+import { buildExpectedSchemas } from '../src/schema/schema-sync.js';
+import { createMockExecutor } from './helpers/mock-executor.js';
+
+/**
+ * Глобальная согласованность рантайма и схемы (#139): конфликт объявлений
+ * одного имени join-таблицы, не видимый внутри пары сущностей (объявление
+ * в другом месте модели), должен одинаково отвергаться schema sync/verify/
+ * миграциями и рантайм-чтением relations.
+ *
+ * Реестр @YdbEntity изолирован на файл теста, поэтому «вторгающаяся»
+ * сущность живёт здесь отдельно от остальных спеков.
+ */
+
+// Валидная пара: зеркальные эквивалентные декларации одной таблицы
+@YdbEntity('fp_parents')
+@EagerLoad(['children'])
+class FpParentEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Int64')
+  parent_id: bigint;
+
+  @YdbColumn('Utf8')
+  name: string;
+
+  @ManyToMany(() => FpChildEntity, (child) => child.parents)
+  @JoinTable('fp_join', {
+    joinColumn: 'parent_ref',
+    inverseJoinColumn: 'child_key',
+  })
+  children?: FpChildEntity[];
+}
+
+@YdbEntity('fp_children')
+class FpChildEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  child_key: string;
+
+  @YdbColumn('Utf8')
+  label: string;
+
+  @ManyToMany(() => FpParentEntity, (parent) => parent.children)
+  @JoinTable('fp_join', {
+    joinColumn: 'child_key',
+    inverseJoinColumn: 'parent_ref',
+  })
+  parents?: FpParentEntity[];
+}
+
+// Вторгающаяся пара: то же имя таблицы, другое физическое описание
+@YdbEntity('fp_intruders')
+class FpIntruderEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Int64')
+  intruder_id: bigint;
+
+  @YdbColumn('Utf8')
+  tag: string;
+
+  @ManyToMany(() => FpOtherEntity, (other) => other.intruders)
+  @JoinTable('fp_join')
+  others?: FpOtherEntity[];
+}
+
+@YdbEntity('fp_others')
+class FpOtherEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  other_code: string;
+
+  @YdbColumn('Utf8')
+  label: string;
+
+  @ManyToMany(() => FpIntruderEntity, (intruder) => intruder.others)
+  intruders?: FpIntruderEntity[];
+}
+
+describe('foreign conflicting join-table declarations (#139)', () => {
+  afterEach(() => {
+    for (const Entity of [
+      FpParentEntity,
+      FpChildEntity,
+      FpIntruderEntity,
+      FpOtherEntity,
+    ]) {
+      Entity.setExecutor(undefined as any);
+    }
+  });
+
+  it('schema generation accepts the pair alone and rejects it with the intruder', () => {
+    const alone = getManyToManyJoinTables([FpParentEntity, FpChildEntity]);
+    expect(alone).toHaveLength(1);
+    expect(alone[0].tableName).toBe('fp_join');
+    expect(alone[0].joinColumn).toBe('parent_ref');
+
+    expect(() =>
+      getManyToManyJoinTables([
+        FpParentEntity,
+        FpChildEntity,
+        FpIntruderEntity,
+        FpOtherEntity,
+      ]),
+    ).toThrow(/Conflicting definitions for many-to-many join table "fp_join"/);
+  });
+
+  it('buildExpectedSchemas (sync/verify/migrations) fails on the same set', () => {
+    expect(() =>
+      buildExpectedSchemas([
+        FpParentEntity,
+        FpChildEntity,
+        FpIntruderEntity,
+        FpOtherEntity,
+      ]),
+    ).toThrow(/Conflicting definitions for many-to-many join table "fp_join"/);
+  });
+
+  it('explicit loadRelations fails identically at runtime', async () => {
+    const mock = createMockExecutor([[]]);
+    FpParentEntity.setExecutor(mock.executor);
+
+    const parent = new FpParentEntity();
+    parent.parent_id = 1n;
+
+    await expect(parent.loadRelations(['children'])).rejects.toThrow(
+      /Conflicting definitions for many-to-many join table "fp_join"[\s\S]*FpIntruderEntity\.others/,
+    );
+    expect(mock.queries).toHaveLength(0);
+  });
+
+  it('eager loading fails identically at runtime', async () => {
+    const mock = createMockExecutor([[[{ parent_id: 1n, name: 'p' }]]], {
+      sequential: true,
+    });
+    FpParentEntity.setExecutor(mock.executor);
+
+    await expect(FpParentEntity.findAll()).rejects.toThrow(
+      /Conflicting definitions for many-to-many join table "fp_join"[\s\S]*FpIntruderEntity\.others/,
+    );
+  });
+});

--- a/test/many-to-many-pk-types.spec.ts
+++ b/test/many-to-many-pk-types.spec.ts
@@ -170,6 +170,7 @@ class SymChildEntity extends YdbBaseEntity {
 
 // #139: расходящиеся объявления одного имени join-таблицы
 @YdbEntity('rt_conflict_lefts')
+@EagerLoad(['rights'])
 class ConflictLeftEntity extends YdbBaseEntity {
   @YdbPrimaryColumn('Int64')
   left_id: bigint;
@@ -417,6 +418,19 @@ describe('many-to-many join tables derived from actual PKs (#90)', () => {
       /Conflicting definitions for many-to-many join table "rt_conflict_join"/,
     );
     await expect(left.loadRelations(['rights'])).rejects.toThrow(
+      /ConflictLeftEntity\.rights[\s\S]*ConflictRightEntity\.lefts/,
+    );
+  });
+
+  it('eager loading fails on the same conflict as schema generation (#139)', async () => {
+    // Строка владельца нужна, чтобы eager-загрузка дошла до резолва join-таблицы
+    const mock = setup([[[{ left_id: 1n, name: 'L' }]]]);
+    ConflictLeftEntity.setExecutor(mock.executor);
+
+    await expect(ConflictLeftEntity.findAll()).rejects.toThrow(
+      /Conflicting definitions for many-to-many join table "rt_conflict_join"/,
+    );
+    await expect(ConflictLeftEntity.findAll()).rejects.toThrow(
       /ConflictLeftEntity\.rights[\s\S]*ConflictRightEntity\.lefts/,
     );
   });

--- a/test/many-to-many-pk-types.spec.ts
+++ b/test/many-to-many-pk-types.spec.ts
@@ -1,0 +1,297 @@
+import 'reflect-metadata';
+import { Int64, Uuid } from '@ydbjs/value/primitive';
+import {
+  YdbEntity,
+  YdbColumn,
+  YdbPrimaryColumn,
+  YdbBaseEntity,
+  ManyToMany,
+  JoinTable,
+  EagerLoad,
+} from '../src/index.js';
+import { getManyToManyJoinTables } from '../src/decorators/relation.decorators.js';
+import { buildExpectedJoinTableSchema } from '../src/schema/schema-sync.js';
+import { createMockExecutor } from './helpers/mock-executor.js';
+
+/**
+ * Регрессионные тесты #90: имена и типы колонок join-таблицы many-to-many
+ * выводятся из фактических PK обеих сущностей, и сгенерированная схема
+ * совпадает с тем, что relations-код читает из join-таблицы.
+ */
+
+// Int64 PK (owner) <-> Utf8 PK (inverse), явные имена колонок
+@YdbEntity('m2m_orders')
+@EagerLoad(['skus'])
+class OrderEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Int64')
+  order_id: bigint;
+
+  @YdbColumn('Utf8')
+  title: string;
+
+  @ManyToMany(() => SkuEntity, (sku) => sku.orders)
+  @JoinTable('order_skus', {
+    joinColumn: 'order_ref',
+    inverseJoinColumn: 'sku_code',
+  })
+  skus?: SkuEntity[];
+}
+
+@YdbEntity('m2m_skus')
+class SkuEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  sku: string;
+
+  @YdbColumn('Utf8')
+  label: string;
+
+  @ManyToMany(() => OrderEntity, (order) => order.skus)
+  orders?: OrderEntity[];
+}
+
+// Uuid PK с кастомными именами свойств: дефолтные имена колонок выводятся
+// из PK ({table}_{pk}), а не из жёсткого {table}_uuid
+@YdbEntity('m2m_articles')
+class ArticleEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  article_id: string;
+
+  @YdbColumn('Utf8')
+  title: string;
+
+  @ManyToMany(() => AuthorEntity, (author) => author.articles)
+  authors?: AuthorEntity[];
+}
+
+@YdbEntity('m2m_authors')
+class AuthorEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  author_id: string;
+
+  @YdbColumn('Utf8')
+  name: string;
+
+  @ManyToMany(() => ArticleEntity, (article) => article.authors)
+  @JoinTable('article_author')
+  articles?: ArticleEntity[];
+}
+
+// JoinTable объявлена на inverse-стороне: owner читает через её метаданные
+@YdbEntity('m2m_students')
+class StudentEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Int64')
+  student_id: bigint;
+
+  @YdbColumn('Utf8')
+  name: string;
+
+  @ManyToMany(() => CourseEntity, (course) => course.students)
+  courses?: CourseEntity[];
+}
+
+@YdbEntity('m2m_courses')
+class CourseEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  code: string;
+
+  @YdbColumn('Utf8')
+  title: string;
+
+  @ManyToMany(() => StudentEntity, (student) => student.courses)
+  @JoinTable('course_enrollment', {
+    joinColumn: 'course_code',
+    inverseJoinColumn: 'student_ref',
+  })
+  students?: StudentEntity[];
+}
+
+// Составной PK на стороне owner — рантайм обязан отказать явно (#90)
+@YdbEntity('m2m_comp_photos')
+@EagerLoad(['tags'])
+class CompositePhotoEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  tenant_id: string;
+
+  @YdbPrimaryColumn('Uuid')
+  photo_uuid: string;
+
+  @YdbColumn('Utf8')
+  title: string;
+
+  @ManyToMany(() => CompositeTagEntity, (tag) => tag.photos)
+  @JoinTable('composite_photo_tag')
+  tags?: CompositeTagEntity[];
+}
+
+@YdbEntity('m2m_comp_tags')
+class CompositeTagEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  tag_uuid: string;
+
+  @YdbColumn('Utf8')
+  name: string;
+
+  @ManyToMany(() => CompositePhotoEntity, (photo) => photo.tags)
+  photos?: CompositePhotoEntity[];
+}
+
+const orderRow = { order_id: 10n, title: 'o1' };
+const skuRows = [
+  { sku: 'a1', label: 'A' },
+  { sku: 'b2', label: 'B' },
+];
+const linkRows = [
+  { order_ref: 10n, sku_code: 'a1' },
+  { order_ref: 10n, sku_code: 'b2' },
+];
+
+describe('many-to-many join tables derived from actual PKs (#90)', () => {
+  let executors: Array<ReturnType<typeof createMockExecutor>> = [];
+
+  function setup(rows: any[][]) {
+    const mock = createMockExecutor(rows, { sequential: true });
+    executors.push(mock);
+    return mock;
+  }
+
+  afterEach(() => {
+    for (const Entity of [
+      OrderEntity,
+      SkuEntity,
+      ArticleEntity,
+      AuthorEntity,
+      StudentEntity,
+      CourseEntity,
+      CompositePhotoEntity,
+      CompositeTagEntity,
+    ]) {
+      Entity.setExecutor(undefined as any);
+    }
+    executors = [];
+  });
+
+  it('generated schema columns match what eager load reads (Int64/Utf8 PKs)', async () => {
+    const [jt] = getManyToManyJoinTables([OrderEntity, SkuEntity]);
+    const schema = buildExpectedJoinTableSchema(jt);
+
+    // Строки «вставлены» в сгенерированную схему: ключи — её колонки
+    expect(Object.keys(schema.columns).sort()).toEqual([
+      'order_ref',
+      'sku_code',
+    ]);
+    expect(Object.keys(linkRows[0]).sort()).toEqual(
+      Object.keys(schema.columns).sort(),
+    );
+
+    const mock = setup([[[orderRow]], [linkRows], [skuRows]]);
+    OrderEntity.setExecutor(mock.executor);
+
+    const order = await OrderEntity.find({ order_id: 10n });
+
+    // SELECT из join-таблицы использует ровно колонки сгенерированной схемы
+    expect(mock.queries[1].sql).toContain('FROM `order_skus`');
+    expect(mock.queries[1].sql).toContain(
+      'SELECT `order_ref`, `sku_code` FROM `order_skus`',
+    );
+    expect(mock.queries[1].sql).toContain('WHERE `order_ref` IN ($p0)');
+    // Параметр промаплен по типу PK владельца (Int64), а не Uuid
+    expect(mock.queries[1].params.p0).toBeInstanceOf(Int64);
+
+    expect(order?.skus?.map((s) => s.sku)).toEqual(['a1', 'b2']);
+  });
+
+  it('eager load groups related entities by non-uuid owner PK', async () => {
+    const mock = setup([
+      [[orderRow, { order_id: 20n, title: 'o2' }]],
+      [[...linkRows, { order_ref: 20n, sku_code: 'a1' }]],
+      [skuRows],
+    ]);
+    OrderEntity.setExecutor(mock.executor);
+
+    const orders = await OrderEntity.findAll();
+
+    const byOwner = new Map(orders.map((o) => [o.order_id, o]));
+    expect(byOwner.get(10n)?.skus?.map((s) => s.sku)).toEqual(['a1', 'b2']);
+    expect(byOwner.get(20n)?.skus?.map((s) => s.sku)).toEqual(['a1']);
+  });
+
+  it('loadRelations uses default column names derived from custom uuid PK names', async () => {
+    const articleRow = {
+      article_id: '11111111-2222-4333-8444-555555555555',
+      title: 'a1',
+    };
+    const authorRow = {
+      author_id: '99999999-8888-4777-8666-777777777777',
+      name: 'Ivan',
+    };
+    const link = [
+      {
+        m2m_articles_article_id: articleRow.article_id,
+        m2m_authors_author_id: authorRow.author_id,
+      },
+    ];
+
+    // loadRelations делает ровно два запроса: join-select, затем выборка target
+    const mock = setup([[link], [[authorRow]]]);
+    ArticleEntity.setExecutor(mock.executor);
+
+    const article = new ArticleEntity();
+    article.article_id = articleRow.article_id;
+    await article.loadRelations(['authors']);
+
+    expect(mock.queries[0].sql).toContain('FROM `article_author`');
+    expect(mock.queries[0].sql).toContain(
+      'SELECT `m2m_articles_article_id`, `m2m_authors_author_id` FROM `article_author`',
+    );
+    expect(mock.queries[0].params.p0).toBeInstanceOf(Uuid);
+    expect(article.authors?.[0]?.author_id).toBe(authorRow.author_id);
+  });
+
+  it('resolves join table declared on the inverse side with explicit names', async () => {
+    const courseRow = { code: 'cs101', title: 'CS' };
+    const link = [{ course_code: 'cs101', student_ref: 7n }];
+
+    const mock = setup([[link], [[courseRow]]]);
+    StudentEntity.setExecutor(mock.executor);
+
+    const student = new StudentEntity();
+    student.student_id = 7n;
+    await student.loadRelations(['courses']);
+
+    expect(mock.queries[0].sql).toContain('FROM `course_enrollment`');
+    expect(mock.queries[0].sql).toContain(
+      'SELECT `student_ref`, `course_code` FROM `course_enrollment`',
+    );
+    expect(mock.queries[0].sql).toContain('WHERE `student_ref` IN ($p0)');
+    expect(mock.queries[0].params.p0).toBeInstanceOf(Int64);
+    expect(student.courses?.[0]?.code).toBe('cs101');
+  });
+
+  it('rejects composite primary keys at runtime instead of reading a broken schema', async () => {
+    // Строка владельца нужна, чтобы eager-загрузка дошла до резолва join-таблицы
+    const mock = setup([
+      [
+        [
+          {
+            tenant_id: 't1',
+            photo_uuid: '11111111-2222-4333-8444-555555555555',
+            title: 'p1',
+          },
+        ],
+      ],
+    ]);
+    CompositePhotoEntity.setExecutor(mock.executor);
+
+    const photo = new CompositePhotoEntity();
+    photo.tenant_id = 't1';
+    photo.photo_uuid = '11111111-2222-4333-8444-555555555555';
+
+    await expect(photo.loadRelations(['tags'])).rejects.toThrow(
+      /composite primary keys.*not supported in.*many-to-many/s,
+    );
+
+    await expect(CompositePhotoEntity.findAll()).rejects.toThrow(
+      /composite primary keys.*not supported in.*many-to-many/s,
+    );
+  });
+});

--- a/test/many-to-many-pk-types.spec.ts
+++ b/test/many-to-many-pk-types.spec.ts
@@ -135,6 +135,72 @@ class CompositeTagEntity extends YdbBaseEntity {
   photos?: CompositePhotoEntity[];
 }
 
+// #139: зеркальные декларации одной таблицы на обеих сторонах — эквивалентны
+@YdbEntity('rt_sym_parents')
+class SymParentEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Int64')
+  parent_id: bigint;
+
+  @YdbColumn('Utf8')
+  name: string;
+
+  @ManyToMany(() => SymChildEntity, (child) => child.parents)
+  @JoinTable('rt_sym_join', {
+    joinColumn: 'parent_ref',
+    inverseJoinColumn: 'child_key',
+  })
+  children?: SymChildEntity[];
+}
+
+@YdbEntity('rt_sym_children')
+class SymChildEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  child_key: string;
+
+  @YdbColumn('Utf8')
+  label: string;
+
+  @ManyToMany(() => SymParentEntity, (parent) => parent.children)
+  @JoinTable('rt_sym_join', {
+    joinColumn: 'child_key',
+    inverseJoinColumn: 'parent_ref',
+  })
+  parents?: SymParentEntity[];
+}
+
+// #139: расходящиеся объявления одного имени join-таблицы
+@YdbEntity('rt_conflict_lefts')
+class ConflictLeftEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Int64')
+  left_id: bigint;
+
+  @YdbColumn('Utf8')
+  name: string;
+
+  @ManyToMany(() => ConflictRightEntity, (right) => right.lefts)
+  @JoinTable('rt_conflict_join', {
+    joinColumn: 'left_ref',
+    inverseJoinColumn: 'right_code',
+  })
+  rights?: ConflictRightEntity[];
+}
+
+@YdbEntity('rt_conflict_rights')
+class ConflictRightEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  right_code: string;
+
+  @YdbColumn('Utf8')
+  label: string;
+
+  @ManyToMany(() => ConflictLeftEntity, (left) => left.rights)
+  @JoinTable('rt_conflict_join', {
+    joinColumn: 'other_column',
+    inverseJoinColumn: 'another_column',
+  })
+  lefts?: ConflictLeftEntity[];
+}
+
 const orderRow = { order_id: 10n, title: 'o1' };
 const skuRows = [
   { sku: 'a1', label: 'A' },
@@ -164,6 +230,10 @@ describe('many-to-many join tables derived from actual PKs (#90)', () => {
       CourseEntity,
       CompositePhotoEntity,
       CompositeTagEntity,
+      SymParentEntity,
+      SymChildEntity,
+      ConflictLeftEntity,
+      ConflictRightEntity,
     ]) {
       Entity.setExecutor(undefined as any);
     }
@@ -292,6 +362,62 @@ describe('many-to-many join tables derived from actual PKs (#90)', () => {
 
     await expect(CompositePhotoEntity.findAll()).rejects.toThrow(
       /composite primary keys.*not supported in.*many-to-many/s,
+    );
+  });
+
+  it('resolves mirrored equivalent declarations from both sides (#139)', async () => {
+    const parentRow = { parent_id: 1n, name: 'p1' };
+    const childRows = [
+      { child_key: 'c1', label: 'C1' },
+      { child_key: 'c2', label: 'C2' },
+    ];
+    const linkFromParent = [{ parent_ref: 1n, child_key: 'c1' }];
+    const linkFromChild = [
+      { parent_ref: 1n, child_key: 'c1' },
+      { parent_ref: 2n, child_key: 'c1' },
+    ];
+
+    const mock = setup([
+      [linkFromParent],
+      [childRows],
+      [linkFromChild],
+      [[{ parent_id: 2n, name: 'p2' }, parentRow]],
+    ]);
+
+    SymParentEntity.setExecutor(mock.executor);
+    SymChildEntity.setExecutor(mock.executor);
+
+    // Владелец декларации (parent): колонки как объявлены
+    const parent = new SymParentEntity();
+    parent.parent_id = 1n;
+    await parent.loadRelations(['children']);
+    expect(mock.queries[0].sql).toContain(
+      'SELECT `parent_ref`, `child_key` FROM `rt_sym_join`',
+    );
+    expect(parent.children?.map((c) => c.child_key)).toEqual(['c1']);
+
+    // Зеркальная декларация на child: колонки разворачиваются
+    const child = new SymChildEntity();
+    child.child_key = 'c1';
+    await child.loadRelations(['parents']);
+    expect(mock.queries[2].sql).toContain(
+      'SELECT `child_key`, `parent_ref` FROM `rt_sym_join`',
+    );
+    expect(child.parents?.map((p) => String(p.parent_id))).toEqual(['1', '2']);
+  });
+
+  it('rejects conflicting join-table declarations at runtime with a clear error (#139)', async () => {
+    const mock = setup([[]]);
+    ConflictLeftEntity.setExecutor(mock.executor);
+
+    const left = new ConflictLeftEntity();
+    left.left_id = 1n;
+
+    await expect(left.loadRelations(['rights'])).rejects.toThrow(
+      /Conflicting definitions for many-to-many join table "rt_conflict_join"/,
+    );
+    await expect(left.loadRelations(['rights'])).rejects.toThrow(
+      /ConflictLeftEntity\.rights[\s\S]*ConflictRightEntity\.lefts/,
     );
   });
 });


### PR DESCRIPTION
## Проблема

`buildExpectedJoinTableSchema` всегда объявлял обе колонки join-таблицы как `Uuid`, а дефолтные имена были жёстко `{table}_uuid` — независимо от фактических PK владельца и inverse-сущности. Для сущностей с Int64/Utf8 ключами (или PK с другим именем свойства) schema sync создавал join-таблицу с неверными типами/именами: вставки падали в рантайме, а check выдавал неисправимый type-mismatch.

## Решение

**`src/decorators/relation.decorators.ts`**
- `ManyToManyJoinTable` дополнен опциональными `joinColumnType` / `inverseJoinColumnType` (публичный API обратно совместим).
- `getManyToManyJoinTables()` выводит типы колонок из фактического PK обеих сущностей (`meta.schema[pk]`) и заполняет новые поля; PK без объявленной колонки — явная ошибка.
- Дефолтное имя колонки теперь `{table}_{pkProperty}` (хелпер `defaultJoinColumnName`): для PK с именем `uuid` это прежние `{table}_uuid` — существующие связи не меняют имён; для остальных PK имя выводится из реального свойства.
- Составной PK на любой из сторон — явный отказ: рантайм-модель m2m связывает строки ровно по одному значению PK с каждой стороны, составной PK породил бы схему, не совпадающую с relations-кодом.

**`src/schema/schema-sync.ts`**
- `buildExpectedJoinTableSchema` использует типы из метаданных join-таблицы, а при их отсутствии выводит из `ownerEntity`/`inverseEntity` (для структур, собранных вручную) — молчаливое предположение Uuid исключено. CLI (`schema:verify`) и генератор миграций используют тот же путь.

**`src/relations/entity-relations.ts`**
- Резолв join-таблицы на чтении использует ту же формулу имён по умолчанию и строгий тип PK owner-сущности (раньше был тихий fallback `?? 'Uuid'`). Параметры `IN (...)` мапятся по фактическому типу PK (`Int64`/`Utf8`/…), поэтому чтение всегда совместимо со сгенерированной схемой.
- Composite PK на любой стороне — понятная ошибка вместо битого чтения.

## Тесты

Новые регрессионные тесты:
- UUID PK с кастомными именами свойств → дефолтные имена колонок `{table}_{pk}`, тип `Uuid`;
- Int64/Utf8 PK (+ разные типы на двух сторонах), в т.ч. явные имена колонок через `@JoinTable`;
- вывод типов из метаданных для структур без заполненных полей типов;
- составной PK — явная ошибка (и в построении схемы, и в рантайме: `loadRelations` + eager);
- DDL `CREATE TABLE` join-таблицы точно соответствует колонкам/PK;
- обратная совместимость: uuid-PK сущности сохраняют прежние имена `{table}_uuid`;
- рантайм-совместимость «вставка → чтение»: eager load / `loadRelations` читают строки, вставленные в сгенерированную схему (имена колонок и типы параметров совпадают покомпонентно), включая случай `@JoinTable` на inverse-стороне.

`test/helpers/mock-executor.ts`: добавлен обратно совместимый режим `sequential` — свой набор result sets на каждый запрос.

## Проверка

- `yarn test` — 45 suites / 693 tests passed
- `yarn build` — ok
- `yarn lint` — 0 errors

Closes #90