### PR TITLE
fix(module): DI-токены репозиториев привязаны к классу сущности, а не к имени (#94)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,7 @@ export {
   YdbRepository,
   YdbEntityManager,
   getRepositoryToken,
+  getActiveRecordInitToken,
   InjectRepository,
   getOrCreateRepository,
 } from './repository/index.js';

--- a/src/module/repository-factory.ts
+++ b/src/module/repository-factory.ts
@@ -12,6 +12,7 @@ import {
 } from '../encryption/ydb-encryption-provider.interface.js';
 import { YdbBaseEntity } from '../entity/base-entity.js';
 import { getEntityRuntime } from '../entity/entity-runtime.js';
+import { getActiveRecordInitToken } from '../repository/repository-token.js';
 import { v4 as uuidv4, v7 as uuidv7 } from 'uuid';
 import { validateEntityMetadata } from '../metadata/validate-entity.js';
 import { getOrCreateRepository } from '../repository/repository-resolver.js';
@@ -27,7 +28,7 @@ export function createActiveRecordEntityProvider(
   entityClass: typeof YdbBaseEntity,
 ): Provider {
   return {
-    provide: `${entityClass.name}_AR_INIT`,
+    provide: getActiveRecordInitToken(entityClass),
     useFactory: (
       db: YdbExecutor,
       opts: YdbModuleOptions,

--- a/src/module/ydb.module.ts
+++ b/src/module/ydb.module.ts
@@ -4,7 +4,10 @@ import { createActiveRecordEntityProvider } from './repository-factory.js';
 import { YdbModuleAsyncOptions } from '../core/interfaces.js';
 import { YdbBaseEntity } from '../entity/base-entity.js';
 import { getEntityRuntime } from '../entity/entity-runtime.js';
-import { getRepositoryToken } from '../repository/index.js';
+import {
+  getRepositoryToken,
+  getActiveRecordInitToken,
+} from '../repository/repository-token.js';
 
 @Module({})
 export class YdbModule {
@@ -33,7 +36,7 @@ export class YdbModule {
         }
         return repo;
       },
-      inject: [`${entityClass.name}_AR_INIT`],
+      inject: [getActiveRecordInitToken(entityClass as any)],
     }));
 
     return {

--- a/src/repository/index.ts
+++ b/src/repository/index.ts
@@ -1,4 +1,8 @@
 export { YdbRepository, type YdbEntityConstructor } from './ydb-repository.js';
 export { YdbEntityManager } from './ydb-entity-manager.js';
-export { getRepositoryToken, InjectRepository } from './repository-token.js';
+export {
+  getRepositoryToken,
+  getActiveRecordInitToken,
+  InjectRepository,
+} from './repository-token.js';
 export { getOrCreateRepository } from './repository-resolver.js';

--- a/src/repository/repository-token.spec.ts
+++ b/src/repository/repository-token.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from '@jest/globals';
+import { YdbBaseEntity, YdbEntity, YdbPrimaryColumn } from '../index.js';
+import {
+  getActiveRecordInitToken,
+  getRepositoryToken,
+} from './repository-token.js';
+
+let uniqueNameCounter = 0;
+
+/**
+ * Создаёт класс сущности с гарантированно уникальным именем, чтобы тесты
+ * не зависели от глобального состояния реестра токенов между собой.
+ */
+function makeNamedEntityClass(nameSuffix?: string): typeof YdbBaseEntity {
+  const name = `TokenSpec_${nameSuffix ?? ++uniqueNameCounter}`;
+  @YdbEntity(`token_spec_${name}`)
+  class Dynamic extends YdbBaseEntity {
+    @YdbPrimaryColumn('Uuid')
+    uuid!: string;
+  }
+  Object.defineProperty(Dynamic, 'name', { value: name });
+  return Dynamic;
+}
+
+describe('getRepositoryToken / getActiveRecordInitToken (issue #94)', () => {
+  it('один класс всегда даёт один и тот же токен (идемпотентность)', () => {
+    const Entity = makeNamedEntityClass();
+
+    for (let i = 0; i < 3; i++) {
+      const repoToken = getRepositoryToken(Entity as any);
+      const arToken = getActiveRecordInitToken(Entity as any);
+      expect(repoToken).toBe(getRepositoryToken(Entity as any));
+      expect(arToken).toBe(getActiveRecordInitToken(Entity as any));
+    }
+
+    // Исторический формат для первого класса с данным именем
+    expect(getRepositoryToken(Entity as any)).toBe(
+      `YDB_REPOSITORY_${Entity.name}`,
+    );
+    expect(getActiveRecordInitToken(Entity as any)).toBe(
+      `${Entity.name}_AR_INIT`,
+    );
+  });
+
+  it('одноимённые классы получают разные токены без перезаписи', () => {
+    const first = makeNamedEntityClass('Collision');
+    const second = makeNamedEntityClass('Collision');
+
+    expect(first).not.toBe(second);
+    expect(first.name).toBe(second.name);
+
+    const firstRepo = getRepositoryToken(first as any);
+    const secondRepo = getRepositoryToken(second as any);
+    expect(firstRepo).not.toBe(secondRepo);
+
+    const firstAr = getActiveRecordInitToken(first as any);
+    const secondAr = getActiveRecordInitToken(second as any);
+    expect(firstAr).not.toBe(secondAr);
+  });
+
+  it('порядок регистрации не влияет на стабильность токенов класса', () => {
+    const a1 = makeNamedEntityClass('Order');
+    const b1 = makeNamedEntityClass('Order');
+    const a2 = makeNamedEntityClass('Order');
+    const b2 = makeNamedEntityClass('Order');
+
+    // Токены не меняются после регистрации новых одноимённых классов
+    expect(getRepositoryToken(a1 as any)).toBe(getRepositoryToken(a1 as any));
+    expect(getRepositoryToken(a1 as any)).not.toBe(
+      getRepositoryToken(b1 as any),
+    );
+    expect(getRepositoryToken(b1 as any)).toBe(getRepositoryToken(b1 as any));
+    expect(getRepositoryToken(b2 as any)).not.toBe(
+      getRepositoryToken(a2 as any),
+    );
+
+    const tokens = new Set(
+      [a1, b1, a2, b2].map((e) => getRepositoryToken(e as any)),
+    );
+    expect(tokens.size).toBe(4);
+  });
+
+  it('AR_INIT-токен согласован между фабрикой провайдера и inject модуля', () => {
+    // Обе стороны обязаны строить токен одной функцией — иначе рассинхрон строк.
+    const Entity = makeNamedEntityClass();
+    const arToken = getActiveRecordInitToken(Entity as any);
+    expect(arToken).toContain('_AR_INIT');
+    expect(getActiveRecordInitToken(Entity as any)).toBe(arToken);
+  });
+
+  it('класс без имени получает валидный и уникальный токен', () => {
+    @YdbEntity('token_spec_anonymous')
+    class Anonymous extends YdbBaseEntity {
+      @YdbPrimaryColumn('Uuid')
+      uuid!: string;
+    }
+    Object.defineProperty(Anonymous, 'name', { value: '' });
+
+    const token = getRepositoryToken(Anonymous as any);
+    expect(typeof token).toBe('string');
+    expect(token.length).toBeGreaterThan('YDB_REPOSITORY_'.length);
+  });
+});

--- a/src/repository/repository-token.ts
+++ b/src/repository/repository-token.ts
@@ -1,8 +1,60 @@
 import { Inject } from '@nestjs/common';
 import type { YdbBaseEntity } from '../entity/base-entity.js';
-import type { YdbEntityConstructor } from './ydb-repository.js';
+import type { YdbEntityConstructor } from '../persistence/entity-persistence.js';
 
 const REPOSITORY_TOKEN_PREFIX = 'YDB_REPOSITORY_' as const;
+const AR_INIT_TOKEN_SUFFIX = '_AR_INIT' as const;
+
+/**
+ * DI-токены сущности: репозиторий и провайдер инициализации Active Record.
+ */
+interface EntityDiTokens {
+  repository: string;
+  arInit: string;
+}
+
+/**
+ * Реестр class → токены (issue #94).
+ *
+ * Токен исторически строится из имени класса, но привязывается к конкретному
+ * классу: одноимённые классы из разных файлов/пакетов получают разные токены
+ * (первый — в прежнем формате без суффикса, последующие — с суффиксом `#N`),
+ * поэтому провайдеры больше не перезаписывают друг друга молча. Повторное
+ * обращение к тому же классу (forFeature, getRepositoryToken,
+ * InjectRepository) всегда возвращает те же строки.
+ *
+ * WeakMap не держит класс сильной ссылкой; счётчик занятых имён хранит
+ * только строки, поэтому классы собираются GC как раньше.
+ */
+const tokensByClass = new WeakMap<
+  YdbEntityConstructor<YdbBaseEntity>,
+  EntityDiTokens
+>();
+const claimedNames = new Map<string, number>();
+
+function resolveEntityTokens(
+  entityClass: YdbEntityConstructor<YdbBaseEntity>,
+): EntityDiTokens {
+  const cached = tokensByClass.get(entityClass);
+  if (cached) return cached;
+
+  // У анонимных/сминифицированных классов имя может отсутствовать.
+  const baseName = entityClass.name || 'AnonymousEntity';
+
+  const ordinal = claimedNames.get(baseName) ?? 0;
+  claimedNames.set(baseName, ordinal + 1);
+
+  // Первый класс с данным именем сохраняет исторический формат токена;
+  // каждый следующий одноимённый класс получает уникальный суффикс —
+  // коллизия разрешается явно, а не перезаписью провайдеров.
+  const suffix = ordinal === 0 ? '' : `#${ordinal + 1}`;
+  const tokens: EntityDiTokens = {
+    repository: `${REPOSITORY_TOKEN_PREFIX}${baseName}${suffix}`,
+    arInit: `${baseName}${suffix}${AR_INIT_TOKEN_SUFFIX}`,
+  };
+  tokensByClass.set(entityClass, tokens);
+  return tokens;
+}
 
 /**
  * Возвращает DI-токен для репозитория указанной сущности.
@@ -10,7 +62,19 @@ const REPOSITORY_TOKEN_PREFIX = 'YDB_REPOSITORY_' as const;
 export function getRepositoryToken<T extends YdbBaseEntity>(
   entityClass: YdbEntityConstructor<T>,
 ): string {
-  return `${REPOSITORY_TOKEN_PREFIX}${entityClass.name}`;
+  return resolveEntityTokens(entityClass).repository;
+}
+
+/**
+ * Возвращает DI-токен провайдера, который при инициализации модуля
+ * подключает executor/провайдеры к Active Record сущности
+ * (см. createActiveRecordEntityProvider). Используется и при объявлении
+ * провайдера, и в `inject` репозитория — рассинхрон строк невозможен.
+ */
+export function getActiveRecordInitToken<T extends YdbBaseEntity>(
+  entityClass: YdbEntityConstructor<T>,
+): string {
+  return resolveEntityTokens(entityClass).arInit;
 }
 
 /**

--- a/test/fixtures/token_collision_a/dup.entity.ts
+++ b/test/fixtures/token_collision_a/dup.entity.ts
@@ -1,0 +1,17 @@
+// Фикстура для регрессионных тестов коллизии DI-токенов (#94).
+// Имя класса намеренно совпадает с DupEntity из ../token_collision_b/dup.entity.ts.
+import {
+  YdbEntity,
+  YdbPrimaryColumn,
+  YdbColumn,
+  YdbBaseEntity,
+} from '../../../src/index.js';
+
+@YdbEntity('token_dup_a')
+export class DupEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid!: string;
+
+  @YdbColumn('Utf8')
+  title!: string;
+}

--- a/test/fixtures/token_collision_b/dup.entity.ts
+++ b/test/fixtures/token_collision_b/dup.entity.ts
@@ -1,0 +1,17 @@
+// Фикстура для регрессионных тестов коллизии DI-токенов (#94).
+// Имя класса намеренно совпадает с DupEntity из ../token_collision_a/dup.entity.ts.
+import {
+  YdbEntity,
+  YdbPrimaryColumn,
+  YdbColumn,
+  YdbBaseEntity,
+} from '../../../src/index.js';
+
+@YdbEntity('token_dup_b')
+export class DupEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid!: string;
+
+  @YdbColumn('Utf8')
+  title!: string;
+}

--- a/test/nestjs/repository-token-collision.spec.ts
+++ b/test/nestjs/repository-token-collision.spec.ts
@@ -1,0 +1,159 @@
+import 'reflect-metadata';
+import { jest } from '@jest/globals';
+import { Injectable, Module } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  YdbModule,
+  YdbRepository,
+  InjectRepository,
+  getRepositoryToken,
+  YDB_DRIVER,
+  YDB_QUERY,
+  YDB_SCHEMA_SYNC,
+} from '../../src/index.js';
+// Одноимённые классы из разных файлов: оба называются DupEntity
+import { DupEntity as DupEntityA } from '../fixtures/token_collision_a/dup.entity.js';
+import { DupEntity as DupEntityB } from '../fixtures/token_collision_b/dup.entity.js';
+import { createMockExecutor } from '../helpers/mock-executor.js';
+
+const UUID_A = '11111111-1111-1111-1111-111111111111';
+const UUID_B = '22222222-2222-2222-2222-222222222222';
+
+@Injectable()
+class DupService {
+  constructor(
+    @InjectRepository(DupEntityA)
+    public readonly repoA: YdbRepository<DupEntityA>,
+    @InjectRepository(DupEntityB)
+    public readonly repoB: YdbRepository<DupEntityB>,
+  ) {}
+}
+
+const dupFeature = YdbModule.forFeature([DupEntityA, DupEntityB]);
+
+@Module({
+  imports: [dupFeature],
+  exports: [dupFeature],
+})
+class DupFeatureModule {}
+
+describe('NestJS integration: коллизия DI-токенов одноимённых сущностей (#94)', () => {
+  let module: TestingModule;
+  let service: DupService;
+  let queries: { sql: string }[];
+
+  beforeEach(async () => {
+    const mock = createMockExecutor(
+      [
+        [[{ uuid: UUID_A, title: 'from A' }]],
+        [[{ uuid: UUID_B, title: 'from B' }]],
+        [[{ uuid: UUID_A, title: 'from A' }]],
+        [[{ uuid: UUID_B, title: 'from B' }]],
+      ],
+      { sequential: true },
+    );
+    queries = mock.queries;
+
+    module = await Test.createTestingModule({
+      imports: [
+        YdbModule.forRoot({
+          useFactory: () => ({
+            endpoint: 'grpc://localhost:2136/local',
+            database: '/local',
+            auth_type: 'anonymous' as const,
+            authOptions: {},
+            sync: false,
+          }),
+        }),
+        DupFeatureModule,
+      ],
+      providers: [DupService],
+    })
+      .overrideProvider(YDB_DRIVER)
+      .useValue({})
+      .overrideProvider(YDB_SCHEMA_SYNC)
+      .useValue({ verify: jest.fn(), sync: jest.fn() })
+      .overrideProvider(YDB_QUERY)
+      .useValue(mock.executor)
+      .compile();
+
+    service = module.get(DupService);
+  });
+
+  afterEach(async () => {
+    if (module) await module.close();
+    DupEntityA.setExecutor(undefined as any);
+    DupEntityB.setExecutor(undefined as any);
+  });
+
+  it('одноимённые классы получают разные DI-токены', () => {
+    expect(DupEntityA.name).toBe(DupEntityB.name);
+    expect(getRepositoryToken(DupEntityA)).not.toBe(
+      getRepositoryToken(DupEntityB),
+    );
+  });
+
+  it('инжектятся два разных репозитория, привязанных к своим классам', () => {
+    expect(service.repoA).toBeInstanceOf(YdbRepository);
+    expect(service.repoB).toBeInstanceOf(YdbRepository);
+    expect(service.repoA).not.toBe(service.repoB);
+    expect(service.repoA.entityClass).toBe(DupEntityA);
+    expect(service.repoB.entityClass).toBe(DupEntityB);
+  });
+
+  it('каждый репозиторий и Active Record ходят в свою таблицу', async () => {
+    const viaRepoA = await service.repoA.findAll();
+    const viaRepoB = await service.repoB.findAll();
+    expect(viaRepoA[0]).toBeInstanceOf(DupEntityA);
+    expect(viaRepoB[0]).toBeInstanceOf(DupEntityB);
+
+    // AR-путь тоже инициализирован для обоих классов
+    const viaArA = await DupEntityA.find({ uuid: UUID_A });
+    const viaArB = await DupEntityB.find({ uuid: UUID_B });
+    expect(viaArA?.uuid).toBe(UUID_A);
+    expect(viaArB?.uuid).toBe(UUID_B);
+
+    // Запросы уходят строго в свои таблицы: A — только token_dup_a и т.д.
+    const sqls = queries.map((q) => q.sql);
+    expect(sqls.filter((s) => s.includes('token_dup_a')).length).toBe(2);
+    expect(sqls.filter((s) => s.includes('token_dup_b')).length).toBe(2);
+    expect(sqls.every((s) => /token_dup_[ab]/.test(s))).toBe(true);
+  });
+
+  it('повторная регистрация того же класса идемпотентна', async () => {
+    const tokenBefore = getRepositoryToken(DupEntityA);
+
+    // Тот же класс дважды в forFeature — провайдеры не конфликтуют
+    const mock = createMockExecutor([[{ uuid: UUID_A, title: 'again' }]]);
+    const extra = await Test.createTestingModule({
+      imports: [
+        YdbModule.forRoot({
+          useFactory: () => ({
+            endpoint: 'grpc://localhost:2136/local',
+            database: '/local',
+            auth_type: 'anonymous' as const,
+            authOptions: {},
+            sync: false,
+          }),
+        }),
+        YdbModule.forFeature([DupEntityA, DupEntityA]),
+      ],
+    })
+      .overrideProvider(YDB_DRIVER)
+      .useValue({})
+      .overrideProvider(YDB_SCHEMA_SYNC)
+      .useValue({ verify: jest.fn(), sync: jest.fn() })
+      .overrideProvider(YDB_QUERY)
+      .useValue(mock.executor)
+      .compile();
+
+    // Тот же класс — тот же токен; репозиторий резолвится из общего runtime
+    expect(getRepositoryToken(DupEntityA)).toBe(tokenBefore);
+    const resolved = extra.get<YdbRepository<DupEntityA>>(
+      getRepositoryToken(DupEntityA),
+    );
+    expect(resolved.entityClass).toBe(DupEntityA);
+
+    await extra.close();
+  });
+});


### PR DESCRIPTION
## Проблема

`getRepositoryToken` и AR_INIT-токен строились как `${entityClass.name}_...`: два одноимённых класса из разных файлов/пакетов (User в домене и User в админке) молча перезаписывали провайдеры друг друга — инжектился чужой репозиторий, ошибка проявлялась далеко от причины (#94).

## Решение

Токены резолвит общий реестр `class → { repository, arInit }` (`WeakMap` + счётчик занятых имён):

- один класс всегда даёт один и тот же токен во всех путях (`forFeature`, `getRepositoryToken`, `InjectRepository`) — идемпотентно;
- первый класс с данным именем сохраняет исторический формат токена (`YDB_REPOSITORY_User`, `User_AR_INIT`) — обратная совместимость для существующего кода;
- каждый следующий одноимённый класс получает уникальный суффикс (`#2`, `#3`, …) — коллизия разрешается явно, два одноимённых класса получают разные инжектируемые репозитории;
- AR_INIT-токен строится единой функцией `getActiveRecordInitToken()` вместо дублирующихся шаблонных строк в `repository-factory.ts` и `ydb.module.ts` — рассинхрон строк между `provide` и `inject` невозможен;
- классы без имени (анонимные/сминифицированные) получают валидный токен вместо пустого префикса.

`WeakMap` не держит класс сильной ссылкой, счётчик хранит только строки — GC-поведение не меняется. Публичный API расширен экспортом `getActiveRecordInitToken` без изменения существующих сигнатур.

## Тесты

- `src/repository/repository-token.spec.ts` — юнит: стабильность токена одного класса, различие токенов одноимённых классов, независимость от порядка регистрации, согласованность AR_INIT-токена, анонимный класс.
- `test/nestjs/repository-token-collision.spec.ts` — интеграция через NestJS: одноимённые сущности из разных файлов получают разные DI-токены и разные репозитории (`@InjectRepository`), каждый ходит в свою таблицу по репозиторному и AR-пути; повторная регистрация того же класса идемпотентна.
- Фикстуры: `test/fixtures/token_collision_{a,b}/dup.entity.ts` — два класса `DupEntity` в разных файлах.

## Проверка

- `yarn test` — 713 passed (48 suites)
- `yarn build` — ok
- `yarn lint` — 0 errors

Closes #94