### PR TITLE
fix(schema): составной PK сравнивается с учётом порядка колонок (#89)

### DIFF
--- a/src/migrations/migration-generator.spec.ts
+++ b/src/migrations/migration-generator.spec.ts
@@ -351,6 +351,70 @@ describe('planMigration', () => {
   });
 });
 
+describe('planMigration composite primary key order (#89)', () => {
+  const composite: ExpectedTableSchema = {
+    tableName: 'tenant_objects',
+    columns: { tenant_id: 'Utf8', id: 'Uuid' },
+    primaryKey: ['tenant_id', 'id'],
+    indexes: [],
+  };
+
+  const compositeDescription = (primaryKey: string[]) =>
+    description(
+      [
+        ['tenant_id', Type_PrimitiveTypeId.UTF8],
+        ['id', Type_PrimitiveTypeId.UUID],
+      ],
+      primaryKey,
+    );
+
+  it('plans nothing for identical composite PKs', () => {
+    const plan = planMigration(
+      [composite],
+      [compositeDescription(['tenant_id', 'id'])],
+    );
+
+    expect(plan.up).toEqual([]);
+    expect(plan.down).toEqual([]);
+    expect(plan.warnings).toEqual([]);
+  });
+
+  it('warns on reordered composite PK without generating DDL (#89)', () => {
+    const plan = planMigration(
+      [composite],
+      [compositeDescription(['id', 'tenant_id'])],
+    );
+
+    expect(plan.up).toEqual([]);
+    expect(plan.down).toEqual([]);
+    // Ручная миграция вместо опасного автогенерируемого DDL
+    expect(plan.warnings).toEqual([
+      'Table "tenant_objects": primary key column order mismatch: ' +
+        'expected [tenant_id, id], actual [id, tenant_id] — ' +
+        'YDB cannot alter a primary key, manual migration required',
+    ]);
+  });
+
+  it('lists missing and extra PK columns in the warning (#89)', () => {
+    const plan = planMigration(
+      [composite],
+      [compositeDescription(['id', 'legacy_id'])],
+    );
+
+    expect(plan.up).toEqual([]);
+    expect(plan.down).toEqual([]);
+    expect(plan.warnings.some((w) => w.includes('missing [tenant_id]'))).toBe(
+      true,
+    );
+    expect(
+      plan.warnings.some((w) => w.includes('unexpected [legacy_id]')),
+    ).toBe(true);
+    expect(plan.warnings.every((w) => w.includes('manual migration'))).toBe(
+      true,
+    );
+  });
+});
+
 describe('planMigration input validation (#102)', () => {
   it('rejects non-array inputs with a clear error', () => {
     const wrongExpected = () =>

--- a/src/migrations/migration-generator.ts
+++ b/src/migrations/migration-generator.ts
@@ -3,6 +3,7 @@ import {
   YdbTableDescription,
   YdbTableTtl,
   checkTableSchema,
+  describePrimaryKeyMismatch,
   generateAddColumnsYql,
   generateAddIndexYql,
   generateCreateTableYql,
@@ -106,8 +107,11 @@ export function planMigration(
     const check = checkTableSchema(schema, current);
 
     if (!check.primaryKeyMatches) {
+      // #89: перестановка PK-колонок — тоже расхождение (порядок значим),
+      // но DDL не генерируем: PK в YDB не меняется, только ручная миграция.
       warnings.push(
-        `Table "${schema.tableName}": primary key mismatch — YDB cannot alter it, manual migration required`,
+        `Table "${schema.tableName}": ${describePrimaryKeyMismatch(check)} — ` +
+          `YDB cannot alter a primary key, manual migration required`,
       );
     }
     for (const mismatch of check.typeMismatches) {

--- a/src/schema/schema-sync.spec.ts
+++ b/src/schema/schema-sync.spec.ts
@@ -76,6 +76,19 @@ class TestNoPkEntity extends YdbBaseEntity {
   name: string;
 }
 
+// #89: составной PK — порядок колонок значим при сравнении схем
+@YdbEntity('test_composite_pk')
+class TestCompositePkEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  tenant_id: string;
+
+  @YdbPrimaryColumn('Uuid')
+  id: string;
+
+  @YdbColumn('Int64')
+  amount: bigint;
+}
+
 @YdbEntity('test_json')
 class TestJsonEntity extends YdbBaseEntity {
   @YdbPrimaryColumn('Uuid')
@@ -337,6 +350,21 @@ const description = (
   indexes,
   ...(ttl ? { ttl } : {}),
 });
+
+// #89: описание таблицы с составным PK; primaryKey передаётся явно,
+// чтобы проверять перестановки порядка
+const compositePkExpected = buildExpectedTableSchema(
+  meta(TestCompositePkEntity),
+);
+const compositePkDescription = (primaryKey: string[]): YdbTableDescription =>
+  description(
+    [
+      ['tenant_id', Type_PrimitiveTypeId.UTF8],
+      ['id', Type_PrimitiveTypeId.UUID],
+      ['amount', Type_PrimitiveTypeId.INT64],
+    ],
+    primaryKey,
+  );
 
 describe('entity registry', () => {
   it('registers classes decorated with @YdbEntity', () => {
@@ -863,6 +891,118 @@ describe('checkTableSchema', () => {
   });
 });
 
+describe('composite primary key comparison (#89)', () => {
+  it('passes for identical composite PKs', () => {
+    const check = checkTableSchema(
+      compositePkExpected,
+      compositePkDescription(['tenant_id', 'id']),
+    );
+
+    expect(check.primaryKeyMatches).toBe(true);
+    expect(check.primaryKeyOrderMismatch).toBe(false);
+    expect(check.missingPrimaryKeyColumns).toEqual([]);
+    expect(check.extraPrimaryKeyColumns).toEqual([]);
+  });
+
+  it('preserves behavior for identical single-column PKs', () => {
+    const check = checkTableSchema(
+      buildExpectedTableSchema(meta(TestUserEntity)),
+      description(
+        [
+          ['uuid', Type_PrimitiveTypeId.UUID],
+          ['name', Type_PrimitiveTypeId.UTF8],
+          ['secret', Type_PrimitiveTypeId.STRING],
+          ['is_active', Type_PrimitiveTypeId.BOOL],
+          ['secret_bi', Type_PrimitiveTypeId.UTF8],
+        ],
+        ['uuid'],
+      ),
+    );
+
+    expect(check.primaryKeyMatches).toBe(true);
+    expect(check.missingPrimaryKeyColumns).toEqual([]);
+    expect(check.extraPrimaryKeyColumns).toEqual([]);
+    expect(check.primaryKeyOrderMismatch).toBe(false);
+  });
+
+  it('treats reordered composite PKs as different schemas', () => {
+    const check = checkTableSchema(
+      compositePkExpected,
+      compositePkDescription(['id', 'tenant_id']),
+    );
+
+    expect(check.primaryKeyMatches).toBe(false);
+    // Чистая перестановка: наборы колонок равны — диагностируется именно порядок
+    expect(check.primaryKeyOrderMismatch).toBe(true);
+    expect(check.missingPrimaryKeyColumns).toEqual([]);
+    expect(check.extraPrimaryKeyColumns).toEqual([]);
+  });
+
+  it('distinguishes missing PK columns from reorder', () => {
+    const check = checkTableSchema(
+      compositePkExpected,
+      compositePkDescription(['tenant_id']),
+    );
+
+    expect(check.primaryKeyMatches).toBe(false);
+    expect(check.primaryKeyOrderMismatch).toBe(false);
+    expect(check.missingPrimaryKeyColumns).toEqual(['id']);
+    expect(check.extraPrimaryKeyColumns).toEqual([]);
+  });
+
+  it('distinguishes extra PK columns from reorder', () => {
+    const check = checkTableSchema(
+      compositePkExpected,
+      compositePkDescription(['tenant_id', 'id', 'amount']),
+    );
+
+    expect(check.primaryKeyMatches).toBe(false);
+    expect(check.primaryKeyOrderMismatch).toBe(false);
+    expect(check.missingPrimaryKeyColumns).toEqual([]);
+    expect(check.extraPrimaryKeyColumns).toEqual(['amount']);
+  });
+
+  it('reports reordered PK via diffSchemas with both orders', () => {
+    const issues = diffSchemas(
+      [compositePkExpected],
+      [compositePkDescription(['id', 'tenant_id'])],
+    );
+
+    expect(issues).toContainEqual({
+      tableName: 'test_composite_pk',
+      kind: 'primary-key-mismatch',
+      message:
+        'Table "test_composite_pk" primary key column order mismatch: ' +
+        'expected [tenant_id, id], actual [id, tenant_id]',
+    });
+  });
+
+  it('reports missing and extra PK columns distinctly in issues', () => {
+    const missingIssues = checkToIssues(
+      checkTableSchema(compositePkExpected, compositePkDescription(['id'])),
+    );
+    expect(missingIssues).toContainEqual({
+      tableName: 'test_composite_pk',
+      kind: 'primary-key-mismatch',
+      message:
+        'Table "test_composite_pk" primary key mismatch (missing [tenant_id])',
+    });
+
+    const extraIssues = checkToIssues(
+      checkTableSchema(
+        compositePkExpected,
+        compositePkDescription(['id', 'tenant_id', 'amount']),
+      ),
+    );
+    expect(extraIssues).toContainEqual({
+      tableName: 'test_composite_pk',
+      kind: 'primary-key-mismatch',
+      message:
+        'Table "test_composite_pk" primary key mismatch (unexpected [amount])',
+    });
+  });
+});
+
 describe('checkTableSchema TTL (#88)', () => {
   const ttlExpected = buildExpectedTableSchema(meta(TestSessionEntity));
 
@@ -1279,6 +1419,40 @@ describe('YdbSchemaSyncer', () => {
     await expect(syncer.sync([TestUserEntity])).rejects.toThrow(
       /primary key mismatch/,
     );
+  });
+
+  it('verify reports reordered composite PK as a mismatch (#89)', async () => {
+    mockDescribe(compositePkDescription(['id', 'tenant_id']));
+
+    const issues = await syncer.verify([TestCompositePkEntity]);
+
+    expect(issues).toEqual([
+      {
+        tableName: 'test_composite_pk',
+        kind: 'primary-key-mismatch',
+        message:
+          'Table "test_composite_pk" primary key column order mismatch: ' +
+          'expected [tenant_id, id], actual [id, tenant_id]',
+      },
+    ]);
+    expect(executedSql()).toEqual([]);
+  });
+
+  it('verify passes for identical composite PKs (#89)', async () => {
+    mockDescribe(compositePkDescription(['tenant_id', 'id']));
+
+    const issues = await syncer.verify([TestCompositePkEntity]);
+
+    expect(issues).toEqual([]);
+  });
+
+  it('sync throws on reordered composite PK and executes no DDL (#89)', async () => {
+    mockDescribe(compositePkDescription(['id', 'tenant_id']));
+
+    await expect(syncer.sync([TestCompositePkEntity])).rejects.toThrow(
+      /primary key mismatch \(expected \[tenant_id, id\], actual \[id, tenant_id\]\)/,
+    );
+    expect(executedSql()).toEqual([]);
   });
 
   it('throws on index columns mismatch', async () => {

--- a/src/schema/schema-sync.ts
+++ b/src/schema/schema-sync.ts
@@ -94,6 +94,24 @@ export interface SchemaCheckResult {
   /** Лишние колонки в БД (не удаляются автоматически — потеря данных). */
   extraColumns: string[];
   primaryKeyMatches: boolean;
+  /**
+   * Ожидаемый PK из метаданных сущности — копия входа, нужна для
+   * диагностики перестановок порядка (#89).
+   */
+  expectedPrimaryKey: string[];
+  /** Фактический PK из DescribeTable (для диагностики порядка, #89). */
+  actualPrimaryKey: string[];
+  /** Ожидаемые PK-колонки, которых нет в PK БД (#89). */
+  missingPrimaryKeyColumns: string[];
+  /** PK-колонки БД, не объявленные как PK в сущности (#89). */
+  extraPrimaryKeyColumns: string[];
+  /**
+   * Чистая перестановка: наборы PK-колонок совпадают, но порядок
+   * различается (#89). В YDB порядок колонок PK определяет
+   * партиционирование и сортировку диапазонов, поэтому [tenant, id] и
+   * [id, tenant] — принципиально разные таблицы.
+   */
+  primaryKeyOrderMismatch: boolean;
   /** Индексы, которые есть в метаданных, но нет в БД. */
   missingIndexes: ExpectedIndex[];
   /** Индексы, которые есть в БД, но нет в метаданных. */
@@ -557,9 +575,24 @@ export function checkTableSchema(
   ].filter((name) => !expectedColumns.has(name));
   const uniqueExtraColumns = [...new Set(extraColumns)];
 
+  // Порядок колонок PK значим (#89): в YDB он определяет партиционирование
+  // и сортировку диапазонов, поэтому [tenant, id] и [id, tenant] — разные
+  // таблицы. Сравниваем поэлементно и никогда — как множество.
   const primaryKeyMatches =
     expected.primaryKey.length === existing.primaryKey.length &&
-    expected.primaryKey.every((pk) => existing.primaryKey.includes(pk));
+    expected.primaryKey.every((pk, i) => existing.primaryKey[i] === pk);
+  const missingPrimaryKeyColumns = expected.primaryKey.filter(
+    (pk) => !existing.primaryKey.includes(pk),
+  );
+  const extraPrimaryKeyColumns = existing.primaryKey.filter(
+    (pk) => !expected.primaryKey.includes(pk),
+  );
+  // Чистая перестановка: наборы равны, порядок различается. Если есть
+  // отсутствующие или лишние PK-колонки, случай уже покрыт их списками.
+  const primaryKeyOrderMismatch =
+    !primaryKeyMatches &&
+    missingPrimaryKeyColumns.length === 0 &&
+    extraPrimaryKeyColumns.length === 0;
 
   const existingIndexes = existing.indexes ?? [];
 
@@ -630,6 +663,11 @@ export function checkTableSchema(
     typeMismatches,
     extraColumns: uniqueExtraColumns,
     primaryKeyMatches,
+    expectedPrimaryKey: [...expected.primaryKey],
+    actualPrimaryKey: [...existing.primaryKey],
+    missingPrimaryKeyColumns,
+    extraPrimaryKeyColumns,
+    primaryKeyOrderMismatch,
     missingIndexes,
     extraIndexes,
     uniqueMismatches,
@@ -638,6 +676,32 @@ export function checkTableSchema(
     ttlMismatches,
     extraTtl,
   };
+}
+
+/**
+ * Человекочитаемое описание расхождения первичного ключа (#89):
+ * различает чистую перестановку PK-колонок (порядок значим в YDB) и
+ * отсутствующие/лишние PK-колонки. Используется в issues verify/diffSchemas
+ * и в предупреждениях плана миграций.
+ */
+export function describePrimaryKeyMismatch(check: SchemaCheckResult): string {
+  if (check.primaryKeyOrderMismatch) {
+    return (
+      'primary key column order mismatch: ' +
+      `expected [${check.expectedPrimaryKey.join(', ')}], ` +
+      `actual [${check.actualPrimaryKey.join(', ')}]`
+    );
+  }
+  const parts: string[] = [];
+  if (check.missingPrimaryKeyColumns.length) {
+    parts.push(`missing [${check.missingPrimaryKeyColumns.join(', ')}]`);
+  }
+  if (check.extraPrimaryKeyColumns.length) {
+    parts.push(`unexpected [${check.extraPrimaryKeyColumns.join(', ')}]`);
+  }
+  return parts.length
+    ? `primary key mismatch (${parts.join(', ')})`
+    : 'primary key mismatch';
 }
 
 /**
@@ -651,7 +715,7 @@ export function checkToIssues(check: SchemaCheckResult): YdbSchemaIssue[] {
     issues.push({
       tableName: check.tableName,
       kind: 'primary-key-mismatch',
-      message: `Table "${check.tableName}" primary key does not match entity`,
+      message: `Table "${check.tableName}" ${describePrimaryKeyMismatch(check)}`,
     });
   }
   for (const [column] of check.missingColumns) {

--- a/test/cli/schema-diff.spec.ts
+++ b/test/cli/schema-diff.spec.ts
@@ -224,6 +224,39 @@ describe('diffSchemas + renderSchemaDiff (schema:verify output)', () => {
       '~ index "users__name_age": [age, name] → [name, age]',
     );
   });
+
+  it('reports reordered composite PK as a primary-key order mismatch (#89)', () => {
+    const expected: ExpectedTableSchema = {
+      tableName: 'tenant_users',
+      columns: { tenant_id: 'Utf8', uuid: 'Uuid' },
+      primaryKey: ['tenant_id', 'uuid'],
+      indexes: [],
+    };
+    const existing: YdbTableDescription = {
+      columns: new Map<string, Type_PrimitiveTypeId>([
+        ['tenant_id', Type_PrimitiveTypeId.UTF8],
+        ['uuid', Type_PrimitiveTypeId.UUID],
+      ]),
+      // Порядок переставлен: [tenant, id] и [id, tenant] — разные схемы
+      primaryKey: ['uuid', 'tenant_id'],
+      indexes: [],
+    };
+
+    const issues = diffSchemas([expected], [existing]);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0].kind).toBe('primary-key-mismatch');
+    expect(issues[0].message).toBe(
+      'Table "tenant_users" primary key column order mismatch: ' +
+        'expected [tenant_id, uuid], actual [uuid, tenant_id]',
+    );
+
+    const out = renderSchemaDiff(issues, { color: false });
+    expect(out).toContain(
+      '! primary key column order mismatch: ' +
+        'expected [tenant_id, uuid], actual [uuid, tenant_id]',
+    );
+  });
 });
 
 describe('shouldUseColor', () => {


### PR DESCRIPTION
## Summary

Fixes #89

`checkTableSchema` сравнивала PK как множество (`every` + `includes`), из-за чего `[tenant,id]` и `[id,tenant]` считались одинаковой схемой: sync не видел расхождение и продолжал работать поверх таблицы с другой физической раскладкой. В YDB порядок колонок PK определяет партиционирование и сортировку диапазонов — перестановка принципиально меняет таблицу.

## Changes

- `checkTableSchema`: сравнение PK поэлементное с учётом порядка; сравнение как множество убрано полностью.
- Диагностика различает случаи:
  - чистая перестановка — новый флаг `primaryKeyOrderMismatch` (наборы колонок равны, порядок различается);
  - отсутствующие PK-колонки — `missingPrimaryKeyColumns`;
  - лишние PK-колонки — `extraPrimaryKeyColumns`.
- Новый экспорт `describePrimaryKeyMismatch(check)` — человекочитаемое описание расхождения, общее для issues и предупреждений миграций:
  - перестановка: `primary key column order mismatch: expected [tenant_id, id], actual [id, tenant_id]`;
  - missing/extra: `primary key mismatch (missing [tenant_id], unexpected [legacy_id])`.
- `schema:verify` / `diffSchemas()`: расхождение репортится с kind `primary-key-mismatch` (kind не менялся — потребители CLI-diff совместимы), сообщение теперь содержит оба порядка.
- `planMigration()`: для перестановки PK DDL **не** генерируется — только warning про ручную миграцию (существующая политика: PK в YDB нельзя изменить).
- `sync()` теперь корректно падает на перестановке PK (раньше молча пропускал).

## Behavior preservation

- Идентичные одноколоночные и многоколоночные PK — как раньше, без issues/warnings.
- Потребители `SchemaCheckResult` вне библиотеки: добавлены только новые поля, существенные поля не менялись.

## Tests

Регрессионные тесты (#89):
- идентичный составной PK проходит проверку; идентичный одноколоночный PK — поведение сохранено;
- переставленный составной PK: `primaryKeyMatches=false`, `primaryKeyOrderMismatch=true`, missing/extra пустые;
- missing/extra PK-колонки отличимы от перестановки;
- `verify()` и `diffSchemas()` + вывод `renderSchemaDiff` (маркер `!`) содержат оба порядка;
- `sync()` падает с сообщением об обоих порядках и не выполняет DDL;
- `planMigration()`: перестановка — только warning без DDL; missing/extra — перечислены в warning; идентичный составной PK — пустой план.

Все 759 тестов проходят, `yarn build` и `yarn lint` чистые (0 ошибок; 118 предупреждений — без изменений относительно main).