### PR TITLE
fix(relations): детерминированный отказ от составного PK в m2m и строгие join-колонки без фолбэка Uuid (#87)

### DIFF
--- a/src/decorators/relation.decorators.ts
+++ b/src/decorators/relation.decorators.ts
@@ -23,9 +23,15 @@ export interface RelationMetadata {
 export interface JoinTableMetadata {
   propertyKey: string;
   tableName: string;
-  /** Колонка, ссылающаяся на владеющую сущность (по умолчанию `{ownerTable}_uuid`). */
+  /**
+   * Колонка, ссылающаяся на владеющую сущность
+   * (по умолчанию `{ownerTable}_{pkProperty}`, #90).
+   */
   joinColumn?: string;
-  /** Колонка, ссылающаяся на обратную сущность (по умолчанию `{inverseTable}_uuid`). */
+  /**
+   * Колонка, ссылающаяся на обратную сущность
+   * (по умолчанию `{inverseTable}_{pkProperty}`, #90).
+   */
   inverseJoinColumn?: string;
 }
 
@@ -35,12 +41,14 @@ export interface ManyToManyJoinTable {
   joinColumn: string;
   inverseJoinColumn: string;
   /**
-   * YDB-тип колонки, ссылающейся на владельца (#90): выводится из
-   * фактического PK owner-сущности, а не жёстко Uuid.
+   * YDB-тип колонки, ссылающейся на владельца (#90/#87): выводится из
+   * фактического PK owner-сущности. Обязателен: резолв всегда выводит тип
+   * из PK или бросает понятную ошибку конфигурации — молчаливого фолбэка
+   * на Uuid не существует (#87).
    */
-  joinColumnType?: YdbPrimitive;
-  /** YDB-тип колонки, ссылающейся на inverse-сущность (аналогично #90). */
-  inverseJoinColumnType?: YdbPrimitive;
+  joinColumnType: YdbPrimitive;
+  /** YDB-тип колонки, ссылающейся на inverse-сущность (аналогично #87). */
+  inverseJoinColumnType: YdbPrimitive;
   ownerEntity: typeof YdbBaseEntity;
   ownerTableName: string;
   ownerProperty: string;
@@ -59,6 +67,124 @@ export function defaultJoinColumnName(
   pkProperty: string,
 ): string {
   return `${tableName}_${pkProperty}`;
+}
+
+/** Контекст для сообщений об ошибках конфигурации join-колонки (#87). */
+export interface JoinColumnResolutionContext {
+  /** Имя класса-владельца связи. */
+  entityName: string;
+  /** Свойство связи (@OneToMany/@ManyToOne/@OneToOne). */
+  relationPropertyKey: string;
+}
+
+/**
+ * Строгий резолв декларации join-колонки связи (#87).
+ *
+ * Поддерживается ровно две формы:
+ *  - непустая строка — имя колонки;
+ *  - селектор свойства: `(target) => target.property` (точка или скобочная
+ *    запись с одним чтением свойства).
+ *
+ * Всё остальное — ошибка конфигурации, а не молчаливая угаданная строка:
+ * цепочки свойств (`x.a.b`), вызовы методов (`x.getFk()`), константы
+ * (`() => 'col'`) и неиспользованный аргумент отвергаются с ошибкой,
+ * называющей сущность и связь.
+ *
+ * Единственная точка резолва: используется рантаймом relations и
+ * validateEntityMetadata — расхождений между путями нет (#87).
+ */
+export function resolveRelationJoinColumn(
+  joinColumn: string | ((target: any) => any) | undefined | null,
+  ctx: JoinColumnResolutionContext,
+): string {
+  const where = `relation "${ctx.relationPropertyKey}" on ${ctx.entityName}`;
+
+  if (joinColumn === undefined || joinColumn === null) {
+    throw new Error(
+      `Join column is required for ${where}: ` +
+        `pass a column name or a property selector (target) => target.property.`,
+    );
+  }
+
+  if (typeof joinColumn === 'string') {
+    if (joinColumn.trim().length === 0) {
+      throw new Error(
+        `Invalid join column declaration for ${where}: ` +
+          `column name must be a non-empty string.`,
+      );
+    }
+    return joinColumn;
+  }
+
+  if (typeof joinColumn !== 'function') {
+    throw new Error(
+      `Invalid join column declaration for ${where}: ` +
+        `expected a non-empty string or a property selector ` +
+        `(target) => target.property, got ${typeof joinColumn}.`,
+    );
+  }
+
+  return resolvePropertySelector(joinColumn, where);
+}
+
+/**
+ * Резолвит селектор `(target) => target.property`: прокси-рекордер читает
+ * ровно одно обращение к свойству. Любая другая форма (цепочка, вызов,
+ * символ, вычисленное значение) даёт понятную ошибку вместо угаданной
+ * строки колонки (#87).
+ */
+function resolvePropertySelector(
+  selector: (target: any) => any,
+  where: string,
+): string {
+  const accessedProps: string[] = [];
+  let lastNode: unknown;
+
+  /** Маркер внутренней ошибки рекордера: отличаем её от ошибок пользователя. */
+  class SelectorRejected extends Error {}
+
+  const makeNode = (): unknown =>
+    new Proxy(function joinColumnSelectorTarget() {}, {
+      get: (_target, prop) => {
+        if (typeof prop === 'symbol') throw new SelectorRejected();
+        accessedProps.push(prop);
+        lastNode = makeNode();
+        return lastNode;
+      },
+      apply: () => {
+        throw new SelectorRejected();
+      },
+      construct: () => {
+        throw new SelectorRejected();
+      },
+    });
+
+  let result: unknown;
+  try {
+    result = selector(makeNode());
+  } catch (err) {
+    if (!(err instanceof SelectorRejected)) {
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new Error(`${invalidSelectorMessage(where)} (${detail}).`);
+    }
+    throw new Error(invalidSelectorMessage(where));
+  }
+
+  if (accessedProps.length !== 1 || result !== lastNode) {
+    const detail = accessedProps.length
+      ? `unsupported selector form (target.${accessedProps.join('.')})`
+      : 'the target argument was not used to select a property';
+    throw new Error(`${invalidSelectorMessage(where)} — ${detail}.`);
+  }
+
+  return accessedProps[0];
+}
+
+function invalidSelectorMessage(where: string): string {
+  return (
+    `Invalid join column selector for ${where}: ` +
+    `only direct property access is supported — (target) => target.property`
+  );
 }
 
 function defineRelation(prototype: object, metadata: RelationMetadata): void {
@@ -195,35 +321,46 @@ export function resolveRelationJoinTableDefinition(
     );
   }
 
+  // Контекст связи для ошибок конфигурации (#87): ошибка всегда называет
+  // сущности, свойство связи и join-таблицу, а не только одну сущность.
+  const relationDesc =
+    `${Entity.name}.${relation.propertyKey} -> ${InverseEntity.name} ` +
+    `(join table "${joinTable.tableName}")`;
+
   if (meta.primaryKeys.length === 0) {
     throw new Error(
-      `Cannot build many-to-many join table for entity ${Entity.name}: ` +
-        `no primary key is declared. Mark at least one column with @YdbPrimaryColumn.`,
+      `Cannot build many-to-many join table for relation "${relationDesc}": ` +
+        `owner entity ${Entity.name} declares no primary key. ` +
+        `Mark at least one column with @YdbPrimaryColumn.`,
     );
   }
   if (inverseMeta.primaryKeys.length === 0) {
     throw new Error(
-      `Cannot build many-to-many join table for entity ${InverseEntity.name}: ` +
-        `no primary key is declared. Mark at least one column with @YdbPrimaryColumn.`,
+      `Cannot build many-to-many join table for relation "${relationDesc}": ` +
+        `inverse entity ${InverseEntity.name} declares no primary key. ` +
+        `Mark at least one column with @YdbPrimaryColumn.`,
     );
   }
 
   // Рантайм-модель many-to-many связывает строки ровно по одному
   // значению PK с каждой стороны; составной PK породил бы join-таблицу,
-  // не совпадающую с тем, что читает relations-код, — отказываем явно (#90).
+  // не совпадающую с тем, что читает relations-код, — отказываем явно
+  // (#90/#87). Отказ детерминирован: один и тот же резолвер используется
+  // генерацией схемы, валидацией метаданных, eager loading, loadRelations
+  // и рантаймом join-таблицы — частичной поддержки ни в одном пути нет.
   if (meta.primaryKeys.length > 1) {
     throw new Error(
-      `Cannot build many-to-many join table "${joinTable.tableName}" ` +
-        `for entity ${Entity.name}: composite primary keys ` +
-        `(${meta.primaryKeys.join(', ')}) are not supported in ` +
+      `Cannot build many-to-many join table for relation "${relationDesc}": ` +
+        `owner entity ${Entity.name} has composite primary keys ` +
+        `(${meta.primaryKeys.join(', ')}) that are not supported in ` +
         `many-to-many relations. Declare a single-column @YdbPrimaryColumn.`,
     );
   }
   if (inverseMeta.primaryKeys.length > 1) {
     throw new Error(
-      `Cannot build many-to-many join table "${joinTable.tableName}" ` +
-        `for entity ${InverseEntity.name}: composite primary keys ` +
-        `(${inverseMeta.primaryKeys.join(', ')}) are not supported in ` +
+      `Cannot build many-to-many join table for relation "${relationDesc}": ` +
+        `inverse entity ${InverseEntity.name} has composite primary keys ` +
+        `(${inverseMeta.primaryKeys.join(', ')}) that are not supported in ` +
         `many-to-many relations. Declare a single-column @YdbPrimaryColumn.`,
     );
   }
@@ -231,32 +368,42 @@ export function resolveRelationJoinTableDefinition(
   const ownerPk = meta.primaryKeys[0];
   const inversePk = inverseMeta.primaryKeys[0];
 
+  // Имена по умолчанию выводятся из фактических PK-колонок (#90):
+  // для PK "uuid" это прежние `{table}_uuid`, для остальных — `{table}_{pk}`.
+  const resolvedJoinColumn =
+    joinTable.joinColumn ?? defaultJoinColumnName(meta.tableName, ownerPk);
+  const resolvedInverseJoinColumn =
+    joinTable.inverseJoinColumn ??
+    defaultJoinColumnName(inverseMeta.tableName, inversePk);
+
+  // Тип join-колонки = точный тип PK-колонки сущности (#90/#87).
+  // Вывести тип невозможно — ошибка конфигурации; молчаливого фолбэка на
+  // Uuid не существует: он породил бы схему, несовместимую с данными.
   const ownerPkType = meta.schema[ownerPk];
   if (!ownerPkType) {
     throw new Error(
-      `Cannot build many-to-many join table for entity ${Entity.name}: ` +
-        `primary key column "${ownerPk}" is not declared via @YdbColumn. ` +
-        `Declare it or mark another column with @YdbPrimaryColumn.`,
+      `Cannot derive type of join column "${resolvedJoinColumn}" ` +
+        `for relation "${relationDesc}": primary key "${ownerPk}" of ` +
+        `${Entity.name} is not declared via @YdbColumn/@YdbPrimaryColumn. ` +
+        `Join-table columns reuse the exact primary key type — ` +
+        `there is no implicit fallback.`,
     );
   }
   const inversePkType = inverseMeta.schema[inversePk];
   if (!inversePkType) {
     throw new Error(
-      `Cannot build many-to-many join table for entity ${InverseEntity.name}: ` +
-        `primary key column "${inversePk}" is not declared via @YdbColumn. ` +
-        `Declare it or mark another column with @YdbPrimaryColumn.`,
+      `Cannot derive type of inverse join column "${resolvedInverseJoinColumn}" ` +
+        `for relation "${relationDesc}": primary key "${inversePk}" of ` +
+        `${InverseEntity.name} is not declared via @YdbColumn/@YdbPrimaryColumn. ` +
+        `Join-table columns reuse the exact primary key type — ` +
+        `there is no implicit fallback.`,
     );
   }
 
-  // Имена по умолчанию выводятся из фактических PK-колонок (#90):
-  // для PK "uuid" это прежние `{table}_uuid`, для остальных — `{table}_{pk}`.
   return {
     tableName: joinTable.tableName,
-    joinColumn:
-      joinTable.joinColumn ?? defaultJoinColumnName(meta.tableName, ownerPk),
-    inverseJoinColumn:
-      joinTable.inverseJoinColumn ??
-      defaultJoinColumnName(inverseMeta.tableName, inversePk),
+    joinColumn: resolvedJoinColumn,
+    inverseJoinColumn: resolvedInverseJoinColumn,
     joinColumnType: ownerPkType,
     inverseJoinColumnType: inversePkType,
     ownerEntity: Entity as typeof YdbBaseEntity,

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,12 +52,14 @@ export {
   getYdbRelationsMetadata,
   getYdbJoinTableMetadata,
   getManyToManyJoinTables,
+  resolveRelationJoinColumn,
 } from './decorators/relation.decorators.js';
 export type {
   RelationMetadata,
   RelationType,
   JoinTableMetadata,
   ManyToManyJoinTable,
+  JoinColumnResolutionContext,
 } from './decorators/relation.decorators.js';
 export { EagerLoad, getEagerRelations } from './decorators/eager.decorator.js';
 export { YdbJson, getJsonColumns } from './decorators/json.decorator.js';

--- a/src/metadata/validate-entity.ts
+++ b/src/metadata/validate-entity.ts
@@ -1,6 +1,8 @@
 import {
   getYdbJoinTableMetadata,
   getYdbRelationsMetadata,
+  resolveRelationJoinColumn,
+  resolveRelationJoinTableDefinition,
   RelationMetadata,
 } from '../decorators/relation.decorators.js';
 import { getYdbIndexesMetadata } from '../decorators/index.decorator.js';
@@ -140,9 +142,25 @@ function validateRelation(
     return issues;
   }
 
+  // Строгий резолв join-колонки (#87): тот же резолвер, что и в рантайме
+  // relations. Невалидный селектор или отсутствие join-колонки — issue с
+  // понятным описанием, а не молчаливо угаданная строка.
+  let joinColumn: string | undefined;
+  if (rel.type !== 'many-to-many') {
+    try {
+      joinColumn = resolveRelationJoinColumn(rel.joinColumn, {
+        entityName: entity.name,
+        relationPropertyKey: rel.propertyKey,
+      });
+    } catch (err) {
+      issues.push(
+        `${rel.type} "${rel.propertyKey}": ${(err as Error).message}`,
+      );
+    }
+  }
+
   if (rel.type === 'one-to-many') {
-    const joinColumn = resolveJoinColumnName(rel);
-    if (joinColumn && !targetMeta.schema[joinColumn]) {
+    if (joinColumn !== undefined && !targetMeta.schema[joinColumn]) {
       issues.push(
         `one-to-many "${rel.propertyKey}": join column "${joinColumn}" is not a column of ${Target.name}`,
       );
@@ -150,8 +168,7 @@ function validateRelation(
   }
 
   if (rel.type === 'many-to-one' || rel.type === 'one-to-one') {
-    const joinColumn = resolveJoinColumnName(rel);
-    if (joinColumn && !schema[joinColumn]) {
+    if (joinColumn !== undefined && !schema[joinColumn]) {
       issues.push(
         `${rel.type} "${rel.propertyKey}": join column "${joinColumn}" is not a column of ${entity.name}`,
       );
@@ -181,16 +198,21 @@ function validateRelation(
         `many-to-many "${rel.propertyKey}" requires @JoinTable on one of the sides ` +
           `(${entity.name} or ${Target.name})`,
       );
+    } else {
+      // Ошибки конфигурации m2m (нет PK, составной PK, невыводимый тип
+      // join-колонки и т.п.) обнаруживаются тем же резолвером, который
+      // строит схему и читает рантайм (#87): module init падает с той же
+      // ошибкой, что позже дали бы schema sync/verify/relations.
+      try {
+        resolveRelationJoinTableDefinition(
+          ownJoin ? entity : Target,
+          ownJoin ? rel : inverseRel!,
+        );
+      } catch (err) {
+        issues.push((err as Error).message);
+      }
     }
   }
 
   return issues;
-}
-
-/** Извлекает имя колонки из строки или селектора (x) => x.field. */
-function resolveJoinColumnName(rel: RelationMetadata): string | undefined {
-  if (!rel.joinColumn) return undefined;
-  if (typeof rel.joinColumn === 'string') return rel.joinColumn;
-  const proxy = new Proxy({}, { get: (_, prop) => prop as string });
-  return rel.joinColumn(proxy);
 }

--- a/src/relations/entity-relations.ts
+++ b/src/relations/entity-relations.ts
@@ -5,6 +5,7 @@ import {
   assertNoForeignJoinTableConflicts,
   getManyToManyJoinTables,
   getYdbRelationsMetadata,
+  resolveRelationJoinColumn,
 } from '../decorators/relation.decorators.js';
 import type { QueryOptions } from '../core/query-options.js';
 import type { YdbExecutor } from '../core/interfaces.js';
@@ -175,7 +176,10 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
       const Target = rel.target();
 
       if (rel.type === 'one-to-many') {
-        const joinColumnName = resolveJoinColumn(rel.joinColumn!);
+        const joinColumnName = resolveRelationJoinColumn(rel.joinColumn, {
+          entityName: constructor.name,
+          relationPropertyKey: rel.propertyKey,
+        });
         const pks = items
           .map((item) => (item as any)[pkField])
           .filter((v) => v !== undefined);
@@ -223,7 +227,10 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
           (item as any)[name] = related.get((item as any)[pkField]) ?? [];
         }
       } else {
-        const joinColumnName = resolveJoinColumn(rel.joinColumn!);
+        const joinColumnName = resolveRelationJoinColumn(rel.joinColumn, {
+          entityName: constructor.name,
+          relationPropertyKey: rel.propertyKey,
+        });
         const fks = items
           .map((item) => (item as any)[joinColumnName])
           .filter((v) => v !== undefined);
@@ -277,7 +284,10 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
       const Target = rel.target();
 
       if (rel.type === 'one-to-many') {
-        const joinColumnName = resolveJoinColumn(rel.joinColumn!);
+        const joinColumnName = resolveRelationJoinColumn(rel.joinColumn, {
+          entityName: constructor.name,
+          relationPropertyKey: rel.propertyKey,
+        });
         const pkField = getPrimaryKey(constructor);
 
         for (const item of items) {
@@ -329,7 +339,10 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
           (item as any)[name] = related.get(pkValue) ?? [];
         }
       } else {
-        const joinColumnName = resolveJoinColumn(rel.joinColumn!);
+        const joinColumnName = resolveRelationJoinColumn(rel.joinColumn, {
+          entityName: constructor.name,
+          relationPropertyKey: rel.propertyKey,
+        });
         const targetPk = getPrimaryKey(Target);
 
         for (const item of items) {
@@ -367,21 +380,6 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
     }
     return await query;
   }
-}
-
-/** Извлекает имя свойства из стрелочной функции вида (x) => x.field */
-function resolveJoinColumn(
-  joinColumn: string | ((target: any) => any),
-): string {
-  if (typeof joinColumn === 'string') return joinColumn;
-
-  const proxy = new Proxy(
-    {},
-    {
-      get: (_, prop) => prop as string,
-    },
-  );
-  return joinColumn(proxy);
 }
 
 /** Возвращает первый PK из метаданных. Бросает ошибку, если PK не объявлен. */
@@ -439,7 +437,10 @@ function resolveManyToManyJoinTable(
       tableName: own.tableName,
       ownerColumn: own.joinColumn,
       inverseColumn: own.inverseJoinColumn,
-      ownerColumnType: own.joinColumnType as YdbPrimitive,
+      // Имя, тип и сущности берутся из того же определения, по которому
+      // строится схема join-таблицы (#87): расхождений между рантаймом
+      // и schema sync быть не может.
+      ownerColumnType: own.joinColumnType,
       ownerEntity: owner,
       inverseEntity,
     };
@@ -457,7 +458,7 @@ function resolveManyToManyJoinTable(
       ownerColumn: inverseOwned.inverseJoinColumn,
       inverseColumn: inverseOwned.joinColumn,
       // Тип owner-колонки = тип PK владельца = тип её колонки в объявлении.
-      ownerColumnType: inverseOwned.inverseJoinColumnType as YdbPrimitive,
+      ownerColumnType: inverseOwned.inverseJoinColumnType,
       ownerEntity: owner,
       inverseEntity,
     };

--- a/src/schema/schema-sync.spec.ts
+++ b/src/schema/schema-sync.spec.ts
@@ -463,15 +463,15 @@ describe('buildExpectedJoinTableSchema', () => {
     expect(schema.primaryKey).toEqual(['order_ref', 'sku_code']);
   });
 
-  it('derives types from entity metadata when join-table struct carries none (#90)', () => {
+  it('definition always carries explicit column types; schema builds from it as-is (#87)', () => {
+    // Единственный источник имён/типов — resolveRelationJoinTableDefinition:
+    // типы обязательны и выводятся только там (ошибкой конфигурации, без
+    // молчаливого фолбэка). Отдельного пути вывода типов в схеме нет (#87).
     const [jt] = getManyToManyJoinTables([TestOrderEntity, TestSkuEntity]);
-    const bare = {
-      ...jt,
-      joinColumnType: undefined,
-      inverseJoinColumnType: undefined,
-    };
-    const schema = buildExpectedJoinTableSchema(bare);
+    expect(jt.joinColumnType).toBe('Int64');
+    expect(jt.inverseJoinColumnType).toBe('Utf8');
 
+    const schema = buildExpectedJoinTableSchema(jt);
     expect(schema.columns).toEqual({ order_ref: 'Int64', sku_code: 'Utf8' });
   });
 

--- a/src/schema/schema-sync.ts
+++ b/src/schema/schema-sync.ts
@@ -283,70 +283,25 @@ export function buildExpectedTableSchema(
 /**
  * Ожидаемая схема join-таблицы many-to-many.
  *
- * Типы колонок выводятся из фактических PK-метаданных обеих сущностей (#90):
- * getManyToManyJoinTables заполняет joinColumnType/inverseJoinColumnType;
- * для структур, собранных вручную без типов, они выводятся из
- * ownerEntity/inverseEntity здесь — молчаливое предположение Uuid запрещено.
+ * Имена и типы колонок берутся ровно из того определения, которое построил
+ * resolveRelationJoinTableDefinition (#90/#87): типы выводятся из
+ * фактических PK-метаданных обеих сущностей, а невыводимый тип — ошибка
+ * конфигурации в самом резолве. Отдельного пути вывода типов здесь нет:
+ * сгенерированная схема по построению совпадает с тем, что читает
+ * relations-код (см. ResolvedJoinTable в entity-relations.ts).
  */
 export function buildExpectedJoinTableSchema(
   joinTable: ManyToManyJoinTable,
 ): ExpectedTableSchema {
-  const joinColumnType =
-    joinTable.joinColumnType ??
-    joinTablePkColumnType(joinTable.ownerEntity, 'owner');
-  const inverseJoinColumnType =
-    joinTable.inverseJoinColumnType ??
-    joinTablePkColumnType(joinTable.inverseEntity, 'inverse');
-
   return {
     tableName: joinTable.tableName,
     columns: {
-      [joinTable.joinColumn]: joinColumnType,
-      [joinTable.inverseJoinColumn]: inverseJoinColumnType,
+      [joinTable.joinColumn]: joinTable.joinColumnType,
+      [joinTable.inverseJoinColumn]: joinTable.inverseJoinColumnType,
     },
     primaryKey: [joinTable.joinColumn, joinTable.inverseJoinColumn],
     indexes: [],
   };
-}
-
-/**
- * Тип PK-колонки сущности для join-таблицы (#90).
- * Ровно один PK, объявленный через @YdbPrimaryColumn; иначе — явная ошибка,
- * чтобы sync/CLI не сгенерировали схему, несовместимую с relations-кодом.
- */
-function joinTablePkColumnType(
-  entity: ManyToManyJoinTable['ownerEntity'],
-  side: 'owner' | 'inverse',
-): YdbPrimitive {
-  const meta = getYdbEntityMetadata(entity);
-  if (!meta) {
-    throw new Error(
-      `Cannot derive ${side} join-table column type: ` +
-        `${entity.name} is not decorated with @YdbEntity`,
-    );
-  }
-  if (meta.primaryKeys.length === 0) {
-    throw new Error(
-      `Cannot derive ${side} join-table column type for entity ${entity.name}: ` +
-        `no primary key is declared. Mark at least one column with @YdbPrimaryColumn.`,
-    );
-  }
-  if (meta.primaryKeys.length > 1) {
-    throw new Error(
-      `Cannot derive ${side} join-table column type for entity ${entity.name}: ` +
-        `composite primary keys (${meta.primaryKeys.join(', ')}) are not supported ` +
-        `in many-to-many relations.`,
-    );
-  }
-  const pk = meta.primaryKeys[0];
-  const type = meta.schema[pk];
-  if (!type) {
-    throw new Error(
-      `Cannot derive ${side} join-table column type for entity ${entity.name}: ` +
-        `primary key column "${pk}" is not declared via @YdbColumn.`,
-    );
-  }
-  return type;
 }
 
 /**

--- a/test/many-to-many-composite-pk-config.spec.ts
+++ b/test/many-to-many-composite-pk-config.spec.ts
@@ -1,0 +1,535 @@
+import 'reflect-metadata';
+import { Int64 } from '@ydbjs/value/primitive';
+import {
+  YdbEntity,
+  YdbColumn,
+  YdbPrimaryColumn,
+  YdbBaseEntity,
+  ManyToMany,
+  OneToMany,
+  JoinTable,
+  EagerLoad,
+} from '../src/index.js';
+import { getManyToManyJoinTables } from '../src/decorators/relation.decorators.js';
+import { buildExpectedSchemas } from '../src/schema/schema-sync.js';
+import { validateEntityMetadata } from '../src/metadata/validate-entity.js';
+import { YDB_PRIMARY_KEYS_KEY } from '../src/metadata/entity-metadata.js';
+import { createMockExecutor } from './helpers/mock-executor.js';
+
+/**
+ * Регрессионные тесты #87:
+ *  - составной PK в many-to-many отвергается детерминированно во всех путях
+ *    (схема, метаданные, eager loading, loadRelations, рантайм join-таблицы);
+ *  - невыводимый тип join-колонки — ошибка конфигурации, а не тихий фолбэк Uuid;
+ *  - селектор join-колонки валидируется строго: поддерживается ровно одна
+ *    форма (target) => target.property, остальное — понятная ошибка;
+ *  - схема и рантайм используют одно и то же резолвнутое определение
+ *    join-колонок.
+ */
+
+const COMPOSITE_PK_RE =
+  /composite primary keys[\s\S]*not supported in[\s\S]*many-to-many/;
+
+const validationCtx = {
+  encryptionProviderConfigured: true,
+  blindIndexProviderConfigured: true,
+};
+
+// ---- Составной PK на стороне владельца (#87) ----
+
+@YdbEntity('jc87_comp_tags')
+@EagerLoad(['photos'])
+class CompTag extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  tag_uuid: string;
+
+  @YdbColumn('Utf8')
+  name: string;
+
+  @ManyToMany(() => CompOwnerPhoto, (photo) => photo.tags)
+  photos?: CompOwnerPhoto[];
+}
+
+@YdbEntity('jc87_comp_photos')
+@EagerLoad(['tags'])
+class CompOwnerPhoto extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  tenant_id: string;
+
+  @YdbPrimaryColumn('Uuid')
+  photo_uuid: string;
+
+  @YdbColumn('Utf8')
+  title: string;
+
+  @ManyToMany(() => CompTag, (tag) => tag.photos)
+  @JoinTable('jc87_comp_join')
+  tags?: CompTag[];
+}
+
+// ---- Составной PK на обратной стороне (@JoinTable на владельце с одиночным PK) ----
+
+@YdbEntity('jc87_inv_rights')
+class InvRight extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  tenant_id: string;
+
+  @YdbPrimaryColumn('Int64')
+  right_id: bigint;
+
+  @ManyToMany(() => InvLeft, (left) => left.rights)
+  lefts?: InvLeft[];
+}
+
+@YdbEntity('jc87_inv_lefts')
+@EagerLoad(['rights'])
+class InvLeft extends YdbBaseEntity {
+  @YdbPrimaryColumn('Int64')
+  left_id: bigint;
+
+  @ManyToMany(() => InvRight, (right) => right.lefts)
+  @JoinTable('jc87_inv_join', {
+    joinColumn: 'left_ref',
+    inverseJoinColumn: 'right_ref',
+  })
+  rights?: InvRight[];
+}
+
+// ---- Составной PK на владельце при зеркальной декларации ----
+
+@YdbEntity('jc87_mirror_lefts')
+class MirrorLeft extends YdbBaseEntity {
+  @YdbPrimaryColumn('Int64')
+  left_id: bigint;
+
+  @ManyToMany(() => MirrorRight, (right) => right.lefts)
+  rights?: MirrorRight[];
+}
+
+@YdbEntity('jc87_mirror_rights')
+class MirrorRight extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  tenant_id: string;
+
+  @YdbPrimaryColumn('Int64')
+  right_id: bigint;
+
+  @ManyToMany(() => MirrorLeft, (left) => left.rights)
+  @JoinTable('jc87_mirror_join', {
+    joinColumn: 'right_ref',
+    inverseJoinColumn: 'left_ref',
+  })
+  lefts?: MirrorLeft[];
+}
+
+// ---- Нет первичного ключа вовсе (#87) ----
+
+@YdbEntity('jc87_nopk_b')
+class NoPkB extends YdbBaseEntity {
+  // Обычная колонка Uuid, НЕ помечена как PK: фолбэка «колонка uuid => PK» нет.
+  @YdbColumn('Uuid')
+  uuid: string;
+
+  @ManyToMany(() => NoPkA, (a) => a.bs)
+  as?: NoPkA[];
+}
+
+@YdbEntity('jc87_nopk_a')
+class NoPkA extends YdbBaseEntity {
+  @YdbColumn('Uuid')
+  uuid: string;
+
+  @ManyToMany(() => NoPkB, (b) => b.as)
+  @JoinTable('jc87_nopk_join')
+  bs?: NoPkB[];
+}
+
+// ---- Битые PK-метаданные (PK указывает на необъявленную колонку) ----
+
+@YdbEntity('jc87_ghost_b')
+class GhostPeer extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  peer_uuid: string;
+
+  @ManyToMany(() => GhostPk, (o) => o.peers)
+  owners?: GhostPk[];
+}
+
+@YdbEntity('jc87_ghost_a')
+class GhostPk extends YdbBaseEntity {
+  @YdbPrimaryColumn('Int64')
+  id: bigint;
+
+  @ManyToMany(() => GhostPeer, (p) => p.owners)
+  @JoinTable('jc87_ghost_join')
+  peers?: GhostPeer[];
+}
+
+// ---- Селекторы join-колонок (#87) ----
+
+@YdbEntity('jc87_sel_children')
+class SelChild extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @YdbColumn('Int64')
+  parent_ref: bigint;
+}
+
+@YdbEntity('jc87_sel_parents')
+class SelParent extends YdbBaseEntity {
+  @YdbPrimaryColumn('Int64')
+  id: bigint;
+
+  // Поддерживаемая форма: ровно одно чтение свойства.
+  @OneToMany(() => SelChild, (child) => child.parent_ref)
+  children?: SelChild[];
+}
+
+@YdbEntity('jc87_bad_chain')
+class BadChainSelector extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  // Цепочка свойств — не поддерживается.
+  @OneToMany(() => SelChild, (child) => child.parent.ref)
+  children?: SelChild[];
+}
+
+@YdbEntity('jc87_bad_const')
+class BadConstantSelector extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  // Раньше такой селектор молча давал строку 'parent_ref' — угадывание (#87).
+  @OneToMany(() => SelChild, () => 'parent_ref')
+  children?: SelChild[];
+}
+
+@YdbEntity('jc87_bad_call')
+class BadMethodCallSelector extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @OneToMany(() => SelChild, (child) => child.getFk())
+  children?: SelChild[];
+}
+
+@YdbEntity('jc87_no_jc_parent')
+class NoJoinColumnParent extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @OneToMany(() => SelChild, undefined as any)
+  children?: SelChild[];
+}
+
+// ---- Паритет схемы и рантайма (#87) ----
+
+@YdbEntity('jc87_parity_skus')
+class ParitySku extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  sku: string;
+
+  @ManyToMany(() => ParityOrder, (order) => order.skus)
+  orders?: ParityOrder[];
+}
+
+@YdbEntity('jc87_parity_orders')
+class ParityOrder extends YdbBaseEntity {
+  @YdbPrimaryColumn('Int64')
+  order_id: bigint;
+
+  @ManyToMany(() => ParitySku, (sku) => sku.orders)
+  @JoinTable('jc87_parity_join', {
+    joinColumn: 'order_ref',
+    inverseJoinColumn: 'sku_code',
+  })
+  skus?: ParitySku[];
+}
+
+describe('many-to-many composite PK rejection is deterministic in every path (#87)', () => {
+  let executors: Array<ReturnType<typeof createMockExecutor>> = [];
+
+  function setup(rows: any[][]) {
+    const mock = createMockExecutor(rows, { sequential: true });
+    executors.push(mock);
+    return mock;
+  }
+
+  afterEach(() => {
+    for (const Entity of [
+      CompTag,
+      CompOwnerPhoto,
+      InvRight,
+      InvLeft,
+      MirrorLeft,
+      MirrorRight,
+      NoPkB,
+      NoPkA,
+      GhostPeer,
+      GhostPk,
+      SelChild,
+      SelParent,
+      BadChainSelector,
+      BadConstantSelector,
+      BadMethodCallSelector,
+      NoJoinColumnParent,
+      ParitySku,
+      ParityOrder,
+    ]) {
+      Entity.setExecutor(undefined as any);
+    }
+    executors = [];
+  });
+
+  it('schema generation fails for composite-PK owner with a clear error naming entity and relation', () => {
+    expect(() => buildExpectedSchemas([CompOwnerPhoto, CompTag])).toThrow(
+      COMPOSITE_PK_RE,
+    );
+
+    let message = '';
+    try {
+      buildExpectedSchemas([CompOwnerPhoto, CompTag]);
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toContain('CompOwnerPhoto');
+    expect(message).toContain('tenant_id, photo_uuid');
+    expect(message).toContain('CompOwnerPhoto.tags');
+  });
+
+  it('schema generation fails for composite-PK inverse side too (both declaration sides)', () => {
+    // @JoinTable объявлена на владельце с одиночным PK...
+    expect(() => buildExpectedSchemas([InvLeft, InvRight])).toThrow(
+      /InvRight has composite primary keys \(tenant_id, right_id\)/,
+    );
+    // ...и при зеркальной декларации на самой составной стороне.
+    expect(() => buildExpectedSchemas([MirrorLeft, MirrorRight])).toThrow(
+      COMPOSITE_PK_RE,
+    );
+    expect(() => getManyToManyJoinTables([MirrorLeft, MirrorRight])).toThrow(
+      COMPOSITE_PK_RE,
+    );
+  });
+
+  it('eager loading fails on composite PK from both owner and inverse sides', async () => {
+    const ownerMock = setup([
+      [[{ tenant_id: 't1', photo_uuid: 'u1', title: 'p1' }]],
+    ]);
+    CompOwnerPhoto.setExecutor(ownerMock.executor);
+    await expect(CompOwnerPhoto.findAll()).rejects.toThrow(COMPOSITE_PK_RE);
+    // Запрос к join-таблице не выполняется: отказ происходит при резолве.
+    expect(ownerMock.queries).toHaveLength(1);
+
+    const inverseMock = setup([[[{ tag_uuid: 'tag1', name: 'n' }]]]);
+    CompTag.setExecutor(inverseMock.executor);
+    await expect(CompTag.findAll()).rejects.toThrow(COMPOSITE_PK_RE);
+    expect(inverseMock.queries).toHaveLength(1);
+  });
+
+  it('loadRelations() fails on composite PK identically to eager loading', async () => {
+    const photo = new CompOwnerPhoto();
+    photo.tenant_id = 't1';
+    photo.photo_uuid = '11111111-2222-4333-8444-555555555555';
+
+    // Eager: сущность реально загружена, поэтому резолв связки вызывается.
+    CompOwnerPhoto.setExecutor(
+      setup([[[{ tenant_id: 't1', photo_uuid: 'u1', title: 'p1' }]]]).executor,
+    );
+    let eagerMessage = '';
+    try {
+      await CompOwnerPhoto.findAll();
+    } catch (err) {
+      eagerMessage = (err as Error).message;
+    }
+
+    CompOwnerPhoto.setExecutor(setup([[[]]]).executor);
+    let loadMessage = '';
+    try {
+      await photo.loadRelations(['tags']);
+    } catch (err) {
+      loadMessage = (err as Error).message;
+    }
+
+    // Один и тот же резолвер → одно и то же сообщение об ошибке.
+    expect(eagerMessage).toMatch(COMPOSITE_PK_RE);
+    expect(loadMessage).toBe(eagerMessage);
+  });
+
+  it('composite-PK rejection surfaces as a validation issue at module init', () => {
+    const ownerIssues = validateEntityMetadata(CompOwnerPhoto, validationCtx);
+    expect(ownerIssues.some((i) => COMPOSITE_PK_RE.test(i))).toBe(true);
+
+    // Валидация обратной стороны находит ту же проблему через декларацию владельца.
+    const rightIssues = validateEntityMetadata(InvRight, validationCtx);
+    expect(rightIssues.some((i) => COMPOSITE_PK_RE.test(i))).toBe(true);
+    expect(rightIssues.some((i) => i.includes('InvRight'))).toBe(true);
+  });
+});
+
+describe('no silent Uuid fallback for join-column types (#87)', () => {
+  afterEach(() => {
+    NoPkA.setExecutor(undefined as any);
+  });
+
+  it('entity without any primary key fails everywhere instead of assuming Uuid', async () => {
+    expect(() => getManyToManyJoinTables([NoPkA, NoPkB])).toThrow(
+      /NoPkA declares no primary key/,
+    );
+
+    // Ни схема, ни рантайм не порождают таблицу с молчаливыми Uuid-колонками.
+    // Схема сущности падает раньше join-таблицы — тоже без фолбэка.
+    expect(() => buildExpectedSchemas([NoPkA, NoPkB])).toThrow(
+      /no primary key is declared/,
+    );
+
+    NoPkA.setExecutor(createMockExecutor([[[]]]).executor);
+    const a = new NoPkA();
+    a.uuid = '11111111-2222-4333-8444-555555555555';
+
+    // Рантайм падает на первом же guard'e (getPrimaryKey или резолв join-таблицы):
+    // в любом случае это явная ошибка конфигурации, а не молчаливый Uuid.
+    let runtimeMessage = '';
+    try {
+      await a.loadRelations(['bs']);
+    } catch (err) {
+      runtimeMessage = (err as Error).message;
+    }
+    expect(runtimeMessage).toContain('NoPkA');
+    expect(runtimeMessage.toLowerCase()).toContain('primary key');
+    expect(runtimeMessage).not.toMatch(/\bUuid\b/);
+  });
+
+  it('PK metadata pointing to an undeclared column names the PK, never falls back to Uuid', () => {
+    Reflect.defineMetadata(YDB_PRIMARY_KEYS_KEY, ['ghost_id'], GhostPk);
+
+    let message = '';
+    try {
+      getManyToManyJoinTables([GhostPk, GhostPeer]);
+    } catch (err) {
+      message = (err as Error).message;
+    }
+
+    expect(message).toContain('ghost_id');
+    expect(message).toContain('GhostPk');
+    expect(message).toContain('there is no implicit fallback');
+    // Никакого «подставим Uuid» в ошибке и в построенной схеме нет.
+    expect(message).not.toMatch(/\bUuid\b/);
+    expect(() => buildExpectedSchemas([GhostPk, GhostPeer])).toThrow(
+      /ghost_id/,
+    );
+  });
+});
+
+describe('join-column selector resolution is strict (#87)', () => {
+  afterEach(() => {
+    for (const Entity of [
+      SelParent,
+      BadChainSelector,
+      BadConstantSelector,
+      BadMethodCallSelector,
+      NoJoinColumnParent,
+    ]) {
+      Entity.setExecutor(undefined as any);
+    }
+  });
+
+  it('supported selector (target) => target.property resolves the correct column at runtime', async () => {
+    const childRow = { uuid: 'c1', parent_ref: 7n };
+    const mock = createMockExecutor([[[childRow]]], { sequential: true });
+    SelParent.setExecutor(mock.executor);
+
+    const parent = new SelParent();
+    parent.id = 7n;
+    await parent.loadRelations(['children']);
+
+    expect(mock.queries[0].sql).toContain('`parent_ref` = $parent_ref');
+    expect(mock.queries[0].params.parent_ref).toBeInstanceOf(Int64);
+    expect(parent.children?.map((c) => c.uuid)).toEqual(['c1']);
+  });
+
+  it('unsupported selectors fail validation and runtime instead of producing a guessed name', async () => {
+    const cases: Array<[typeof YdbBaseEntity, RegExp]> = [
+      [BadChainSelector, /unsupported selector form \(target\.parent\.ref\)/],
+      // Раньше константный селектор молча проходил со строкой 'parent_ref'.
+      [BadConstantSelector, /target argument was not used/],
+      [BadMethodCallSelector, /only direct property access is supported/],
+    ];
+
+    for (const [Entity, re] of cases) {
+      const issues = validateEntityMetadata(Entity, validationCtx);
+      const hasIssue = issues.some((i) =>
+        i.includes('Invalid join column selector'),
+      );
+      if (!hasIssue) {
+        throw new Error(
+          `${Entity.name}: expected a validation issue, got: ${JSON.stringify(issues)}`,
+        );
+      }
+
+      Entity.setExecutor(createMockExecutor([[[]]]).executor);
+      const instance = new (Entity as any)();
+      instance.uuid = '11111111-2222-4333-8444-555555555555';
+      await expect(instance.loadRelations(['children'])).rejects.toThrow(re);
+      await expect(instance.loadRelations(['children'])).rejects.toThrow(
+        /Invalid join column selector for relation "children"/,
+      );
+    }
+  });
+
+  it('missing join column declaration fails with a configuration error, not undefined', async () => {
+    NoJoinColumnParent.setExecutor(createMockExecutor([[[]]]).executor);
+
+    const issues = validateEntityMetadata(NoJoinColumnParent, validationCtx);
+    expect(issues.some((i) => i.includes('Join column is required'))).toBe(
+      true,
+    );
+
+    const instance = new NoJoinColumnParent();
+    instance.uuid = '11111111-2222-4333-8444-555555555555';
+    await expect(instance.loadRelations(['children'])).rejects.toThrow(
+      /Join column is required for relation "children" on NoJoinColumnParent/,
+    );
+  });
+});
+
+describe('schema and runtime use the same join-column resolution (#87)', () => {
+  afterEach(() => {
+    ParityOrder.setExecutor(undefined as any);
+  });
+
+  it('runtime SELECT reads exactly the columns of the generated schema with exact types', async () => {
+    const [def] = getManyToManyJoinTables([ParityOrder, ParitySku]);
+    const expected = buildExpectedSchemas([ParityOrder, ParitySku]).find(
+      (s) => s.tableName === 'jc87_parity_join',
+    )!;
+
+    // Сгенерированная схема построена из того же определения.
+    expect(expected.columns).toEqual({
+      order_ref: 'Int64',
+      sku_code: 'Utf8',
+    });
+    expect(expected.primaryKey).toEqual(['order_ref', 'sku_code']);
+    expect(def.joinColumnType).toBe('Int64');
+    expect(def.inverseJoinColumnType).toBe('Utf8');
+
+    // Рантайм читает ровно эти колонки и биндит параметры по типу PK владельца.
+    // Запросов два: выборка связей из join-таблицы и дозагрузка Sku по PK.
+    const mock = createMockExecutor(
+      [[[{ order_ref: 10n, sku_code: 'a1' }]], [[{ sku: 'a1' }]]],
+      { sequential: true },
+    );
+    ParityOrder.setExecutor(mock.executor);
+
+    const order = new ParityOrder();
+    order.order_id = 10n;
+    await order.loadRelations(['skus']);
+
+    expect(mock.queries[0].sql).toBe(
+      'SELECT `order_ref`, `sku_code` FROM `jc87_parity_join` WHERE `order_ref` IN ($p0)',
+    );
+    expect(mock.queries[0].params.p0).toBeInstanceOf(Int64);
+    expect(order.skus?.map((s) => s.sku)).toEqual(['a1']);
+  });
+});


### PR DESCRIPTION
## Проблема

Fixes #87

Many-to-many при составном PK владельца или обратной стороны вёл себя недетерминированно: часть путей падала, часть молча подставляла тип `Uuid` для join-колонок. Proxy-резолвер селекторов join-колонок возвращал мусор на нетривиальных селекторах (`(x) => x.user.uuid`), а константные селекторы (`() => 'col'`) молча проходили.

## Решение

- **Единый источник истины**: `resolveRelationJoinTableDefinition` (src/decorators/relation.decorators.ts) — её результат используют и schema sync (`buildExpectedJoinTableSchema`), и рантайм (`resolveManyToManyJoinTable`). Дублирующий вывод типов в schema-sync удалён.
- **Никаких фолбэков**: необязательные `joinColumnType`/`inverseJoinColumnType` в `@JoinTable` стали обязательными; все ветки «не смогли вывести — возьмём Uuid» заменены на ошибку конфигурации с указанием сущности, PK и связи.
- **Составной PK** отвергается детерминированно во всех путях: генерация схемы, резолв метаданных, eager loading, `loadRelations()`, валидация при старте модуля. Частичная поддержка не добавлялась (вне скоупа #87).
- **Строгий резолв селекторов** (`resolveRelationJoinColumn`, экспортирован из пакета): поддерживается ровно одна форма `(target) => target.property`; цепочки, вызовы методов, константы и неиспользование `target` — понятная ошибка.
- **Валидация при module init**: невалидные селекторы и ошибки конфигурации m2m всплывают как issues `validateEntityMetadata` → понятный фейл при старте, а не в рантайме.

## Тесты

- Новый спек `test/many-to-many-composite-pk-config.spec.ts` (11 тестов) закрывает все 6 пунктов регрессии из чеклиста issue.
- Обновлён `schema-sync.spec.ts`: тест на вывод типов из структуры (#90) заменён на проверку паритета #87 (явные типы обязательны).

## Проверка

- `yarn test` — 52 suites / 770 tests ✅
- `yarn build` ✅
- `yarn lint` — 0 errors (предупреждений не больше базовой линии) ✅