### PR TITLE
feat(module): кастомный CredentialsProvider в опциях модуля; экспорт YDB_CREDENTIALS_PROVIDER (#96)

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,42 @@ YdbCoreModule.forRootAsync({
 - `auth_key` — authorized key JSON сервисного аккаунта (`authOptions.authorized_key_path`); JWT-обмен реализован на `fetch`, без тяжёлых SDK;
 - `anonymous` — локальная YDB.
 
+### Кастомный CredentialsProvider
+
+Готовый провайдер можно передать напрямую — опция `credentialsProvider`
+(тип `CredentialsProvider` из `@ydbjs/auth`, реэкспортирован из пакета):
+
+```ts
+import { CredentialsProvider } from '@ycforge/ydb-orm';
+
+class OAuthTokenProvider extends CredentialsProvider {
+  getToken(): Promise<string> {
+    return fetchOAuthToken(); // ваша реализация получения токена
+  }
+}
+
+YdbCoreModule.forRootAsync({
+  useFactory: () => ({
+    endpoint: process.env.YDB_ENDPOINT!,
+    authOptions: {},
+    credentialsProvider: new OAuthTokenProvider(),
+  }),
+});
+```
+
+Провайдер также доступен для инжекции через DI-токен `YDB_CREDENTIALS_PROVIDER`
+(экспортируется ядром). Приоритет источников провайдера детерминирован:
+
+1. `credentialsProvider` — явная опция модуля;
+2. DI-провайдер `YDB_CREDENTIALS_PROVIDER`;
+3. `driverOptions.credentialsProvider`;
+4. создание по `auth_type`.
+
+Задание одновременно `credentialsProvider` и `driverOptions.credentialsProvider`
+— ошибка конфигурации (`Conflicting YDB credentials configuration`): молчаливый
+выбор одного из них не выполняется. Без кастомного провайдера поведение
+по умолчанию (`meta` / `auth_key` / `anonymous`) не меняется.
+
 ## Разработка
 
 ```bash

--- a/src/core/driver.spec.ts
+++ b/src/core/driver.spec.ts
@@ -1,0 +1,194 @@
+import 'reflect-metadata';
+import { beforeAll, describe, expect, it, jest } from '@jest/globals';
+import { CredentialsProvider } from '@ydbjs/auth';
+import { AnonymousCredentialsProvider } from '@ydbjs/auth/anonymous';
+import { MetadataCredentialsProvider } from '@ydbjs/auth/metadata';
+import type { YdbModuleOptions } from './interfaces.js';
+
+/**
+ * Спеки ядра подключения (#96): приоритет источников CredentialsProvider,
+ * конфликт конфигурации и неизменное поведение по умолчанию.
+ *
+ * Модуль @ydbjs/core подменяется заглушкой ДО первого импорта ./driver.js
+ * (динамический импорт после jest.unstable_mockModule), чтобы createDriver
+ * можно было вызвать без сети и проверить, какой провайдер дошёл до
+ * конструктора Driver.
+ */
+
+/** Заглушка провайдера с маркером: по значению видно, кто разрешён. */
+function makeProvider(tag: string): CredentialsProvider {
+  return {
+    getToken: () => Promise.resolve(`token:${tag}`),
+  } as unknown as CredentialsProvider;
+}
+
+const BASE_OPTIONS: YdbModuleOptions = {
+  endpoint: 'grpc://localhost:2136/local',
+  auth_type: 'anonymous',
+  authOptions: {},
+};
+
+class StubDriver {
+  static calls: Array<{ endpoint: string; options: Record<string, any> }> = [];
+  constructor(cs: string, options: Record<string, any>) {
+    StubDriver.calls.push({ endpoint: cs, options });
+  }
+  async ready(): Promise<void> {}
+
+  close(): any {}
+}
+
+type DriverModule = typeof import('./driver.js');
+let mod: DriverModule;
+
+beforeAll(async () => {
+  StubDriver.calls = [];
+  jest.unstable_mockModule('@ydbjs/core', () => ({ Driver: StubDriver }));
+  mod = await import('./driver.js');
+});
+
+describe('resolveCredentialsProvider (#96)', () => {
+  it('явный opts.credentialsProvider используется как есть', () => {
+    const custom = makeProvider('custom');
+    const resolved = mod.resolveCredentialsProvider({
+      ...BASE_OPTIONS,
+      credentialsProvider: custom,
+    });
+
+    expect(resolved).toBe(custom);
+  });
+
+  it('injected (DI) используется при отсутствии явного провайдера', () => {
+    const injected = makeProvider('injected');
+    const resolved = mod.resolveCredentialsProvider(BASE_OPTIONS, injected);
+
+    expect(resolved).toBe(injected);
+  });
+
+  it('driverOptions.credentialsProvider используется без явных источников', () => {
+    const lowLevel = makeProvider('low-level');
+    const resolved = mod.resolveCredentialsProvider({
+      ...BASE_OPTIONS,
+      driverOptions: { credentialsProvider: lowLevel },
+    });
+
+    expect(resolved).toBe(lowLevel);
+  });
+
+  it('конфликт credentialsProvider и driverOptions.credentialsProvider — ошибка', () => {
+    const custom = makeProvider('custom');
+    const lowLevel = makeProvider('low-level');
+
+    expect(() =>
+      mod.resolveCredentialsProvider({
+        ...BASE_OPTIONS,
+        credentialsProvider: custom,
+        driverOptions: { credentialsProvider: lowLevel },
+      }),
+    ).toThrow(
+      /Conflicting YDB credentials configuration[\s\S]*"credentialsProvider"[\s\S]*"driverOptions.credentialsProvider"/,
+    );
+  });
+
+  it('поведение по умолчанию не изменилось: meta → MetadataCredentialsProvider', () => {
+    const resolved = mod.resolveCredentialsProvider({
+      ...BASE_OPTIONS,
+      auth_type: 'meta',
+    });
+    expect(resolved).toBeInstanceOf(MetadataCredentialsProvider);
+  });
+
+  it('поведение по умолчанию не изменилось: anonymous → AnonymousCredentialsProvider', () => {
+    const resolved = mod.resolveCredentialsProvider(BASE_OPTIONS);
+    expect(resolved).toBeInstanceOf(AnonymousCredentialsProvider);
+  });
+
+  it('поведение по умолчанию не изменилось: невалидный auth_type — понятная ошибка', () => {
+    expect(() =>
+      mod.resolveCredentialsProvider({
+        ...BASE_OPTIONS,
+        auth_type: 'oauth' as never,
+      }),
+    ).toThrow(/Invalid YDB auth type/);
+  });
+
+  it('поведение по умолчанию не изменилось: auth_key требует authorized_key_path', () => {
+    expect(() =>
+      mod.resolveCredentialsProvider({
+        ...BASE_OPTIONS,
+        auth_type: 'auth_key',
+        authOptions: {},
+      }),
+    ).toThrow(/authorized_key_path.*is required/);
+  });
+});
+
+describe('validateYdbModuleOptions (#96)', () => {
+  it('fail-fast на конфликт источников провайдера ещё до создания драйвера', () => {
+    expect(() =>
+      mod.validateYdbModuleOptions({
+        ...BASE_OPTIONS,
+        credentialsProvider: makeProvider('custom'),
+        driverOptions: { credentialsProvider: makeProvider('low-level') },
+      }),
+    ).toThrow(/Conflicting YDB credentials configuration/);
+  });
+});
+
+describe('createDriver (#96): провайдер доходит до Driver', () => {
+  it('явный opts.credentialsProvider передаётся в конструктор драйвера', async () => {
+    const custom = makeProvider('custom');
+
+    await mod.createDriver({
+      ...BASE_OPTIONS,
+      credentialsProvider: custom,
+    });
+
+    const call = StubDriver.calls.at(-1)!;
+    expect(call.options.credentialsProvider).toBe(custom);
+  });
+
+  it('аргумент createDriver() (путь NestJS DI) доходит до драйвера', async () => {
+    const injected = makeProvider('injected');
+
+    await mod.createDriver(BASE_OPTIONS, injected);
+
+    const call = StubDriver.calls.at(-1)!;
+    expect(call.options.credentialsProvider).toBe(injected);
+  });
+
+  it('без кастомных источников создаётся провайдер по auth_type', async () => {
+    await mod.createDriver(BASE_OPTIONS);
+
+    const call = StubDriver.calls.at(-1)!;
+    expect(call.options.credentialsProvider).toBeInstanceOf(
+      AnonymousCredentialsProvider,
+    );
+  });
+
+  it('конфликт ловится fail-fast: молчаливой подмены явного провайдера нет', async () => {
+    const custom = makeProvider('custom');
+
+    await expect(
+      mod.createDriver({
+        ...BASE_OPTIONS,
+        credentialsProvider: custom,
+        driverOptions: { credentialsProvider: makeProvider('low-level') },
+      }),
+    ).rejects.toThrow(/Conflicting YDB credentials configuration/);
+  });
+
+  it('остальные driverOptions сохраняются вместе с разрешённым провайдером', async () => {
+    const custom = makeProvider('custom');
+
+    await mod.createDriver({
+      ...BASE_OPTIONS,
+      credentialsProvider: custom,
+      driverOptions: { 'ydb.sdk.ready_timeout_ms': 1234 },
+    });
+
+    const options = StubDriver.calls.at(-1)!.options;
+    expect(options['ydb.sdk.ready_timeout_ms']).toBe(1234);
+    expect(options.credentialsProvider).toBe(custom);
+  });
+});

--- a/src/core/driver.ts
+++ b/src/core/driver.ts
@@ -30,6 +30,51 @@ export function validateYdbModuleOptions(opts: YdbModuleOptions): void {
         'when auth_type is "auth_key".',
     );
   }
+  assertNoCredentialsProviderConflict(opts);
+}
+
+/**
+ * Конфликт источников CredentialsProvider (#96): если заданы и явный
+ * credentialsProvider, и низкоуровневый driverOptions.credentialsProvider,
+ * приоритет не выбирается молча — это ошибка конфигурации.
+ */
+function assertNoCredentialsProviderConflict(opts: YdbModuleOptions): void {
+  if (
+    opts.credentialsProvider !== undefined &&
+    opts.driverOptions?.credentialsProvider !== undefined
+  ) {
+    throw new Error(
+      'Conflicting YDB credentials configuration: both "credentialsProvider" ' +
+        'and "driverOptions.credentialsProvider" are set. Keep only one source: ' +
+        'either pass the provider via the top-level "credentialsProvider" option ' +
+        'or remove it from "driverOptions".',
+    );
+  }
+}
+
+/**
+ * Разрешает итоговый CredentialsProvider по детерминированному приоритету (#96):
+ *
+ *   1. opts.credentialsProvider — явный провайдер из опций модуля;
+ *   2. injected — провайдер, пришедший из DI (YDB_CREDENTIALS_PROVIDER) или
+ *      переданный аргументом в createDriver();
+ *   3. opts.driverOptions.credentialsProvider — низкоуровневая опция драйвера;
+ *   4. создание по auth_type (createCredentialsProvider).
+ *
+ * Комбинация (1) + (3) запрещена — ошибка конфигурации, а не молчаливый
+ * выбор. Используется NestJS-модулем, createDriver() и CLI.
+ */
+export function resolveCredentialsProvider(
+  opts: YdbModuleOptions,
+  injected?: CredentialsProvider,
+): CredentialsProvider {
+  assertNoCredentialsProviderConflict(opts);
+  return (
+    opts.credentialsProvider ??
+    injected ??
+    opts.driverOptions?.credentialsProvider ??
+    createCredentialsProvider(opts)
+  );
 }
 
 /**
@@ -68,9 +113,18 @@ export async function createDriver(
   credentialsProvider?: CredentialsProvider,
 ): Promise<Driver> {
   validateYdbModuleOptions(opts);
+  // Провайдер разрешается по единому правилу приоритета (#96) и передаётся
+  // ПОСЛЕ spread driverOptions: driverOptions.credentialsProvider не может
+  // молча перезатереть уже разрешённый провайдер.
+  const resolvedProvider = resolveCredentialsProvider(
+    opts,
+    credentialsProvider,
+  );
+  const { credentialsProvider: _driverOptionsProvider, ...restDriverOptions } =
+    opts.driverOptions ?? {};
   const driver = new Driver(opts.endpoint, {
-    credentialsProvider: credentialsProvider ?? createCredentialsProvider(opts),
-    ...opts.driverOptions,
+    ...restDriverOptions,
+    credentialsProvider: resolvedProvider,
   });
   await driver.ready();
   return driver;

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -1,5 +1,6 @@
 import { ModuleMetadata, Type } from '@nestjs/common';
 import { Driver, DriverOptions } from '@ydbjs/core';
+import type { CredentialsProvider } from '@ydbjs/auth';
 import {
   YdbBlindIndexProvider,
   YdbEncryptionProvider,
@@ -20,6 +21,21 @@ export interface YdbModuleOptions {
   endpoint: string;
   auth_type?: YdbAuthMethod;
   authOptions: YdbAuthOptions;
+  /**
+   * Готовый CredentialsProvider (#96) — паттерн useExisting: передаётся
+   * как есть вместо создания провайдера по auth_type (OAuth-токен,
+   * тестовые реализации, переиспользование провайдера из другого модуля).
+   * Динамическое создание — через useFactory в forRootAsync.
+   *
+   * Приоритет источников провайдера (детерминированный, см.
+   * resolveCredentialsProvider):
+   *   credentialsProvider → DI-провайдер YDB_CREDENTIALS_PROVIDER →
+   *   driverOptions.credentialsProvider → создание по auth_type.
+   * Задание одновременно credentialsProvider и
+   * driverOptions.credentialsProvider — ошибка конфигурации:
+   * молчаливый выбор одного из них запрещён.
+   */
+  credentialsProvider?: CredentialsProvider;
   /**
    * Кастомная фабрика драйвера: если задана, используется вместо создания
    * Driver по endpoint/driverOptions. Удобно для тестов и нестандартных

--- a/src/index.ts
+++ b/src/index.ts
@@ -229,6 +229,7 @@ export type { PlannedMigration } from './migrations/migration-generator.js';
 // Подключение без NestJS (CLI, скрипты)
 export {
   createCredentialsProvider,
+  resolveCredentialsProvider,
   createDriver,
   createExecutor,
   validateYdbModuleOptions,
@@ -242,3 +243,7 @@ export type {
   AuthKeyCredentialsProviderOptions,
   IamJWTKeyCredentials,
 } from './credentials/auth-key-credentials-provider.js';
+// Базовый класс провайдера учётных данных из SDK (#96): тип реэкспортируется,
+// чтобы пользователи могли типизировать свои реализации без прямой
+// зависимости от @ydbjs/auth.
+export type { CredentialsProvider } from '@ydbjs/auth';

--- a/src/module/ydb-core.module.ts
+++ b/src/module/ydb-core.module.ts
@@ -9,9 +9,9 @@ import {
 } from '@nestjs/common';
 import { Driver } from '@ydbjs/core';
 import {
-  createCredentialsProvider,
   createDriver,
   createExecutor,
+  resolveCredentialsProvider,
   validateYdbModuleOptions,
 } from '../core/driver.js';
 import {
@@ -152,10 +152,13 @@ export class YdbCoreModule {
         },
 
         {
+          // Провайдер учётных данных (#96): явный opts.credentialsProvider
+          // используется как есть; иначе driverOptions.credentialsProvider;
+          // иначе создаётся по auth_type (meta/auth_key/anonymous).
           provide: YDB_CREDENTIALS_PROVIDER,
           useFactory: (opts: YdbModuleOptions) => {
             try {
-              return createCredentialsProvider(opts);
+              return resolveCredentialsProvider(opts);
             } catch (error) {
               // Компиляция упала после claim — освобождаем слот,
               // чтобы следующий бутстрап в этом процессе был возможен.
@@ -250,6 +253,7 @@ export class YdbCoreModule {
         YDB_DRIVER,
         YDB_QUERY,
         YdbTransactionManager,
+        YDB_CREDENTIALS_PROVIDER,
         YDB_ENCRYPTION_PROVIDER,
         YDB_BLIND_INDEX_PROVIDER,
         YDB_VALIDATION_PROVIDER,

--- a/test/nestjs/credentials-provider.spec.ts
+++ b/test/nestjs/credentials-provider.spec.ts
@@ -1,0 +1,181 @@
+import 'reflect-metadata';
+import { Test } from '@nestjs/testing';
+import { Module } from '@nestjs/common';
+import { CredentialsProvider } from '@ydbjs/auth';
+import { AnonymousCredentialsProvider } from '@ydbjs/auth/anonymous';
+import {
+  YdbCoreModule,
+  YDB_CREDENTIALS_PROVIDER,
+  YDB_DRIVER,
+  YDB_QUERY,
+  type YdbModuleOptions,
+  type YdbOptionsFactory,
+} from '../../src/index.js';
+import type { TestingModule } from '@nestjs/testing';
+import { createMockExecutor } from '../helpers/mock-executor.js';
+
+/**
+ * Регрессионные тесты #96: кастомный CredentialsProvider в опциях модуля.
+ *
+ * Сеть не используется: драйвер и executor подменяются через overrideProvider.
+ * Тот факт, что провайдер доходит до createDriver, покрывается юнит-спекой
+ * src/core/driver.spec.ts (заглушка Driver фиксирует аргументы конструктора);
+ * здесь проверяется DI-обвязка модуля: токен YDB_CREDENTIALS_PROVIDER
+ * разрешается ровно в настроенный провайдер — именно он инжектируется
+ * фабрикой YDB_DRIVER в createDriver().
+ */
+
+/** Тестовая реализация провайдера с маркером. */
+class TaggedCredentialsProvider extends CredentialsProvider {
+  constructor(private readonly tag: string) {
+    super();
+  }
+  getToken(): Promise<string> {
+    return Promise.resolve(`token:${this.tag}`);
+  }
+}
+
+/** useExisting-паттерн: готовая конфигурация, отдающая опции модуля. */
+class TaggedCredentialsConfig implements YdbOptionsFactory {
+  constructor(private readonly provider: CredentialsProvider) {}
+  createYdbOptions(): YdbModuleOptions {
+    return {
+      endpoint: 'grpc://localhost:2136/local',
+      auth_type: 'anonymous',
+      authOptions: {},
+      credentialsProvider: this.provider,
+      sync: false,
+    };
+  }
+}
+
+@Module({
+  providers: [TaggedCredentialsConfig],
+  exports: [TaggedCredentialsConfig],
+})
+class ConfigHolderModule {}
+
+async function bootstrapWithOptions(
+  options: Partial<YdbModuleOptions>,
+): Promise<{ moduleRef: TestingModule; close: () => Promise<void> }> {
+  const moduleRef = await Test.createTestingModule({
+    imports: [
+      YdbCoreModule.forRootAsync({
+        useFactory: () => ({
+          endpoint: 'grpc://localhost:2136/local',
+          auth_type: 'anonymous' as const,
+          authOptions: {},
+          sync: false as const,
+          ...options,
+        }),
+      }),
+    ],
+  })
+    .overrideProvider(YDB_DRIVER)
+    .useValue({})
+    .overrideProvider(YDB_QUERY)
+    .useValue(createMockExecutor().executor)
+    .compile();
+
+  return { moduleRef, close: () => moduleRef.close() };
+}
+
+async function bootstrapUseExisting(
+  provider: CredentialsProvider,
+): Promise<{ moduleRef: TestingModule; close: () => Promise<void> }> {
+  const config = new TaggedCredentialsConfig(provider);
+  const moduleRef = await Test.createTestingModule({
+    imports: [
+      // Класс-фабрика предоставляется своим модулем (паттерн useExisting):
+      // ядро инжектирует уже существующий экземпляр и вызывает createYdbOptions().
+      // Модуль с классом-фабрикой передаётся в imports ядра, чтобы
+      // TaggedCredentialsConfig был виден провайдерам YdbCoreModule.
+      YdbCoreModule.forRootAsync({
+        useExisting: TaggedCredentialsConfig,
+        imports: [ConfigHolderModule],
+      }),
+    ],
+  })
+    .overrideProvider(TaggedCredentialsConfig)
+    .useValue(config)
+    .overrideProvider(YDB_DRIVER)
+    .useValue({})
+    .overrideProvider(YDB_QUERY)
+    .useValue(createMockExecutor().executor)
+    .compile();
+
+  return { moduleRef, close: () => moduleRef.close() };
+}
+
+describe('NestJS integration: кастомный CredentialsProvider (#96)', () => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    await cleanup?.();
+    cleanup = undefined;
+  });
+
+  it('useFactory: кастомный провайдер резолвится из токена YDB_CREDENTIALS_PROVIDER', async () => {
+    const custom = new TaggedCredentialsProvider('factory');
+    const boot = await bootstrapWithOptions({ credentialsProvider: custom });
+    cleanup = boot.close;
+
+    expect(boot.moduleRef.get(YDB_CREDENTIALS_PROVIDER)).toBe(custom);
+  });
+
+  it('useExisting: провайдер из готовой конфигурации попадает в DI', async () => {
+    const custom = new TaggedCredentialsProvider('existing');
+    const boot = await bootstrapUseExisting(custom);
+    cleanup = boot.close;
+
+    expect(boot.moduleRef.get(YDB_CREDENTIALS_PROVIDER)).toBe(custom);
+  });
+
+  it('конфликт credentialsProvider и driverOptions.credentialsProvider — понятная ошибка компиляции', async () => {
+    await expect(
+      bootstrapWithOptions({
+        credentialsProvider: new TaggedCredentialsProvider('custom'),
+        driverOptions: {
+          credentialsProvider: new TaggedCredentialsProvider('low-level'),
+        },
+      }),
+    ).rejects.toThrow(/Conflicting YDB credentials configuration/);
+  });
+
+  it('без кастомного провайдера поведение по умолчанию не изменилось (auth_type=anonymous)', async () => {
+    const boot = await bootstrapWithOptions({});
+    cleanup = boot.close;
+
+    expect(boot.moduleRef.get(YDB_CREDENTIALS_PROVIDER)).toBeInstanceOf(
+      AnonymousCredentialsProvider,
+    );
+  });
+
+  it('повторный бутстрап подменяет провайдер; сброс возвращает дефолт по auth_type', async () => {
+    const first = new TaggedCredentialsProvider('A');
+    const firstBoot = await bootstrapWithOptions({
+      credentialsProvider: first,
+    });
+    cleanup = firstBoot.close;
+    expect(firstBoot.moduleRef.get(YDB_CREDENTIALS_PROVIDER)).toBe(first);
+    await firstBoot.close();
+
+    const second = new TaggedCredentialsProvider('B');
+    const secondBoot = await bootstrapWithOptions({
+      credentialsProvider: second,
+    });
+    cleanup = secondBoot.close;
+    // Провайдер прошлого бутстрапа не «протекает»: токен указывает на новый.
+    expect(secondBoot.moduleRef.get(YDB_CREDENTIALS_PROVIDER)).toBe(second);
+    await secondBoot.close();
+
+    // Бутстрап без кастомного провайдера: свежий дефолт по auth_type,
+    // а не оставшийся экземпляр прошлой конфигурации (#108/#95).
+    const defaultBoot = await bootstrapWithOptions({});
+    cleanup = defaultBoot.close;
+    const resolved = defaultBoot.moduleRef.get(YDB_CREDENTIALS_PROVIDER);
+    expect(resolved).not.toBe(first);
+    expect(resolved).not.toBe(second);
+    expect(resolved).toBeInstanceOf(AnonymousCredentialsProvider);
+  });
+});


### PR DESCRIPTION
## Что сделано

Реализация #96 — кастомный `CredentialsProvider` в опциях модуля.

### Изменения

- **`YdbModuleOptions.credentialsProvider`** (`src/core/interfaces.ts`) — готовый провайдер передаётся как есть (паттерн useExisting, как у `encryptionProvider`/`validationProvider`); динамическое создание — через `useFactory`/`useClass`/`useExisting` в `forRootAsync`.
- **`resolveCredentialsProvider(opts, injected?)`** (`src/core/driver.ts`) — единая детерминированная точка разрешения провайдера, используется NestJS-модулем, `createDriver()` и CLI:
  1. `opts.credentialsProvider` (явная опция);
  2. DI-провайдер / аргумент `createDriver()`;
  3. `driverOptions.credentialsProvider`;
  4. создание по `auth_type` (`meta` | `auth_key` | `anonymous`).
- **Конфликт валидируется, а не разрешается молча**: одновременное задание `credentialsProvider` и `driverOptions.credentialsProvider` — ошибка `Conflicting YDB credentials configuration` (fail-fast в `validateYdbModuleOptions`, т.е. ещё до claim слота и создания драйвера). Дополнительно в `createDriver()` резолвнутый провайдер передаётся после spread `driverOptions` — низкоуровневая опция не может молча перезатереть явный провайдер.
- **`YDB_CREDENTIALS_PROVIDER` включён в `exports` ядра** (`ydb-core.module.ts`) — токен был экспортирован из `index.ts`, но инжектировать его было нельзя.
- **`export type { CredentialsProvider }` из публичного API** — тип SDK реэкспортирован, чтобы типизировать свои реализации без прямой зависимости от `@ydbjs/auth`.
- Поведение по умолчанию (`auth_type` + key-file/meta/anonymous, ошибка `Invalid YDB auth type`) не изменено. Семантика повторного бутстрапа — как у остальных опциональных провайдеров (#108/#95): фабрики создаются в замыкании каждого `forRootAsync`, провайдер подменяется новым, а бутстрап без кастомного провайдера даёт свежий дефолт по `auth_type`.

### Тесты

- `src/core/driver.spec.ts` (14 юнит-тестов): приоритет всех источников, конфликт, дефолты по `auth_type`; через заглушку `@ydbjs/core` проверено, что разрешённый провайдер реально доходит до конструктора `Driver`.
- `test/nestjs/credentials-provider.spec.ts` (5 интеграционных): `useFactory`, `useExisting` (через `imports` ядра), конфликт → понятная ошибка компиляции, неизменный дефолт, повторный бутстрап (подмена + сброс).

### Проверка

- `yarn build` ✅
- `yarn test` ✅ 56 suites / 833 tests
- `yarn lint` ✅ 0 errors (129 предупреждений — все существовавшие до ветки)
- README: раздел «Аутентификация» дополнен документацией опции и правила приоритета.

Closes #96