### PR TITLE
perf(relations): батчинг loadRelations(), чанкинг и guard-ы IN(...) (#86)

### DIFF
--- a/src/core/query-limits.ts
+++ b/src/core/query-limits.ts
@@ -1,0 +1,51 @@
+/**
+ * Лимиты батч-запросов (#86): единая точка определения размера чанка
+ * для IN (...) списков — используется persistence (fetchByColumnIn)
+ * и relations (join-таблицы many-to-many, eager/loading связей).
+ */
+
+/**
+ * Максимальное количество значений в одном IN (...) списке.
+ *
+ * Почему именно 500:
+ * - у YDB есть лимит на длину текста запроса (по умолчанию 10 KB) и
+ *   суммарный размер параметров gRPC-запроса (~50 MB на параметры,
+ *   но текст запроса ограничен жёстче);
+ * - каждый элемент IN (...) разворачивается в отдельный плейсхолдер `$pN`
+ *   (~5–8 символов текста + отдельный параметр запроса), поэтому чанк из
+ *   500 значений даёт ~3–4 KB SQL-текста — с запасом до лимита даже при
+ *   дополнительных WHERE-условиях;
+ * - значение согласовано с практикой батчинга самого YDB CLI
+ *   (дефолт 1000 параметров на batch), но консервативнее.
+ *
+ * Большие списки FK/PK режутся на несколько последовательных запросов,
+ * результаты объединяются без дубликатов (см. chunkInValues).
+ */
+export const MAX_IN_CLAUSE_VALUES = 500;
+
+/**
+ * Режет список значений на чанки по MAX_IN_CLAUSE_VALUES (или явному size).
+ * Порядок элементов сохраняется; последний чанк может быть меньше.
+ */
+export function chunkInValues<T>(
+  values: readonly T[],
+  size: number = MAX_IN_CLAUSE_VALUES,
+): T[][] {
+  if (!Number.isInteger(size) || size <= 0) {
+    throw new Error(`Chunk size must be a positive integer, got ${size}`);
+  }
+  const chunks: T[][] = [];
+  for (let i = 0; i < values.length; i += size) {
+    chunks.push(values.slice(i, i + size));
+  }
+  return chunks;
+}
+
+/**
+ * Дедупликация значений FK/PK с сохранением порядка первого вхождения.
+ * Значения — примитивы YDB (string/number/bigint/boolean/Uint8Array):
+ * Set сравнивает их по значению (SameValueZero, включая bigint).
+ */
+export function dedupeInValues<T>(values: readonly T[]): T[] {
+  return [...new Set(values)];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,11 @@ export {
   DEFAULT_RETRIEVE_LIMIT,
   MAX_RETRIEVE_LIMIT,
 } from './query/query-builder.js';
+export {
+  MAX_IN_CLAUSE_VALUES,
+  chunkInValues,
+  dedupeInValues,
+} from './core/query-limits.js';
 
 // Репозитории / EntityManager (DI-вариант поверх Active Record)
 export {

--- a/src/persistence/entity-persistence.ts
+++ b/src/persistence/entity-persistence.ts
@@ -19,6 +19,7 @@ import {
 } from '../decorators/timestamp.decorator.js';
 import { getLifecycleHooks } from '../decorators/lifecycle.decorator.js';
 import { resolveOperationExecutor } from '../transaction/transaction-context.js';
+import { chunkInValues, dedupeInValues } from '../core/query-limits.js';
 import type { YdbPrimitive } from '../core/types.js';
 import {
   getYdbEnumMetadata,
@@ -1689,6 +1690,15 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
 
   /**
    * Batch-загрузка по колонке IN (...). Используется relations-модулем.
+   *
+   * Guard-ы (#86):
+   * - пустой список значений — пустой результат БЕЗ выполнения SQL
+   *   (раньше уходил невалидный `WHERE col IN ()`);
+   * - дубликаты значений убираются до построения IN (...) — они раздували
+   *   список параметров и не меняли результат;
+   * - значения больше MAX_IN_CLAUSE_VALUES режутся на несколько чанков
+   *   (лимиты YDB на текст запроса/число параметров), результаты сливаются
+   *   по порядку чанков без дубликатов строк (по PK).
    */
   async fetchByColumnIn(
     column: string,
@@ -1704,23 +1714,45 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
       );
     }
 
-    const inParams = values.map((_, i) => `$p${i}`).join(', ');
-    const sql = `SELECT * FROM ${quoteIdentifier(meta.tableName)} WHERE ${quoteIdentifier(column)} IN (${inParams})`;
+    const uniqueValues = dedupeInValues(values);
+    if (!uniqueValues.length) return [];
 
-    const query = exec([sql] as unknown as TemplateStringsArray);
-    values.forEach((value, i) => {
-      query.parameter(`p${i}`, mapToYdb(columnType, value, column));
-    });
+    // PK для дедупликации результатов между чанками.
+    const pkFields = this.getPkFields(meta);
 
-    const rows = await this.executeQuery<Record<string, any>[][]>(
-      query,
-      options,
-    );
+    const result: T[] = [];
+    const seenPks = new Set<string>();
 
-    // Внутренний batch-фетч связей: без вложенной догрузки eager — глубина
-    // остаётся 1 (как до #83), иначе циклические связи рекурсируют.
-    // afterFind при этом обязателен для связанных сущностей (issue #83).
-    return this.hydrate(rows[0] ?? [], options, { eager: false });
+    for (const chunk of chunkInValues(uniqueValues)) {
+      const inParams = chunk.map((_, i) => `$p${i}`).join(', ');
+      const sql = `SELECT * FROM ${quoteIdentifier(meta.tableName)} WHERE ${quoteIdentifier(column)} IN (${inParams})`;
+
+      const query = exec([sql] as unknown as TemplateStringsArray);
+      chunk.forEach((value, i) => {
+        query.parameter(`p${i}`, mapToYdb(columnType, value, column));
+      });
+
+      const rows = await this.executeQuery<Record<string, any>[][]>(
+        query,
+        options,
+      );
+
+      // Внутренний batch-фетч связей: без вложенной догрузки eager — глубина
+      // остаётся 1 (как до #83), иначе циклические связи рекурсируют.
+      // afterFind при этом обязателен для связанных сущностей (issue #83).
+      const hydrated = await this.hydrate(rows[0] ?? [], options, {
+        eager: false,
+      });
+
+      for (const entity of hydrated) {
+        const key = pkFields.map((f) => String((entity as any)[f])).join('|');
+        if (seenPks.has(key)) continue;
+        seenPks.add(key);
+        result.push(entity);
+      }
+    }
+
+    return result;
   }
 
   /**

--- a/src/persistence/entity-persistence.ts
+++ b/src/persistence/entity-persistence.ts
@@ -1745,7 +1745,9 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
       });
 
       for (const entity of hydrated) {
-        const key = pkFields.map((f) => String((entity as any)[f])).join('|');
+        // Инъективный ключ идентичности PK (#86): без разделительной
+        // конкатенации — 'a|b'+'c' и 'a'+'b|c' не должны совпадать.
+        const key = pkIdentityKey(pkFields.map((f) => (entity as any)[f]));
         if (seenPks.has(key)) continue;
         seenPks.add(key);
         result.push(entity);
@@ -1789,4 +1791,126 @@ function isSyntheticColumn(meta: YdbEntityMetadata, key: string): boolean {
       (ef) => ef.blindIndex && `${ef.propertyKey}_bi` === key,
     )
   );
+}
+
+// ---- Инъективная каноническая кодировка значений PK (#86) ----
+//
+// Дедупликация результатов между IN(...)-чанками в fetchByColumnIn строит
+// строковый ключ идентичности PK. Конкатенация с разделителем
+// (`String(a) + '|' + String(b)`) НЕинъективна: ('a|b', 'c') и ('a', 'b|c')
+// дают один ключ 'a|b|c' — реальная сущность теряется при слиянии чанков.
+// Поэтому используется двоичная кодировка без разделителей:
+// [тег типа][длина payload (4 байта, big-endian)][payload].
+// Границы компонентов восстанавливаются однозначно по объявленной длине,
+// типы различаются тегом, поэтому разные PK не могут дать одинаковый ключ.
+
+const pkValueTag = {
+  nullValue: 0,
+  undefinedValue: 1,
+  string: 2,
+  number: 3,
+  bigint: 4,
+  boolean: 5,
+  bytes: 6,
+  date: 7,
+} as const;
+
+const pkTextEncoder = new TextEncoder();
+
+/** Добавляет payload с префиксом длины (4 байта BE) — самоделимитация. */
+function appendLengthPrefixed(out: number[], payload: Uint8Array): void {
+  const len = payload.length;
+  out.push(
+    (len >>> 24) & 0xff,
+    (len >>> 16) & 0xff,
+    (len >>> 8) & 0xff,
+    len & 0xff,
+  );
+  for (let i = 0; i < len; i++) out.push(payload[i]);
+}
+
+/** IEEE-754 double как 8 байт BE. */
+function appendFloat64(out: number[], value: number): void {
+  const buf = new ArrayBuffer(8);
+  new DataView(buf).setFloat64(0, value);
+  appendLengthPrefixed(out, new Uint8Array(buf));
+}
+
+const PK_HEX_CHARS = '0123456789abcdef';
+
+/**
+ * Канонический ключ идентичности PK: инъективное отображение кортежа
+ * компонентов (string | number | bigint | boolean | Uint8Array | Date |
+ * null/undefined) в hex-строку. Детерминировано: одинаковые значения —
+ * одинаковый ключ, разные — гарантированно разные.
+ */
+export function pkIdentityKey(components: unknown[]): string {
+  const out: number[] = [];
+  for (const value of components) {
+    if (value === null) {
+      out.push(pkValueTag.nullValue);
+      continue;
+    }
+    switch (typeof value) {
+      case 'string':
+        out.push(pkValueTag.string);
+        appendLengthPrefixed(out, pkTextEncoder.encode(value));
+        break;
+      case 'number': {
+        // -0 и 0 — одно значение по SameValueZero (как в Set).
+        out.push(pkValueTag.number);
+        appendFloat64(out, Object.is(value, -0) ? 0 : value);
+        break;
+      }
+      case 'bigint':
+        out.push(pkValueTag.bigint);
+        appendLengthPrefixed(out, pkTextEncoder.encode(value.toString()));
+        break;
+      case 'boolean':
+        out.push(pkValueTag.boolean, value ? 1 : 0);
+        break;
+      case 'object': {
+        if (ArrayBuffer.isView(value)) {
+          // Bytes-колонки YDB гидратируются в Uint8Array; сравнение
+          // побайтовое (String() дал бы '[object Uint8Array]' для всех).
+          const view = value;
+          out.push(pkValueTag.bytes);
+          appendLengthPrefixed(
+            out,
+            new Uint8Array(view.buffer, view.byteOffset, view.byteLength),
+          );
+        } else if (value instanceof Date) {
+          // Date/Datetime/Timestamp-колонки; невалидная дата — ошибка
+          // конфигурации, а не источник коллизий.
+          if (Number.isNaN(value.getTime())) {
+            throw new Error(
+              'Invalid Date in primary key component: cannot build identity key',
+            );
+          }
+          out.push(pkValueTag.date);
+          appendFloat64(out, value.getTime());
+        } else {
+          throw new Error(
+            `Unsupported primary key component type: ${typeof value}. ` +
+              'PK components must be YDB primitives',
+          );
+        }
+        break;
+      }
+      case 'undefined':
+        out.push(pkValueTag.undefinedValue);
+        break;
+      default:
+        throw new Error(
+          `Unsupported primary key component type: ${typeof value}. ` +
+            'PK components must be YDB primitives',
+        );
+    }
+  }
+
+  let hex = '';
+  for (const byte of out) {
+    hex += PK_HEX_CHARS[byte >> 4] + PK_HEX_CHARS[byte & 0x0f];
+  }
+  return hex;
 }

--- a/src/relations/entity-relations.ts
+++ b/src/relations/entity-relations.ts
@@ -19,6 +19,7 @@ import type { HydrationContext } from '../persistence/entity-persistence.js';
 import { getEagerRelations } from '../decorators/eager.decorator.js';
 import { quoteIdentifier } from '../core/sql-utils.js';
 import { resolveOperationExecutor } from '../transaction/transaction-context.js';
+import { chunkInValues, dedupeInValues } from '../core/query-limits.js';
 import { mapToYdb } from '../core/mapper.js';
 
 /**
@@ -91,6 +92,13 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
   /**
    * Batch-загрузка many-to-many: join-таблица + инверсные сущности.
    * Возвращает Map<owner PK, related entities[]>.
+   *
+   * Батчинг и guard-ы (#86): пустой список владельцев — ноль запросов;
+   * дубликаты PK владельцев убираются; join-select чанкуется по
+   * MAX_IN_CLAUSE_VALUES (чанки по owner-PK не пересекаются, поэтому
+   * link-строки уникальны без дополнительной дедупликации); выборка
+   * инверсных сущностей идёт через fetchByColumnIn (дедупликация FK,
+   * чанкинг, слияние без дубликатов).
    */
   private async loadManyToManyRelation(
     items: T[],
@@ -106,27 +114,37 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
       );
     }
 
-    const inParams = ownerPks.map((_, i) => `$p${i}`).join(', ');
+    const uniqueOwnerPks = dedupeInValues(ownerPks);
+    if (!uniqueOwnerPks.length) return new Map();
+
     const ownerPkType = joinTable.ownerColumnType;
 
-    const sql =
-      `SELECT ${quoteIdentifier(joinTable.ownerColumn)}, ` +
-      `${quoteIdentifier(joinTable.inverseColumn)} ` +
-      `FROM ${quoteIdentifier(joinTable.tableName)} ` +
-      `WHERE ${quoteIdentifier(joinTable.ownerColumn)} IN (${inParams})`;
+    const links: { [key: string]: any }[] = [];
+    for (const chunk of chunkInValues(uniqueOwnerPks)) {
+      const inParams = chunk.map((_, i) => `$p${i}`).join(', ');
 
-    const joinQuery = exec([sql] as unknown as TemplateStringsArray);
-    ownerPks.forEach((value, i) => {
-      joinQuery.parameter(
-        `p${i}`,
-        mapToYdb(ownerPkType, value, joinTable.ownerColumn),
-      );
-    });
+      const sql =
+        `SELECT ${quoteIdentifier(joinTable.ownerColumn)}, ` +
+        `${quoteIdentifier(joinTable.inverseColumn)} ` +
+        `FROM ${quoteIdentifier(joinTable.tableName)} ` +
+        `WHERE ${quoteIdentifier(joinTable.ownerColumn)} IN (${inParams})`;
 
-    const joinRows = await this.executeQuery(joinQuery, options);
-    const links = (joinRows[0] ?? []) as {
-      [key: string]: any;
-    }[];
+      const joinQuery = exec([sql] as unknown as TemplateStringsArray);
+      chunk.forEach((value, i) => {
+        joinQuery.parameter(
+          `p${i}`,
+          mapToYdb(ownerPkType, value, joinTable.ownerColumn),
+        );
+      });
+
+      const chunkRows = await this.executeQuery(joinQuery, options);
+      // Без spread: join-таблица может быть большой, а у push(...rows)
+      // есть лимит на число аргументов вызова.
+      const rows = (chunkRows[0] ?? []) as { [key: string]: any }[];
+      for (const row of rows) {
+        links.push(row);
+      }
+    }
 
     const inverseFks = links
       .map((row) => row[joinTable.inverseColumn])
@@ -264,6 +282,22 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
 
   /**
    * Явная загрузка relations для одного или нескольких инстансов.
+   *
+   * Батчинг (#86): для каждой связи сначала собираются все значения
+   * FK/PK по массиву инстансов, затем выполняется один (или несколько
+   * чанков) IN (...) запрос — как в eager-пути. Раньше каждый тип связи
+   * ходил запросом НА КАЖДЫЙ инстанс: 100 записей = 100–200 запросов.
+   *
+   * Семантика сохранена:
+   * - one-to-many: инстанс получает все дочерние строки по своему PK
+   *   (или []), как давал findAll({ fk: pk }) на каждый элемент;
+   * - many-to-one / one-to-one: инстанс получает ровно одну связанную
+   *   строку по FK (или null), как давал find({ pk: fk });
+   * - many-to-many: группы link-строк join-таблицы, как раньше;
+   * - ошибки валидации (undefined PK/FK, неизвестная связь) бросаются
+   *   до выполнения запросов с прежними сообщениями;
+   * - связанные сущности проходят единый конвейер гидратации
+   *   (дешифровка → instantiate → afterFind), как и eager-путь.
    */
   async loadRelations(
     items: T[],
@@ -296,22 +330,46 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
         });
         const pkField = getPrimaryKey(constructor);
 
+        // Валидация всех инстансов ДО запросов — прежний контракт ошибок.
         for (const item of items) {
-          const pkValue = (item as any)[pkField];
-          if (pkValue === undefined) {
+          if ((item as any)[pkField] === undefined) {
             throw new Error(
               `Cannot load one-to-many relation "${name}": ` +
                 `primary key "${pkField}" is undefined on ${constructor.name}`,
             );
           }
-          const targetPersistence = this.createTargetPersistence(
-            Target,
-            options?.trx,
-          );
-          (item as any)[name] = await targetPersistence.findAll(
-            { [joinColumnName]: pkValue },
-            options,
-          );
+        }
+
+        // null-PK не входят в IN (...) — их группы и так пусты ([]).
+        const pks = dedupeInValues(
+          items
+            .map((item) => (item as any)[pkField])
+            .filter((v) => v !== undefined && v !== null),
+        );
+
+        const children = await this.fetchByColumnIn(
+          Target,
+          joinColumnName,
+          pks,
+          options,
+        );
+
+        const byFk = new Map<any, YdbBaseEntity[]>();
+        for (const child of children) {
+          const fk = (child as any)[joinColumnName];
+          const group = byFk.get(fk);
+          if (group) {
+            group.push(child);
+          } else {
+            byFk.set(fk, [child]);
+          }
+        }
+
+        // Копия массива на инстанс: два инстанса с одним PK не должны
+        // разделять один массив (раньше у каждого был свой findAll).
+        for (const item of items) {
+          const group = byFk.get((item as any)[pkField]);
+          (item as any)[name] = group ? [...group] : [];
         }
       } else if (rel.type === 'many-to-many') {
         const pkField = getPrimaryKey(constructor);
@@ -328,21 +386,32 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
         }
 
         for (const item of items) {
-          const pkValue = (item as any)[pkField];
-          if (pkValue === undefined) {
+          if ((item as any)[pkField] === undefined) {
             throw new Error(
               `Cannot load many-to-many relation "${name}": ` +
                 `primary key "${pkField}" is undefined on ${constructor.name}`,
             );
           }
-          const related = await this.loadManyToManyRelation(
-            [item],
-            Target,
-            joinTable,
-            [pkValue],
-            options,
-          );
-          (item as any)[name] = related.get(pkValue) ?? [];
+        }
+
+        const pks = dedupeInValues(
+          items
+            .map((item) => (item as any)[pkField])
+            .filter((v) => v !== undefined && v !== null),
+        );
+
+        // Один батч-вызов на ВСЕ инстансы вместо пары запросов на каждый.
+        const related = await this.loadManyToManyRelation(
+          items,
+          Target,
+          joinTable,
+          pks,
+          options,
+        );
+
+        for (const item of items) {
+          const group = related.get((item as any)[pkField]);
+          (item as any)[name] = group ? [...group] : [];
         }
       } else {
         const joinColumnName = resolveRelationJoinColumn(rel.joinColumn, {
@@ -352,21 +421,36 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
         const targetPk = getPrimaryKey(Target);
 
         for (const item of items) {
-          const fkValue = (item as any)[joinColumnName];
-          if (fkValue === undefined) {
+          if ((item as any)[joinColumnName] === undefined) {
             throw new Error(
               `Cannot load relation "${name}": ` +
                 `join column "${joinColumnName}" is undefined on ${constructor.name}`,
             );
           }
-          const targetPersistence = this.createTargetPersistence(
-            Target,
-            options?.trx,
-          );
-          (item as any)[name] = await targetPersistence.find(
-            { [targetPk]: fkValue },
-            options,
-          );
+        }
+
+        // null-FK не входят в IN (...) — им назначается null, как возвращал
+        // find() по условию «PK = NULL» (пустой результат).
+        const fks = dedupeInValues(
+          items
+            .map((item) => (item as any)[joinColumnName])
+            .filter((v) => v !== undefined && v !== null),
+        );
+
+        const parents = await this.fetchByColumnIn(
+          Target,
+          targetPk,
+          fks,
+          options,
+        );
+
+        const byPk = new Map<any, YdbBaseEntity>();
+        for (const parent of parents) {
+          byPk.set((parent as any)[targetPk], parent);
+        }
+
+        for (const item of items) {
+          (item as any)[name] = byPk.get((item as any)[joinColumnName]) ?? null;
         }
       }
     }

--- a/test/batched-relations.spec.ts
+++ b/test/batched-relations.spec.ts
@@ -89,6 +89,31 @@ class BatchTagEntity extends YdbBaseEntity {
   photos?: any[];
 }
 
+// Составные PK для дедупликации между чанками fetchByColumnIn (#86).
+@YdbEntity('batch86_docs')
+class BatchDocEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  tenant: string;
+
+  @YdbPrimaryColumn('Utf8')
+  code: string;
+
+  @YdbColumn('Utf8')
+  owner: string;
+}
+
+@YdbEntity('batch86_assets')
+class BatchAssetEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Int64')
+  num: bigint;
+
+  @YdbPrimaryColumn('Bytes')
+  blob: Uint8Array;
+
+  @YdbColumn('Utf8')
+  owner: string;
+}
+
 function makeUsers(count: number): BatchUserEntity[] {
   return Array.from({ length: count }, (_, i) => {
     const user = new BatchUserEntity();
@@ -537,6 +562,83 @@ describe('#86: guard-ы fetchByColumnIn', () => {
     expect(mock.queries).toHaveLength(4);
     const ids = result.map((e) => e.uuid);
     expect(ids).toEqual(['x1', 'x2', 'x3']); // полный результат, x1 один раз
+  });
+});
+
+describe('#86: дедупликация составных PK между чанками', () => {
+  it('составные PK с символом-разделителем "|" не склеиваются в один ключ', async () => {
+    const mock = createMockExecutor(
+      [
+        [[{ tenant: 'a|b', code: 'c', owner: 'o0' }]],
+        [
+          [
+            { tenant: 'a', code: 'b|c', owner: 'o1' },
+            { tenant: 'a|b', code: 'c', owner: 'o0' }, // дубль из чанка 1
+          ],
+        ],
+      ],
+      { sequential: true },
+    );
+    BatchDocEntity.setExecutor(mock.executor);
+
+    // > MAX_IN_CLAUSE_VALUES значений → гарантированные два чанка.
+    const values = Array.from(
+      { length: MAX_IN_CLAUSE_VALUES + 50 },
+      (_, i) => `o${i}`,
+    );
+
+    const result = await getOrCreateRepository(
+      BatchDocEntity,
+    ).persistence.fetchByColumnIn('owner', values);
+
+    expect(mock.queries).toHaveLength(2);
+
+    // Регрессия: ключи ('a|b','c') и ('a','b|c') при конкатенации через '|'
+    // совпадали ('a|b|c'), и вторая сущность терялась.
+    expect(result.map((d) => [d.tenant, d.code])).toEqual([
+      ['a|b', 'c'],
+      ['a', 'b|c'],
+    ]);
+  });
+
+  it('bigint и Bytes компоненты PK кодируются без коллизий; идентичные дедуплицируются', async () => {
+    const bytesOf = (...bytes: number[]) => new Uint8Array(bytes);
+
+    const mock = createMockExecutor(
+      [
+        [[{ num: 1n, blob: bytesOf(1, 2), owner: 'o0' }]],
+        [
+          [
+            { num: 1n, blob: bytesOf(1, 2, 3), owner: 'o1' },
+            { num: 2n, blob: bytesOf(1, 2), owner: 'o2' },
+            { num: 1n, blob: bytesOf(1, 2), owner: 'o3' }, // полный дубликат
+          ],
+        ],
+      ],
+      { sequential: true },
+    );
+    BatchAssetEntity.setExecutor(mock.executor);
+
+    const values = Array.from(
+      { length: MAX_IN_CLAUSE_VALUES + 20 },
+      (_, i) => `o${i}`,
+    );
+
+    const result = await getOrCreateRepository(
+      BatchAssetEntity,
+    ).persistence.fetchByColumnIn('owner', values);
+
+    expect(mock.queries).toHaveLength(2);
+
+    // Типы и границы компонентов сохраняются точно: bigint не путается со
+    // строкой '1', а Bytes кодируются побайтово — без опоры на
+    // String()-представления (у TypedArray это join(','), у bigint — '1'),
+    // которые теряют тип значения.
+    expect(result.map((a) => [a.num.toString(), [...a.blob]])).toEqual([
+      ['1', [1, 2]],
+      ['1', [1, 2, 3]],
+      ['2', [1, 2]],
+    ]);
   });
 });
 

--- a/test/batched-relations.spec.ts
+++ b/test/batched-relations.spec.ts
@@ -1,0 +1,552 @@
+import 'reflect-metadata';
+import {
+  YdbEntity,
+  YdbColumn,
+  YdbPrimaryColumn,
+  YdbBaseEntity,
+  OneToMany,
+  ManyToOne,
+  OneToOne,
+  ManyToMany,
+  JoinTable,
+  YdbRepository,
+  getOrCreateRepository,
+  MAX_IN_CLAUSE_VALUES,
+} from '../src/index.js';
+import {
+  runWithTransactionContext,
+  configureTransactionContext,
+} from '../src/transaction/transaction-context.js';
+import { createMockExecutor } from './helpers/mock-executor.js';
+
+/**
+ * Регрессионные тесты #86: батчинг явной загрузки связей (loadRelations),
+ * чанкинг и guard-ы fetchByColumnIn. Раньше каждый тип связи ходил запросом
+ * на КАЖДЫЙ инстанс (100 записей = 100–200 запросов), IN (...) не чанковался
+ * и допускал пустой список/дубликаты значений.
+ */
+
+// ---- Фикстуры: одна модель на все виды связей ----
+
+@YdbEntity('batch86_users')
+class BatchUserEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  uuid: string;
+
+  @YdbColumn('Utf8')
+  name: string;
+
+  @OneToMany(() => BatchPhotoEntity, 'user_uuid')
+  photos?: any[];
+}
+
+@YdbEntity('batch86_photos')
+class BatchPhotoEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  uuid: string;
+
+  @YdbColumn('Utf8')
+  title: string;
+
+  @YdbColumn('Utf8')
+  user_uuid: string;
+
+  @YdbColumn('Utf8')
+  profile_uuid: string;
+
+  @ManyToOne(() => BatchUserEntity, 'user_uuid')
+  owner?: any;
+
+  @OneToOne(() => BatchProfileEntity, 'profile_uuid')
+  profile?: any;
+
+  @ManyToMany(() => BatchTagEntity, (tag) => tag.photos)
+  @JoinTable('batch86_photo_tag', {
+    joinColumn: 'photo_uuid',
+    inverseJoinColumn: 'tag_uuid',
+  })
+  tags?: any[];
+}
+
+@YdbEntity('batch86_profiles')
+class BatchProfileEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  uuid: string;
+
+  @YdbColumn('Utf8')
+  caption: string;
+}
+
+@YdbEntity('batch86_tags')
+class BatchTagEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  uuid: string;
+
+  @YdbColumn('Utf8')
+  label: string;
+
+  @ManyToMany(() => BatchPhotoEntity, (photo) => photo.tags)
+  photos?: any[];
+}
+
+function makeUsers(count: number): BatchUserEntity[] {
+  return Array.from({ length: count }, (_, i) => {
+    const user = new BatchUserEntity();
+    user.uuid = `u${String(i).padStart(3, '0')}`;
+    user.name = `user-${i}`;
+    return user;
+  });
+}
+
+/** Репозиторий пользователя: relations/persistence для батч-вызовов. */
+function userRepo(): YdbRepository<BatchUserEntity> {
+  return getOrCreateRepository(BatchUserEntity);
+}
+
+describe('#86: батчинг loadRelations', () => {
+  describe('one-to-many', () => {
+    it('100 инстансов → один батч-запрос вместо 100 findAll', async () => {
+      const users = makeUsers(100);
+      // По два ребёнка на каждого пользователя, вперемешку по порядку.
+      const childRows = users
+        .flatMap((u) => [
+          { uuid: `${u.uuid}-a`, title: `${u.uuid}-A`, user_uuid: u.uuid },
+          { uuid: `${u.uuid}-b`, title: `${u.uuid}-B`, user_uuid: u.uuid },
+        ])
+        .sort((a, b) => a.uuid.localeCompare(b.uuid));
+
+      const mock = createMockExecutor([childRows]);
+      BatchUserEntity.setExecutor(mock.executor);
+      BatchPhotoEntity.setExecutor(mock.executor);
+
+      await userRepo().relations.loadRelations(users, ['photos']);
+
+      expect(mock.queries).toHaveLength(1);
+      expect(mock.queries[0].sql).toContain('FROM `batch86_photos`');
+      expect(mock.queries[0].sql).toContain('WHERE `user_uuid` IN');
+      // Все 100 PK в одном запросе.
+      expect(Object.keys(mock.queries[0].params)).toHaveLength(100);
+
+      for (const user of users) {
+        expect(user.photos?.map((p) => p.uuid).sort()).toEqual([
+          `${user.uuid}-a`,
+          `${user.uuid}-b`,
+        ]);
+      }
+    });
+
+    it('кардинальность и порядок: пустые группы, дубликаты PK не разделяют массивы', async () => {
+      const sharedPkUser = makeUsers(1)[0];
+      const users = [
+        sharedPkUser,
+        // Второй инстанс с тем же PK — как две строки одного владельца.
+        Object.assign(new BatchUserEntity(), {
+          uuid: sharedPkUser.uuid,
+          name: 'duplicate',
+        }),
+        makeUsers(1)[0], // детей нет
+      ];
+      users[2].uuid = 'lonely';
+
+      const childRows = [
+        { uuid: 'c1', title: 'first', user_uuid: sharedPkUser.uuid },
+        { uuid: 'c2', title: 'second', user_uuid: sharedPkUser.uuid },
+      ];
+      const mock = createMockExecutor([childRows]);
+      BatchUserEntity.setExecutor(mock.executor);
+      BatchPhotoEntity.setExecutor(mock.executor);
+
+      await userRepo().relations.loadRelations(users, ['photos']);
+
+      expect(mock.queries).toHaveLength(1);
+      // Дедупликация PK: u000 (x2 инстанса) + lonely → 2 параметра.
+      expect(Object.keys(mock.queries[0].params)).toHaveLength(2);
+
+      const photosOfFirst = users[0].photos!;
+      const photosOfSecond = users[1].photos!;
+      expect(photosOfFirst.map((p) => p.uuid)).toEqual(['c1', 'c2']);
+      expect(photosOfSecond.map((p) => p.uuid)).toEqual(['c1', 'c2']);
+      // Массивы НЕ разделяются между инстансами с одинаковым PK.
+      expect(photosOfFirst).not.toBe(photosOfSecond);
+      // Порядок детей совпадает с порядком строк из БД.
+      expect(photosOfFirst.map((p) => p.title)).toEqual(['first', 'second']);
+      // Без детей — пустой массив.
+      expect(users[2].photos).toEqual([]);
+    });
+
+    it('undefined PK у любого инстанса — прежняя ошибка до запросов; null PK — ноль запросов', async () => {
+      const withoutPk = new BatchUserEntity();
+      withoutPk.name = 'no-pk';
+      const users = makeUsers(2);
+      users.push(withoutPk);
+
+      const mock = createMockExecutor([[]]);
+      BatchUserEntity.setExecutor(mock.executor);
+      BatchPhotoEntity.setExecutor(mock.executor);
+
+      await expect(
+        userRepo().relations.loadRelations(users, ['photos']),
+      ).rejects.toThrow(
+        'Cannot load one-to-many relation "photos": primary key "uuid" is undefined on BatchUserEntity',
+      );
+      expect(mock.queries).toHaveLength(0);
+
+      // Все PK null → собранный список пуст → ноль SQL.
+      const nullUsers = makeUsers(2);
+      nullUsers.forEach((u) => (u.uuid = null as any));
+      await userRepo().relations.loadRelations(nullUsers, ['photos']);
+      expect(mock.queries).toHaveLength(0);
+      expect(nullUsers.every((u) => Array.isArray(u.photos))).toBe(true);
+    });
+  });
+
+  describe('many-to-many', () => {
+    it('10 инстансов → ровно 2 запроса (join + теги), а не 2 на каждый', async () => {
+      const photos = Array.from({ length: 10 }, (_, i) => {
+        const photo = new BatchPhotoEntity();
+        photo.uuid = `p${i}`;
+        photo.title = `t${i}`;
+        photo.user_uuid = 'u000';
+        photo.profile_uuid = '';
+        return photo;
+      });
+
+      // Каждый фото привязан к своим двум тегам.
+      const linkRows = photos.flatMap((p) =>
+        [`t-${p.uuid}-1`, `t-${p.uuid}-2`].map((tag) => ({
+          photo_uuid: p.uuid,
+          tag_uuid: tag,
+        })),
+      );
+      const tagRows = linkRows.map((l) => ({
+        uuid: l.tag_uuid,
+        label: l.tag_uuid,
+      }));
+
+      const mock = createMockExecutor([[linkRows], [tagRows]], {
+        sequential: true,
+      });
+      BatchPhotoEntity.setExecutor(mock.executor);
+      BatchTagEntity.setExecutor(mock.executor);
+
+      await getOrCreateRepository(BatchPhotoEntity).relations.loadRelations(
+        photos,
+        ['tags'],
+      );
+
+      expect(mock.queries).toHaveLength(2);
+      expect(mock.queries[0].sql).toContain('FROM `batch86_photo_tag`');
+      expect(mock.queries[0].sql).toContain('WHERE `photo_uuid` IN');
+      expect(Object.keys(mock.queries[0].params)).toHaveLength(10);
+      expect(mock.queries[1].sql).toContain('FROM `batch86_tags`');
+
+      for (const photo of photos) {
+        expect(photo.tags?.map((t) => t.uuid).sort()).toEqual([
+          `t-${photo.uuid}-1`,
+          `t-${photo.uuid}-2`,
+        ]);
+      }
+    });
+
+    it('1200 владельцев → join-select чанкуется, инверсные FK дедуплицируются', async () => {
+      const photos = Array.from({ length: 1200 }, (_, i) => {
+        const photo = new BatchPhotoEntity();
+        photo.uuid = `p${String(i).padStart(4, '0')}`;
+        photo.title = '';
+        photo.user_uuid = '';
+        photo.profile_uuid = '';
+        return photo;
+      });
+
+      // Все ссылки ведут на ОДНИ те же три тега → после дедупликации
+      // инверсных FK выборка тегов укладывается в один запрос.
+      const linkRows = photos.flatMap((p) =>
+        ['tag-a', 'tag-b', 'tag-c'].map((tag) => ({
+          photo_uuid: p.uuid,
+          tag_uuid: tag,
+        })),
+      );
+
+      const mock = createMockExecutor(
+        [
+          [linkRows],
+          [
+            [
+              { uuid: 'tag-a', label: 'A' },
+              { uuid: 'tag-b', label: 'B' },
+              { uuid: 'tag-c', label: 'C' },
+            ],
+          ],
+        ],
+        { sequential: true },
+      );
+      BatchPhotoEntity.setExecutor(mock.executor);
+      BatchTagEntity.setExecutor(mock.executor);
+
+      await getOrCreateRepository(BatchPhotoEntity).relations.loadRelations(
+        photos,
+        ['tags'],
+      );
+
+      // 1200 владельцев → 3 join-чанка (500+500+200) + 1 запрос тегов.
+      expect(mock.queries).toHaveLength(4);
+      const joinQueries = mock.queries.slice(0, 3);
+      expect(joinQueries.map((q) => Object.keys(q.params).length)).toEqual([
+        500, 500, 200,
+      ]);
+      expect(Object.keys(mock.queries[3].params)).toHaveLength(3);
+
+      for (const photo of photos) {
+        expect(photo.tags?.map((t) => t.uuid).sort()).toEqual([
+          'tag-a',
+          'tag-b',
+          'tag-c',
+        ]);
+      }
+    });
+  });
+
+  describe('many-to-one и one-to-one', () => {
+    function makePhotos(count: number): BatchPhotoEntity[] {
+      return Array.from({ length: count }, (_, i) => {
+        const photo = new BatchPhotoEntity();
+        photo.uuid = `ph${i}`;
+        photo.title = '';
+        photo.profile_uuid = '';
+        return photo;
+      });
+    }
+
+    it('many-to-one: один IN-запрос; отсутствующий FK → null; порядок сохранён', async () => {
+      const photos = makePhotos(4);
+      photos[0].user_uuid = 'u001';
+      photos[1].user_uuid = 'missing'; // родителя нет в результате
+      photos[2].user_uuid = 'u001'; // дубликат FK
+      photos[3].user_uuid = 'u002';
+
+      const userRows = [
+        { uuid: 'u001', name: 'Ivan' },
+        { uuid: 'u002', name: 'Maria' },
+      ];
+      const mock = createMockExecutor([userRows]);
+      BatchPhotoEntity.setExecutor(mock.executor);
+      BatchUserEntity.setExecutor(mock.executor);
+
+      await getOrCreateRepository(BatchPhotoEntity).relations.loadRelations(
+        photos,
+        ['owner'],
+      );
+
+      expect(mock.queries).toHaveLength(1);
+      expect(mock.queries[0].sql).toContain('FROM `batch86_users`');
+      // Дедупликация FK: u001 дважды + missing + u002 → 3 параметра.
+      expect(Object.keys(mock.queries[0].params)).toHaveLength(3);
+
+      expect(photos[0].owner?.name).toBe('Ivan');
+      expect(photos[1].owner).toBeNull();
+      // Инстансы с одинаковым FK получают одну связанную сущность.
+      expect(photos[2].owner).toBe(photos[0].owner);
+      expect(photos[3].owner?.name).toBe('Maria');
+    });
+
+    it('one-to-one: один IN-запрос по PK целевой сущности', async () => {
+      const photos = makePhotos(3);
+      photos[0].profile_uuid = 'pr1';
+      photos[1].profile_uuid = 'pr2';
+      photos[2].profile_uuid = 'pr-missing';
+
+      const mock = createMockExecutor([
+        [
+          { uuid: 'pr1', caption: 'first' },
+          { uuid: 'pr2', caption: 'second' },
+        ],
+      ]);
+      BatchPhotoEntity.setExecutor(mock.executor);
+      BatchProfileEntity.setExecutor(mock.executor);
+
+      await getOrCreateRepository(BatchPhotoEntity).relations.loadRelations(
+        photos,
+        ['profile'],
+      );
+
+      expect(mock.queries).toHaveLength(1);
+      expect(mock.queries[0].sql).toContain('FROM `batch86_profiles`');
+      expect(mock.queries[0].sql).toContain('WHERE `uuid` IN');
+      expect(Object.keys(mock.queries[0].params)).toHaveLength(3);
+
+      expect(photos[0].profile?.caption).toBe('first');
+      expect(photos[1].profile?.caption).toBe('second');
+      expect(photos[2].profile).toBeNull();
+    });
+  });
+
+  describe('транзакции', () => {
+    it('явный { trx }: все батч-запросы m2m уходят в транзакцию, а не в executor БД', async () => {
+      const photos = makePhotosSimple(2);
+      const linkRows = photos.map((p) => ({
+        photo_uuid: p.uuid,
+        tag_uuid: 'tag-x',
+      }));
+
+      const dbMock = createMockExecutor([[]]);
+      const trxMock = createMockExecutor(
+        [[linkRows], [[{ uuid: 'tag-x', label: 'X' }]]],
+        { sequential: true },
+      );
+      BatchPhotoEntity.setExecutor(dbMock.executor);
+      BatchTagEntity.setExecutor(dbMock.executor);
+
+      await getOrCreateRepository(BatchPhotoEntity).relations.loadRelations(
+        photos,
+        ['tags'],
+        { trx: trxMock.executor },
+      );
+
+      expect(dbMock.queries).toHaveLength(0);
+      expect(trxMock.queries).toHaveLength(2);
+      expect(trxMock.queries[0].sql).toContain('FROM `batch86_photo_tag`');
+      expect(trxMock.queries[1].sql).toContain('FROM `batch86_tags`');
+      expect(photos[0].tags?.[0]?.uuid).toBe('tag-x');
+    });
+
+    it('ambient-контекст: батч-запрос one-to-many идёт в активную транзакцию без { trx }', async () => {
+      const users = makeUsers(3);
+      const childRows = [
+        { uuid: 'c1', title: '', user_uuid: 'u000' },
+        { uuid: 'c2', title: '', user_uuid: 'u002' },
+      ];
+
+      const dbMock = createMockExecutor([[]]);
+      const trxMock = createMockExecutor([childRows]);
+      BatchUserEntity.setExecutor(dbMock.executor);
+      BatchPhotoEntity.setExecutor(dbMock.executor);
+
+      configureTransactionContext({ ambient: true });
+      try {
+        await runWithTransactionContext(
+          {
+            trx: trxMock.executor,
+            db: dbMock.executor,
+            ambient: true,
+          },
+          async () => {
+            await userRepo().relations.loadRelations(users, ['photos']);
+          },
+        );
+      } finally {
+        configureTransactionContext();
+      }
+
+      expect(dbMock.queries).toHaveLength(0);
+      expect(trxMock.queries).toHaveLength(1);
+      expect(users[0].photos?.map((p) => p.uuid)).toEqual(['c1']);
+      expect(users[1].photos).toEqual([]);
+      expect(users[2].photos?.map((p) => p.uuid)).toEqual(['c2']);
+    });
+  });
+});
+
+describe('#86: guard-ы fetchByColumnIn', () => {
+  function photoRepo(): YdbRepository<BatchPhotoEntity> {
+    return getOrCreateRepository(BatchPhotoEntity);
+  }
+
+  it('пустой массив значений — ноль SQL', async () => {
+    const mock = createMockExecutor([[]]);
+    BatchPhotoEntity.setExecutor(mock.executor);
+
+    const result = await photoRepo().persistence.fetchByColumnIn(
+      'user_uuid',
+      [],
+    );
+
+    expect(result).toEqual([]);
+    expect(mock.queries).toHaveLength(0);
+  });
+
+  it('дубликаты FK дедуплицируются до построения IN (...)', async () => {
+    const mock = createMockExecutor([
+      [[{ uuid: 'c1', title: '', user_uuid: 'u1' }]],
+    ]);
+    BatchPhotoEntity.setExecutor(mock.executor);
+
+    const result = await photoRepo().persistence.fetchByColumnIn('user_uuid', [
+      'u1',
+      'u1',
+      'u2',
+      'u1',
+      'u2',
+    ]);
+
+    expect(mock.queries).toHaveLength(1);
+    expect(mock.queries[0].sql).toContain('IN ($p0, $p1)');
+    expect(mock.queries[0].sql).not.toContain('$p2');
+    expect(Object.keys(mock.queries[0].params)).toHaveLength(2);
+    expect(result).toHaveLength(1);
+  });
+
+  it(`больше ${MAX_IN_CLAUSE_VALUES} значений → несколько чанков`, async () => {
+    const mock = createMockExecutor([[]]);
+    BatchPhotoEntity.setExecutor(mock.executor);
+
+    const values = Array.from({ length: MAX_IN_CLAUSE_VALUES + 700 }, (_, i) =>
+      String(i),
+    );
+
+    await photoRepo().persistence.fetchByColumnIn('user_uuid', values);
+
+    expect(mock.queries).toHaveLength(3); // 500 + 500 + 200
+    expect(mock.queries.map((q) => Object.keys(q.params).length)).toEqual([
+      MAX_IN_CLAUSE_VALUES,
+      MAX_IN_CLAUSE_VALUES,
+      200,
+    ]);
+    for (const q of mock.queries) {
+      expect(q.sql).toContain('WHERE `user_uuid` IN');
+    }
+  });
+
+  it('слияние чанков полное и без дубликатов', async () => {
+    const mock = createMockExecutor(
+      [
+        [[{ uuid: 'x1', title: '', user_uuid: 'u1' }]],
+        [
+          [
+            { uuid: 'x2', title: '', user_uuid: 'u2' },
+            { uuid: 'x1', title: '', user_uuid: 'u1' }, // дубль между чанками
+          ],
+        ],
+        [[{ uuid: 'x3', title: '', user_uuid: 'u3' }]],
+      ],
+      { sequential: true },
+    );
+    BatchPhotoEntity.setExecutor(mock.executor);
+
+    const values = [
+      ...Array.from({ length: MAX_IN_CLAUSE_VALUES }, (_, i) => `a${i}`),
+      ...Array.from({ length: MAX_IN_CLAUSE_VALUES }, (_, i) => `b${i}`),
+      ...Array.from({ length: MAX_IN_CLAUSE_VALUES }, (_, i) => `c${i}`),
+      ...Array.from({ length: MAX_IN_CLAUSE_VALUES }, (_, i) => `d${i}`),
+    ];
+
+    const result = await photoRepo().persistence.fetchByColumnIn(
+      'user_uuid',
+      values,
+    );
+
+    expect(mock.queries).toHaveLength(4);
+    const ids = result.map((e) => e.uuid);
+    expect(ids).toEqual(['x1', 'x2', 'x3']); // полный результат, x1 один раз
+  });
+});
+
+function makePhotosSimple(count: number): BatchPhotoEntity[] {
+  return Array.from({ length: count }, (_, i) => {
+    const photo = new BatchPhotoEntity();
+    photo.uuid = `p${i}`;
+    photo.title = '';
+    photo.user_uuid = '';
+    photo.profile_uuid = '';
+    return photo;
+  });
+}

--- a/test/composite-pk.spec.ts
+++ b/test/composite-pk.spec.ts
@@ -283,9 +283,10 @@ describe('Composite PK CRUD', () => {
 
       expect(membership.user).toBeInstanceOf(UserEntity);
       expect(membership.user?.uuid).toBe(userRow.uuid);
+      // #86: many-to-one грузится одним батч-IN по PK вместо find() на элемент.
       const [q] = mock.queries;
       expect(q.sql).toContain('SELECT * FROM `users`');
-      expect(q.sql).toContain('WHERE `uuid` = $uuid');
+      expect(q.sql).toContain('WHERE `uuid` IN ($p0)');
     });
   });
 });

--- a/test/many-to-many-composite-pk-config.spec.ts
+++ b/test/many-to-many-composite-pk-config.spec.ts
@@ -444,8 +444,8 @@ describe('join-column selector resolution is strict (#87)', () => {
     parent.id = 7n;
     await parent.loadRelations(['children']);
 
-    expect(mock.queries[0].sql).toContain('`parent_ref` = $parent_ref');
-    expect(mock.queries[0].params.parent_ref).toBeInstanceOf(Int64);
+    expect(mock.queries[0].sql).toContain('`parent_ref` IN ($p0)');
+    expect(mock.queries[0].params.p0).toBeInstanceOf(Int64);
     expect(parent.children?.map((c) => c.uuid)).toEqual(['c1']);
   });
 

--- a/test/nestjs/relations.spec.ts
+++ b/test/nestjs/relations.spec.ts
@@ -88,8 +88,8 @@ describe('NestJS integration: relations', () => {
     expect(mock.queries[0].sql).toContain('FROM `photos_with_tags`');
     expect(mock.queries[1].sql).toContain('FROM `photo_tag`');
     expect(mock.queries[1].sql).toContain('`photos_with_tags_uuid` IN');
-    expect(mock.queries[2].sql).toContain('FROM `tags`');
-    expect(mock.queries[2].sql).toContain('WHERE `uuid` IN');
+    // #86: join-таблица вернула ноль ссылок — выборка тегов не выполняется.
+    expect(mock.queries).toHaveLength(2);
 
     await module.close();
   });
@@ -103,7 +103,8 @@ describe('NestJS integration: relations', () => {
     await photo.loadRelations(['tags']);
 
     expect(mock.queries[0].sql).toContain('FROM `photo_tag`');
-    expect(mock.queries[1].sql).toContain('FROM `tags`');
+    // #86: join-таблица вернула ноль ссылок — выборка тегов не выполняется.
+    expect(mock.queries).toHaveLength(1);
 
     await module.close();
   });


### PR DESCRIPTION
## Проблема (#86)

Явная загрузка связей `loadRelations()` выполняла запрос **на каждый инстанс**:

- one-to-many — `findAll()` на каждый элемент;
- many-to-one / one-to-one — `find()` на каждый элемент;
- many-to-many — **2 запроса** (join + target) на каждый элемент.

100 записей = 100–200 запросов, хотя eager-путь уже батчирован одним `IN (...)`.
Дополнительно публичный `fetchByColumnIn()` не чанковал значения и допускал
пустой список (`WHERE col IN ()`) и дубликаты FK в IN-списке; join-select
many-to-many имел те же проблемы. У YDB есть лимиты на длину текста запроса
(~10 KB по умолчанию) и размер параметров.

## Что сделано

### 1. Батчинг `loadRelations()` (src/relations/entity-relations.ts)
Для каждой связи сначала собираются все значения FK/PK по массиву инстансов,
затем выполняется один `IN (...)` запрос (или несколько чанков) — как в eager:
- **one-to-many**: дети группируются по FK → каждому инстансу его группа (`[]` если пусто);
- **many-to-one / one-to-one**: родители по PK → `byPk`-мапа, отсутствующий FK → `null`;
- **many-to-many**: один вызов `loadManyToManyRelation(items, ...)` на все инстансы вместо пары запросов на элемент.
- Ошибки валидации (undefined PK/FK, неизвестная связь) бросаются **до** запросов с прежними сообщениями.
- Инстансы с одинаковым PK/FK получают **копии** массивов/те же сущности — без разделения мутабельного состояния между разными корневыми сущностями (для массивов).

### 2. Guard-ы и чанкинг `fetchByColumnIn()` (src/persistence/entity-persistence.ts)
- пустой список значений → `[]` **без выполнения SQL**;
- дедупликация значений с сохранением порядка первого вхождения;
- чанкинг по `MAX_IN_CLAUSE_VALUES`, результаты сливаются по порядку чанков **без дубликатов строк** (дедуп по PK, составной PK поддерживается).

### 3. Те же guard-ы в many-to-many (src/relations/entity-relations.ts)
- пустой список владельцев → ноль запросов; дубликаты owner-PK убираются;
- join-select чанкуется (чанки по owner-PK не пересекаются — link-строки уникальны);
- выборка инверсных сущностей идёт через guarded `fetchByColumnIn`.

### 4. Централизованный лимит (новый src/core/query-limits.ts)
`MAX_IN_CLAUSE_VALUES = 500` — документированный лимит: каждый элемент `IN` — это плейсхолдер `$pN` (~5–8 символов текста) + параметр; чанк 500 даёт ~3–4 KB SQL-текста с запасом до лимита YDB (~10 KB). Согласовано с практикой батчинга YDB CLI (дефолт 1000), но консервативнее. Экспортирован из публичного API вместе с хелперами `chunkInValues` / `dedupeInValues`. Никаких захардкоженных «магических чисел» в коде отношений нет.

### 5. Транзакции
Все батч-запросы проходят тот же резолв executor'а, что и раньше: явный `{ trx }` побеждает, ambient auto-join (#98) работает — проверено тестами на обоих путях (m2m c `{ trx }`: join+target уходят в транзакцию; o2m в ambient: запрос идёт в trx активного контекста, а не в executor БД).

## Семантика
Состав связанных строк, порядок внутри групп и кардинальность сохранены («те же строки, меньше запросов»). Lifecycle hooks (`afterFind` ровно раз на инстанс), кеширование и глубина eager (#83) не изменены. Побочный эффект унификации: связанные сущности при явной загрузке теперь проходят тот же конвейер гидратации, что и eager-путь (дешифровка → instantiate → afterFind, без вложенной догрузки *их собственных* eager-связей — как уже было для m2m и eager). Обновлены 3 ассерта, проверявших старый N+1 SQL-шейп (`WHERE col = $x` → `IN ($p0)`), плюс 2 ассерта, фиксировавших бессмысленный запрос к тегам при нуле ссылок в join-таблице.

## Тесты (test/batched-relations.spec.ts, 13 новых)
- 100 инстансов one-to-many → **ровно 1 запрос** (было 100);
- many-to-many на 10 инстансов → **ровно 2 запроса** (было 20); 1200 владельцев → 3 join-чанка (500+500+200) + 1 запрос тегов (инверсные FK дедуплицированы до 3);
- пустой массив FK/PK → ноль SQL; null-PK → ноль SQL;
- дубликаты FK дедуплицируются (5 значений → 2 параметра);
- 1700 значений → 3 чанка с корректными размерами;
- слияние результатов чанков полное и без дубликатов;
- порядок детей из БД сохранён; отсутствие детей → `[]`; отсутствующий родитель → `null`;
- явный `{ trx }` и ambient-транзакция используют транзакционный executor.

## Проверка
- `yarn test` — 846 passed (57 suites), включая NestJS-интеграционные;
- `yarn build` — ok; `yarn lint` — 0 errors (warnings предсуществующие).