### PR TITLE
feat(schema): безопасный rename-детект в migration:generate (#23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,8 @@ export default {
 
 `migration:generate` строит diff по всем `entities` из конфига: нет таблицы → `CREATE TABLE` (+ `DROP TABLE` в `down`), нет колонок → `ADD COLUMN` (+ `DROP COLUMN` в `down`). Расхождения типа/PK и лишние колонки не меняются автоматически — попадают в миграцию как `WARNING`-комментарии.
 
+Если расхождение выглядит как переименование (ровно одна лишняя колонка БД и одна новая колонка сущности с тем же типом, без участия PK/индексов/TTL/blind-index), генератор не делает ADD/DROP молча: в `up()`/`down()` добавляется комментарий-подсказка вида `ALTER TABLE ... RENAME COLUMN ... TO ...`, а применение остаётся ручным — YQL пока не поддерживает `RENAME COLUMN`. При неоднозначности (несколько кандидатов, ключевые колонки, метаданные шифрования) поведение прежнее: `ADD COLUMN` + `WARNING`.
+
 ### Программный API
 
 `YdbMigrationRunner` (run/revert/status, восстановление после сбоев — `markMigrationApplied`/`removeMigrationRecord`), `loadMigrationsFromDir`, `planMigration`, `executeSql` экспортируются из пакета — можно встроить миграции в свой пайплайн.

--- a/src/cli/diff.ts
+++ b/src/cli/diff.ts
@@ -27,6 +27,7 @@ const KIND_STYLE: Record<
   'unique-mismatch': { marker: '~', color: RED },
   'ttl-mismatch': { marker: '~', color: RED },
   'primary-key-mismatch': { marker: '!', color: RED },
+  'rename-suggestion': { marker: '~', color: YELLOW },
   'extra-column': { marker: '-', color: GRAY },
   'extra-index': { marker: '-', color: BLUE },
   'ttl-extra': { marker: '-', color: BLUE },

--- a/src/migrations/migration-generator.spec.ts
+++ b/src/migrations/migration-generator.spec.ts
@@ -448,6 +448,153 @@ describe('planMigration input validation (#102)', () => {
   });
 });
 
+/**
+ * #23: вероятные переименования колонок в migration:generate.
+ */
+describe('planMigration: rename suggestions (#23)', () => {
+  // Сущность переименовала label -> title (тип сохранён)
+  const renameExpected: ExpectedTableSchema = {
+    tableName: 'photos',
+    columns: { uuid: 'Uuid', title: 'Utf8' },
+    primaryKey: ['uuid'],
+    indexes: [],
+  };
+  const dbWithLabel = description([
+    ['uuid', Type_PrimitiveTypeId.UUID],
+    ['label', Type_PrimitiveTypeId.UTF8],
+  ]);
+
+  it('emits a suggestion and suppresses ADD/DROP for a likely rename', () => {
+    const plan = planMigration([renameExpected], [dbWithLabel]);
+
+    expect(plan.suggestions).toEqual([
+      'ALTER TABLE `photos` RENAME COLUMN `label` TO `title`',
+    ]);
+    // ADD для переименованной колонки не генерируется
+    expect(plan.up).toEqual([]);
+    expect(plan.down).toEqual([]);
+    expect(
+      plan.warnings.some((w) => w.includes('may have been renamed to "title"')),
+    ).toBe(true);
+    // Лишняя колонка по-прежнему честно числится лишней и не удаляется
+    expect(plan.warnings.some((w) => w.includes('extra column "label"'))).toBe(
+      true,
+    );
+  });
+
+  it('does not guess with several candidates and keeps ADD/DROP', () => {
+    const plan = planMigration(
+      [
+        {
+          tableName: 'photos',
+          columns: { uuid: 'Uuid', title: 'Utf8', flag: 'Bool' },
+          primaryKey: ['uuid'],
+          indexes: [],
+        },
+      ],
+      [
+        description([
+          ['uuid', Type_PrimitiveTypeId.UUID],
+          ['label', Type_PrimitiveTypeId.UTF8],
+          ['legacy_flag', Type_PrimitiveTypeId.BOOL],
+        ]),
+      ],
+    );
+
+    expect(plan.suggestions).toEqual([]);
+    expect(plan.up).toEqual([
+      'ALTER TABLE `photos` ADD COLUMN `title` Utf8, ADD COLUMN `flag` Bool',
+    ]);
+    expect(plan.down).toEqual([
+      'ALTER TABLE `photos` DROP COLUMN `flag`',
+      'ALTER TABLE `photos` DROP COLUMN `title`',
+    ]);
+    expect(plan.warnings.filter((w) => w.includes('renamed'))).toEqual([]);
+  });
+
+  it('keeps plain ADD/DROP behavior when types differ (unrelated add/drop)', () => {
+    const plan = planMigration(
+      [{ ...renameExpected, columns: { uuid: 'Uuid', title: 'Int32' } }],
+      [dbWithLabel],
+    );
+
+    expect(plan.suggestions).toEqual([]);
+    expect(plan.up).toEqual(['ALTER TABLE `photos` ADD COLUMN `title` Int32']);
+    expect(plan.down).toEqual(['ALTER TABLE `photos` DROP COLUMN `title`']);
+    expect(plan.warnings).toEqual([
+      'Table "photos" has extra column "label" — not dropped automatically',
+    ]);
+  });
+
+  it('does not treat PK changes as a rename (#23)', () => {
+    const plan = planMigration(
+      [{ ...renameExpected, primaryKey: ['uuid', 'title'] }],
+      [
+        description(
+          [
+            ['uuid', Type_PrimitiveTypeId.UUID],
+            ['label', Type_PrimitiveTypeId.UTF8],
+          ],
+          ['uuid', 'label'],
+        ),
+      ],
+    );
+
+    expect(plan.suggestions).toEqual([]);
+    // Подсказки нет — расхождение PK обрабатывается прежним путём:
+    // колонка добавляется обычным ADD, PK требует ручной миграции.
+    expect(plan.up).toEqual(['ALTER TABLE `photos` ADD COLUMN `title` Utf8']);
+    expect(plan.down).toEqual(['ALTER TABLE `photos` DROP COLUMN `title`']);
+    expect(plan.warnings.some((w) => w.includes('primary key mismatch'))).toBe(
+      true,
+    );
+    expect(plan.warnings.some((w) => w.includes('renamed'))).toBe(false);
+  });
+
+  it('does not treat TTL changes as a rename (#23)', () => {
+    const plan = planMigration(
+      [
+        {
+          ...renameExpected,
+          ttl: { interval: 'PT1H', column: 'title' },
+        },
+      ],
+      [dbWithLabel],
+    );
+
+    expect(plan.suggestions).toEqual([]);
+    // Обычный путь: ADD колонки + установка TTL из метаданных
+    expect(plan.up).toEqual([
+      'ALTER TABLE `photos` ADD COLUMN `title` Utf8',
+      'ALTER TABLE `photos` SET (TTL = Interval("PT1H") ON `title`)',
+    ]);
+    expect(plan.down).toEqual([
+      'ALTER TABLE `photos` RESET (TTL)',
+      'ALTER TABLE `photos` DROP COLUMN `title`',
+    ]);
+  });
+
+  it('does not treat index changes as a rename (#23)', () => {
+    const plan = planMigration(
+      [
+        {
+          ...renameExpected,
+          indexes: [
+            { name: 'photos__title', columns: ['title'], unique: false },
+          ],
+        },
+      ],
+      [dbWithLabel],
+    );
+
+    expect(plan.suggestions).toEqual([]);
+    expect(plan.up).toEqual([
+      'ALTER TABLE `photos` ADD COLUMN `title` Utf8',
+      'ALTER TABLE `photos` ADD INDEX `photos__title` GLOBAL SYNC ON (`title`)',
+    ]);
+  });
+});
+
 describe('renderMigrationFile', () => {
   it('renders a migration class with up/down statements', () => {
     const content = renderMigrationFile(
@@ -479,5 +626,55 @@ describe('renderMigrationFile', () => {
     });
 
     expect(content.match(/no statements — fill in manually/g)).toHaveLength(2);
+  });
+
+  it('#23: renders rename as a comment suggestion only — never executable', () => {
+    const content = renderMigrationFile('RenameLabel1000', '1000-RenameLabel', {
+      up: [],
+      down: [],
+      warnings: [
+        'Table "photos" column "label" may have been renamed to "title" — ' +
+          'ADD/DROP suppressed for this pair, see SUGGESTION in the generated migration',
+      ],
+      suggestions: ['ALTER TABLE `photos` RENAME COLUMN `label` TO `title`'],
+    });
+
+    // Подсказка видна в обоих направлениях и явно помечена как неприменённая
+    expect(content).toContain(
+      '// SUGGESTION (not applied automatically): possible column rename detected.',
+    );
+    expect(
+      content.match(
+        /\/\/ {3}ALTER TABLE `photos` RENAME COLUMN `label` TO `title`;/g,
+      ),
+    ).toHaveLength(2);
+    // RENAME не исполняется автоматически
+    expect(content.match(/await executeSql/g) ?? []).toHaveLength(0);
+    // Плейсхолдер «no statements» не нужен — тело занято подсказкой
+    expect(content).not.toContain('no statements');
+  });
+
+  it('#23: keeps executable statements alongside the suggestion block', () => {
+    const content = renderMigrationFile('Mixed1000', '1000-Mixed', {
+      up: [
+        'ALTER TABLE `photos` ADD INDEX `photos__uuid` GLOBAL SYNC ON (`uuid`)',
+      ],
+      down: ['ALTER TABLE `photos` DROP INDEX `photos__uuid`'],
+      warnings: [],
+      suggestions: ['ALTER TABLE `photos` RENAME COLUMN `a` TO `b`'],
+    });
+
+    expect(content).toContain(
+      'await executeSql(executor, "ALTER TABLE `photos` ADD INDEX',
+    );
+    expect(content).toContain(
+      'await executeSql(executor, "ALTER TABLE `photos` DROP INDEX',
+    );
+    // Ни один executeSql не содержит RENAME COLUMN
+    for (const line of content.split('\n')) {
+      if (line.includes('await executeSql')) {
+        expect(line.includes('RENAME COLUMN')).toBe(false);
+      }
+    }
   });
 });

--- a/src/migrations/migration-generator.ts
+++ b/src/migrations/migration-generator.ts
@@ -23,6 +23,13 @@ export interface PlannedMigration {
   up: string[];
   down: string[];
   warnings: string[];
+  /**
+   * Предположения о переименовании колонок (#23): НЕ выполняются и не
+   * применяются автоматически — рендерятся комментариями внутри up()/down()
+   * сгенерированного файла. Для каждой пары соответствующие ADD/DROP
+   * в up/down подавляются: применение переименования — явное решение.
+   */
+  suggestions?: string[];
 }
 
 /** Восстанавливает YdbTtlMetadata из фактических настроек TTL в БД. */
@@ -83,6 +90,14 @@ function validatePlanInputs(
  *  - расхождение существующего индекса (unique/колонки) только
  *    диагностируется — пересоздание индекса небезопасно делать молча;
  *  - PK, типы колонок и лишние колонки не меняются (как раньше).
+ *
+ * Вероятные переименования (#23): если ровно одна лишняя колонка БД и одна
+ * новая колонка сущности совпадают по типу и не затрагивают PK/индексы/TTL/
+ * blind-index, план НЕ генерирует для этой пары ADD/DROP, а кладёт
+ * `ALTER TABLE ... RENAME COLUMN ... TO ...` в suggestions (комментарий
+ * в файле миграции). YQL пока не поддерживает RENAME COLUMN — применение
+ * всегда ручное. При малейшей неоднозначности (несколько кандидатов,
+ * участие ключевых колонок и т.п.) поведение прежнее: ADD/DROP + warning.
  */
 export function planMigration(
   expected: ExpectedTableSchema[],
@@ -93,6 +108,7 @@ export function planMigration(
   const up: string[] = [];
   const down: string[] = [];
   const warnings: string[] = [];
+  const suggestions: string[] = [];
 
   for (let i = 0; i < expected.length; i++) {
     const schema = expected[i];
@@ -127,13 +143,35 @@ export function planMigration(
       );
     }
 
+    // #23: вероятное переименование — только подсказка, ADD/DROP для пары
+    // подавляются. Лишняя колонка по-прежнему не удаляется автоматически.
+    const renamedTargets = new Set(
+      check.likelyRenames.map((rename) => rename.to),
+    );
+    for (const rename of check.likelyRenames) {
+      suggestions.push(
+        `ALTER TABLE ${quoteIdentifier(schema.tableName)} RENAME COLUMN ` +
+          `${quoteIdentifier(rename.from)} TO ${quoteIdentifier(rename.to)}`,
+      );
+      warnings.push(
+        `Table "${schema.tableName}" column "${rename.from}" may have been renamed ` +
+          `to "${rename.to}" — ADD/DROP suppressed for this pair, ` +
+          `see SUGGESTION in the generated migration`,
+      );
+    }
+
     if (check.missingColumns.length) {
-      up.push(generateAddColumnsYql(schema.tableName, check.missingColumns));
-      // down — в обратном порядке через unshift, чтобы up/down были симметричны
-      for (const [column] of check.missingColumns) {
-        down.unshift(
-          `ALTER TABLE ${quoteIdentifier(schema.tableName)} DROP COLUMN ${quoteIdentifier(column)}`,
-        );
+      const autoAdd = check.missingColumns.filter(
+        ([column]) => !renamedTargets.has(column),
+      );
+      if (autoAdd.length) {
+        up.push(generateAddColumnsYql(schema.tableName, autoAdd));
+        // down — в обратном порядке через unshift, чтобы up/down были симметричны
+        for (const [column] of autoAdd) {
+          down.unshift(
+            `ALTER TABLE ${quoteIdentifier(schema.tableName)} DROP COLUMN ${quoteIdentifier(column)}`,
+          );
+        }
       }
     }
 
@@ -194,12 +232,30 @@ export function planMigration(
     }
   }
 
-  return { up, down, warnings };
+  return { up, down, warnings, suggestions };
+}
+
+/**
+ * Рендерит блок комментариев с подсказками о переименовании (#23).
+ * Подсказки никогда не попадают в исполняемые statements: YQL не
+ * поддерживает RENAME COLUMN, применение — только вручную после проверки.
+ */
+function renderSuggestionsBlock(
+  suggestions: string[] | undefined,
+  indent: string,
+): string | null {
+  if (!suggestions?.length) return null;
+  return [
+    `${indent}// SUGGESTION (not applied automatically): possible column rename detected.`,
+    `${indent}// YQL has no ALTER TABLE RENAME COLUMN yet — verify the data and migrate manually:`,
+    ...suggestions.map((sql) => `${indent}//   ${sql};`),
+  ].join('\n');
 }
 
 /**
  * Рендерит файл миграции по плану. Если план пуст — up/down остаются
- * пустыми с комментарием.
+ * пустыми с комментарием. Подсказки о переименовании рендерятся
+ * комментариями внутри up()/down(), а не исполняемыми statements (#23).
  */
 export function renderMigrationFile(
   className: string,
@@ -218,6 +274,18 @@ export function renderMigrationFile(
       ? ''
       : plan.warnings.map((w) => ` * WARNING: ${w}`).join('\n') + '\n';
 
+  const body = (stmts: string[], indent: string): string => {
+    const suggestionComment = renderSuggestionsBlock(plan.suggestions, indent);
+    const parts: string[] = [];
+    if (suggestionComment) {
+      parts.push(suggestionComment);
+    } else if (stmts.length === 0) {
+      parts.push(`${indent}// no statements — fill in manually`);
+    }
+    if (stmts.length) parts.push(statements(stmts, indent));
+    return parts.join('\n');
+  };
+
   return `import type { YdbMigration, YdbExecutor } from '@ycforge/ydb-orm';
 import { executeSql } from '@ycforge/ydb-orm';
 
@@ -228,19 +296,11 @@ export class ${className} implements YdbMigration {
   readonly name = ${JSON.stringify(migrationName)};
 
   async up(executor: YdbExecutor): Promise<void> {
-${
-  plan.up.length
-    ? statements(plan.up, '    ')
-    : '    // no statements — fill in manually'
-}
+${body(plan.up, '    ')}
   }
 
   async down(executor: YdbExecutor): Promise<void> {
-${
-  plan.down.length
-    ? statements(plan.down, '    ')
-    : '    // no statements — fill in manually'
-}
+${body(plan.down, '    ')}
   }
 }
 `;

--- a/src/schema/schema-sync.spec.ts
+++ b/src/schema/schema-sync.spec.ts
@@ -17,6 +17,7 @@ import { YdbBaseEntity } from '../entity/base-entity.js';
 import { getYdbEntityMetadata } from '../metadata/entity-metadata.js';
 import { getRegisteredYdbEntities } from '../metadata/entity-registry.js';
 import { YdbExecutor } from '../core/interfaces.js';
+import { YdbPrimitive } from '../core/types.js';
 import {
   buildExpectedTableSchema,
   buildExpectedJoinTableSchema,
@@ -2282,5 +2283,237 @@ describe('DescribeTable non-primitive column types (#91)', () => {
       /column type mismatch \(price: expected Utf8, actual decimal\(22,9\)\)/,
     );
     expect((executor as unknown as jest.Mock).mock.calls).toEqual([]);
+  });
+});
+
+/**
+ * #23: детекция вероятных переименований колонок. Чистые литеральные
+ * схемы — без декораторов, чтобы точно управлять PK/индексами/TTL.
+ */
+describe('checkTableSchema: column rename hints (#23)', () => {
+  // Сущность переименовала label -> title; в БД осталась label
+  const renameExpected = (overrides: Partial<ExpectedTableSchema> = {}) => ({
+    tableName: 'photos',
+    columns: { uuid: 'Uuid', title: 'Utf8' } as Record<string, YdbPrimitive>,
+    primaryKey: ['uuid'],
+    indexes: [],
+    ...overrides,
+  });
+
+  it('suggests a rename for one missing + one extra column of the same type', () => {
+    const check = checkTableSchema(
+      renameExpected(),
+      description([
+        ['uuid', Type_PrimitiveTypeId.UUID],
+        ['label', Type_PrimitiveTypeId.UTF8],
+      ]),
+    );
+
+    expect(check.missingColumns).toEqual([['title', 'Utf8']]);
+    expect(check.extraColumns).toEqual(['label']);
+    expect(check.likelyRenames).toEqual([{ from: 'label', to: 'title' }]);
+  });
+
+  it('does not guess when several candidates exist (#23)', () => {
+    const ambiguousExpected: ExpectedTableSchema = {
+      tableName: 'photos',
+      columns: { uuid: 'Uuid', title: 'Utf8', flag: 'Bool' },
+      primaryKey: ['uuid'],
+      indexes: [],
+    };
+    const check = checkTableSchema(
+      ambiguousExpected,
+      description([
+        ['uuid', Type_PrimitiveTypeId.UUID],
+        ['label', Type_PrimitiveTypeId.UTF8],
+        ['legacy_flag', Type_PrimitiveTypeId.BOOL],
+      ]),
+    );
+
+    expect(check.extraColumns).toEqual(['label', 'legacy_flag']);
+    expect(check.likelyRenames).toEqual([]);
+  });
+
+  it('does not suggest a rename when types differ', () => {
+    const check = checkTableSchema(
+      renameExpected({ columns: { uuid: 'Uuid', title: 'Int32' } }),
+      description([
+        ['uuid', Type_PrimitiveTypeId.UUID],
+        ['label', Type_PrimitiveTypeId.UTF8],
+      ]),
+    );
+
+    expect(check.likelyRenames).toEqual([]);
+  });
+
+  it('does not suggest a rename for primary key columns (#23)', () => {
+    const pkInDb = checkTableSchema(
+      renameExpected(),
+      description(
+        [
+          ['uuid', Type_PrimitiveTypeId.UUID],
+          ['label', Type_PrimitiveTypeId.UTF8],
+        ],
+        ['uuid', 'label'],
+      ),
+    );
+    expect(pkInDb.likelyRenames).toEqual([]);
+
+    const pkInEntity = checkTableSchema(
+      renameExpected({ primaryKey: ['uuid', 'title'] }),
+      description(
+        [
+          ['uuid', Type_PrimitiveTypeId.UUID],
+          ['label', Type_PrimitiveTypeId.UTF8],
+        ],
+        ['uuid', 'label'],
+      ),
+    );
+    expect(pkInEntity.likelyRenames).toEqual([]);
+  });
+
+  it('does not suggest a rename when columns participate in indexes (#23)', () => {
+    const indexedInDb = checkTableSchema(
+      renameExpected(),
+      description(
+        [
+          ['uuid', Type_PrimitiveTypeId.UUID],
+          ['label', Type_PrimitiveTypeId.UTF8],
+        ],
+        ['uuid'],
+        [{ name: 'photos__label', columns: ['label'], unique: false }],
+      ),
+    );
+    expect(indexedInDb.likelyRenames).toEqual([]);
+
+    const indexedInEntity = checkTableSchema(
+      renameExpected({
+        indexes: [{ name: 'photos__title', columns: ['title'], unique: false }],
+      }),
+      description([
+        ['uuid', Type_PrimitiveTypeId.UUID],
+        ['label', Type_PrimitiveTypeId.UTF8],
+      ]),
+    );
+    expect(indexedInEntity.likelyRenames).toEqual([]);
+  });
+
+  it('does not suggest a rename when columns are TTL columns (#23)', () => {
+    const ttlInDb = checkTableSchema(
+      renameExpected(),
+      description(
+        [
+          ['uuid', Type_PrimitiveTypeId.UUID],
+          ['label', Type_PrimitiveTypeId.UTF8],
+        ],
+        ['uuid'],
+        [],
+        { column: 'label', expireAfterSeconds: 3600 },
+      ),
+    );
+    expect(ttlInDb.likelyRenames).toEqual([]);
+
+    const ttlInEntity = checkTableSchema(
+      renameExpected({ ttl: { interval: 'PT1H', column: 'title' } }),
+      description(
+        [
+          ['uuid', Type_PrimitiveTypeId.UUID],
+          ['label', Type_PrimitiveTypeId.UTF8],
+        ],
+        ['uuid'],
+        [],
+        { column: 'label', expireAfterSeconds: 3600 },
+      ),
+    );
+    expect(ttlInEntity.likelyRenames).toEqual([]);
+  });
+
+  it('does not suggest a rename when blind-index metadata is involved (#23)', () => {
+    const biSiblingInDb = checkTableSchema(
+      renameExpected({ columns: { uuid: 'Uuid', title: 'Utf8' } }),
+      description([
+        ['uuid', Type_PrimitiveTypeId.UUID],
+        ['label', Type_PrimitiveTypeId.UTF8],
+        ['label_bi', Type_PrimitiveTypeId.UTF8],
+      ]),
+    );
+    expect(biSiblingInDb.likelyRenames).toEqual([]);
+
+    const syntheticTarget = checkTableSchema(
+      {
+        tableName: 'photos',
+        columns: { uuid: 'Uuid', title: 'Utf8', title_bi: 'Utf8' },
+        primaryKey: ['uuid'],
+        indexes: [],
+      },
+      description([
+        ['uuid', Type_PrimitiveTypeId.UUID],
+        ['label', Type_PrimitiveTypeId.UTF8],
+      ]),
+    );
+    expect(syntheticTarget.likelyRenames).toEqual([]);
+  });
+
+  it('does not suggest a rename for unsupported actual types (#91)', () => {
+    const withUnsupported: YdbTableDescription = {
+      columns: new Map([['uuid', Type_PrimitiveTypeId.UUID]]),
+      primaryKey: ['uuid'],
+      unsupportedColumns: new Map([['label', 'decimal(22,9)']]),
+    };
+
+    const result = checkTableSchema(renameExpected(), withUnsupported);
+    // Тип label неизвестен (#91) — сравнение типов невозможно, подсказки нет.
+    expect(result.extraColumns).toEqual(['label']);
+    expect(result.missingColumns).toEqual([['title', 'Utf8']]);
+    expect(result.typeMismatches).toEqual([]);
+    expect(result.likelyRenames).toEqual([]);
+  });
+});
+
+describe('rename-suggestion diagnostics consistency (#23)', () => {
+  const expected: ExpectedTableSchema = {
+    tableName: 'photos',
+    columns: { uuid: 'Uuid', title: 'Utf8' },
+    primaryKey: ['uuid'],
+    indexes: [],
+  };
+  const existing: YdbTableDescription = {
+    columns: new Map([
+      ['uuid', Type_PrimitiveTypeId.UUID],
+      ['label', Type_PrimitiveTypeId.UTF8],
+    ]),
+    primaryKey: ['uuid'],
+  };
+
+  it('reports missing + extra + suggestion together via checkToIssues', () => {
+    const issues = checkToIssues(checkTableSchema(expected, existing));
+
+    expect(issues.map((i) => i.kind)).toEqual([
+      'missing-column',
+      'extra-column',
+      'rename-suggestion',
+    ]);
+    expect(issues[2].message).toBe(
+      'Table "photos" column "label" may have been renamed to "title" — ' +
+        'review the data before migrating manually',
+    );
+  });
+
+  it('diffSchemas includes the same suggestion issue', () => {
+    const issues = diffSchemas([expected], [existing]);
+
+    expect(issues.filter((i) => i.kind === 'rename-suggestion')).toHaveLength(
+      1,
+    );
+    // Расхождение само по себе не «закрыто» подсказкой: колонки по-прежнему
+    // числятся отсутствующей и лишней.
+    expect(issues.filter((i) => i.kind === 'missing-column')).toHaveLength(1);
+    expect(issues.filter((i) => i.kind === 'extra-column')).toHaveLength(1);
+  });
+
+  it('emits no suggestion without a likely rename', () => {
+    const issues = diffSchemas([expected], [null]);
+
+    expect(issues.map((i) => i.kind)).toEqual(['missing-table']);
   });
 });

--- a/src/schema/schema-sync.ts
+++ b/src/schema/schema-sync.ts
@@ -54,6 +54,18 @@ export interface YdbTableTtl {
   unit?: YdbTtlUnit;
 }
 
+/**
+ * Вероятное переименование колонки (#23): `from` — лишняя колонка в БД,
+ * `to` — новая колонка сущности. Только предположение по структурным
+ * признакам схемы; никогда не применяется автоматически.
+ */
+export interface LikelyRename {
+  /** Лишняя колонка в БД (старое имя). */
+  from: string;
+  /** Отсутствующая в БД колонка сущности (новое имя). */
+  to: string;
+}
+
 /** Ожидаемая схема таблицы, построенная по метаданным сущности. */
 export interface ExpectedTableSchema {
   tableName: string;
@@ -93,6 +105,13 @@ export interface SchemaCheckResult {
   typeMismatches: { column: string; expected: YdbPrimitive; actual: string }[];
   /** Лишние колонки в БД (не удаляются автоматически — потеря данных). */
   extraColumns: string[];
+  /**
+   * Вероятные переименования колонок (#23): ровно одна лишняя колонка БД
+   * и ровно одна новая колонка сущности с совпадающим типом, не затронутые
+   * PK/индексами/TTL/blind-index. Диагностическая подсказка — не команда
+   * к действию; ADD/DROP и ручная миграция остаются явными.
+   */
+  likelyRenames: LikelyRename[];
   primaryKeyMatches: boolean;
   /**
    * Ожидаемый PK из метаданных сущности — копия входа, нужна для
@@ -141,6 +160,7 @@ export interface YdbSchemaIssue {
     | 'type-mismatch'
     | 'primary-key-mismatch'
     | 'extra-column'
+    | 'rename-suggestion'
     | 'missing-index'
     | 'extra-index'
     | 'index-columns-mismatch'
@@ -478,6 +498,92 @@ function ttlSettingsMatch(
 }
 
 /**
+ * Синтетические колонки blind index (@YdbEncrypted({ blindIndex: true }))
+ * именуются `{propertyKey}_bi`; участие таких колонок (или их «пар»)
+ * в расхождении — признак изменения метаданных шифрования, а не переименования.
+ */
+const BLIND_INDEX_SUFFIX = '_bi';
+
+/**
+ * Детекция вероятного переименования колонки (#23).
+ *
+ * Консервативная эвристика на структурных признаках схемы, без сравнения
+ * похожести имён. Подсказка выдаётся, только когда выполнено ВСЁ:
+ *  - в БД ровно одна лишняя колонка (`from`) и в сущности ровно одна новая
+ *    (`to`) — однозначное соответствие без кандидатов на выбор;
+ *  - примитивный тип `to` совпадает с фактическим типом `from` в БД
+ *    (колонки неявно неподдерживаемых типов #91 сразу отсекаются);
+ *  - ни `from`, ни `to` не участвуют в PK;
+ *  - ни `from`, ни `to` не упоминаются в колонках индексов (фактических
+ *    и ожидаемых) — иначе это изменение индекса, а не переименование;
+ *  - ни `from`, ни `to` не являются TTL-колонкой (фактической или ожидаемой);
+ *  - расхождение не затрагивает blind index: обе колонки не synthetic `_bi`
+ *    и у каждой нет `_bi`-парта в своей схеме.
+ *
+ * При любом несоответствии возвращается пустой список — остаются прежние
+ * ADD/DROP и предупреждения о ручной миграции.
+ */
+function detectLikelyRenames(
+  expected: ExpectedTableSchema,
+  existing: YdbTableDescription,
+  missingColumns: [string, YdbPrimitive][],
+  extraColumns: string[],
+): LikelyRename[] {
+  if (missingColumns.length !== 1 || extraColumns.length !== 1) return [];
+
+  const from = extraColumns[0];
+  const [to, toType] = missingColumns[0];
+
+  // Совпадение типа: необходимое условие «это та же колонка».
+  const actualTypeId = existing.columns.get(from);
+  if (
+    actualTypeId === undefined ||
+    PRIMITIVE_TO_TYPE_ID[toType] !== actualTypeId
+  ) {
+    return [];
+  }
+
+  // PK: переименование ключевой колонки в YDB невозможно — только ручная миграция.
+  if (existing.primaryKey.includes(from) || expected.primaryKey.includes(to)) {
+    return [];
+  }
+
+  // Индексы: расхождение индексов вокруг пары — это изменение индекса,
+  // а не простое переименование.
+  const referencedByIndex = (columnsList: string[][], name: string) =>
+    columnsList.some((cols) => cols.includes(name));
+  if (
+    referencedByIndex(
+      (existing.indexes ?? []).map((idx) => idx.columns),
+      from,
+    ) ||
+    referencedByIndex(
+      (expected.indexes ?? []).map((idx) => idx.columns),
+      to,
+    )
+  ) {
+    return [];
+  }
+
+  // TTL: перенос TTL-колонки — изменение настроек TTL, не простое переименование.
+  if (existing.ttl?.column === from || expected.ttl?.column === to) return [];
+
+  // Blind index/шифрование: synthetic-колонка либо появление/исчезновение
+  // `_bi`-парта — изменение метаданных шифрования.
+  if (from.endsWith(BLIND_INDEX_SUFFIX) || to.endsWith(BLIND_INDEX_SUFFIX)) {
+    return [];
+  }
+  if (
+    existing.columns.has(`${from}${BLIND_INDEX_SUFFIX}`) ||
+    `${to}${BLIND_INDEX_SUFFIX}` in expected.columns
+  ) {
+    return [];
+  }
+
+  return [{ from, to }];
+}
+
+/**
  * Чистая проверка: сравнивает ожидаемую схему с описанием таблицы из БД.
  * Не ходит в сеть и ничего не меняет.
  */
@@ -617,6 +723,12 @@ export function checkTableSchema(
     missingColumns,
     typeMismatches,
     extraColumns: uniqueExtraColumns,
+    likelyRenames: detectLikelyRenames(
+      expected,
+      existing,
+      missingColumns,
+      uniqueExtraColumns,
+    ),
     primaryKeyMatches,
     expectedPrimaryKey: [...expected.primaryKey],
     actualPrimaryKey: [...existing.primaryKey],
@@ -694,6 +806,18 @@ export function checkToIssues(check: SchemaCheckResult): YdbSchemaIssue[] {
       tableName: check.tableName,
       kind: 'extra-column',
       message: `Table "${check.tableName}" has extra column "${column}"`,
+    });
+  }
+  // #23: подсказка о вероятном переименовании — информационная, схему
+  // самой по себе не исправляет (колонка по-прежнему отсутствует в БД),
+  // поэтому расхождение остаётся и в verify, и в diffSchemas.
+  for (const rename of check.likelyRenames) {
+    issues.push({
+      tableName: check.tableName,
+      kind: 'rename-suggestion',
+      message:
+        `Table "${check.tableName}" column "${rename.from}" may have been renamed to ` +
+        `"${rename.to}" — review the data before migrating manually`,
     });
   }
   for (const idx of check.missingIndexes) {
@@ -888,6 +1012,16 @@ export class YdbSchemaSyncer {
         this.logger.warn(
           `Table "${expected.tableName}" has extra column "${extra}" ` +
             `not present in entity ${expected.tableName} — left as is`,
+        );
+      }
+
+      // #23: переименование никогда не применяется автоматически — sync
+      // по-прежнему добавляет новую колонку, старую не трогает.
+      for (const rename of check.likelyRenames) {
+        this.logger.warn(
+          `Table "${expected.tableName}" column "${rename.from}" may have been ` +
+            `renamed to "${rename.to}" — adding "${rename.to}", keeping ` +
+            `"${rename.from}"; rename/copy the data manually if confirmed`,
         );
       }
 


### PR DESCRIPTION
## Что сделано

Closes #23 (TODO.md #83).

При расхождении «лишняя колонка в БД + новая колонка в сущности» `migration:generate` теперь распознаёт вероятное переименование и предлагает его **только как подсказку**, не выполняя автоматически.

### Детекция (консервативная, только структурные признаки)

Подсказка выдаётся, когда выполнено **всё**:

- ровно одна лишняя колонка БД (`from`) и ровно одна новая колонка сущности (`to`) — однозначное соответствие, кандидатов на выбор нет;
- примитивный тип совпадает с фактическим типом колонки в БД (DescribeTable);
- пара не участвует в PK;
- пара не упоминается в колонках индексов (фактических и ожидаемых);
- пара не является TTL-колонкой (фактической или ожидаемой);
- расхождение не затрагивает blind index: обе колонки — не synthetic `_bi`, у каждой нет `_bi`-парта (изменения метаданных шифрования не маскируются под rename).

Схожесть имён **не используется** вообще. При любом несоответствии — прежнее поведение: `ADD COLUMN` + warning о лишней колонке.

### Генерация миграции

- `PlannedMigration.suggestions?: string[]` — для пары переименования ADD/DROP в up/down **подавляются**, вместо этого рендерится блок комментариев:
  \`\`\`
  // SUGGESTION (not applied automatically): possible column rename detected.
  // YQL has no ALTER TABLE RENAME COLUMN yet — verify the data and migrate manually:
  //   ALTER TABLE \`photos\` RENAME COLUMN \`label\` TO \`title\`;
  \`\`\`
  Исполняемого `RENAME COLUMN` в файле не появляется: YQL его пока не поддерживает (в YDB есть только переименование таблиц), применение — всегда вручную.
- Лишняя колонка по-прежнему честно остаётся в warnings («not dropped automatically») — деструктивные операции не выводятся молча.
- Вниз (down) остаётся симметричным и явным: для подавленной пары DDL нет, только тот же комментарий.

### Консистентность диагностики

- `checkTableSchema` → новое поле `likelyRenames`.
- `checkToIssues` / `diffSchemas` / `schema:verify` → новое informational-issue `'rename-suggestion'` (маркер `~`, жёлтый в CLI-diff) **рядом** с прежними `missing-column`/`extra-column`: подсказка сама по себе схему не исправляет.
- `YdbSchemaSyncer.sync` никогда не применяет переименование: добавляет новую колонку как раньше, старую не трогает (warn).

## Тесты

Регрессионные сценарии из задачи покрыты в `schema-sync.spec.ts` и `migration-generator.spec.ts`:

1. один missing + один extra с сильными признаками → suggestion, ADD/DROP подавлены;
2. неоднозначные кандидаты (2↔2) → догадки нет, прежний ADD/DROP;
3. несвязанные add/drop (типы различаются) → точное прежнее поведение;
4. PK/индекс/TTL/blind-index/unsupported-тип → rename не предлагается;
5. сгенерированный `up` содержит подсказку только комментарием, ни одного исполняемого `RENAME COLUMN`;
6. `down` безопасен и явен; смешанный план (statements + suggestion) рендерится корректно.

Полный прогон: **928 тестов зелёные**, `yarn build` и `yarn lint` (0 ошибок) — без замечаний.