### PR TITLE
feat(relations): фильтрация корня по колонкам связанных сущностей (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,47 @@ await UserEntity.findAll({
 
 Группы можно вкладывать друг в друга.
 
+### Фильтрация по связанным сущностям (#17)
+
+В WHERE вместо колонки можно указать свойство-связь (`@OneToMany` / `@ManyToOne` / `@OneToOne` / `@ManyToMany`) с объектом условий по колонкам связанной сущности — корневые строки фильтруются по наличию подходящей связанной строки:
+
+```ts
+// Пользователи, у которых есть роль 'admin' (one-to-many)
+await UserEntity.findAll({ userRoles: { is_global: true } });
+
+// Несколько related-предикатов + обычные условия корня (AND)
+await PhotoWithTagsEntity.findAll({
+  title: { $like: '%sunset%' },
+  tags: { name: 'nature' },          // many-to-many через join-таблицу
+  author: { status: 'active' },      // many-to-one
+});
+
+// Логические группы смешивают колонки корня и связи
+await UserEntity.findAll({
+  $or: [
+    { uuid: someUuid },
+    { userRoles: { role_uuid: adminRoleUuid } },
+  ],
+});
+```
+
+Поддержанные формы связи и генерируемый YQL (полуслияние `IN` с некоррелированным подзапросом — семантика `EXISTS`; коррелированные подзапросы ядром YQL не поддерживаются, а такой `IN` не порождает дубликатов корневых строк, поэтому `DISTINCT`/`JOIN` не нужны):
+
+| связь | условие |
+| --- | --- |
+| one-to-many | `root.pk IN (SELECT child.fk FROM target WHERE pred)` |
+| many-to-one / one-to-one | `root.fk IN (SELECT target.pk FROM target WHERE pred)` |
+| many-to-many | `root.pk IN (SELECT jt.owner FROM jt WHERE jt.inverse IN (SELECT target.pk FROM target WHERE pred))` |
+
+Пустой предикат `{ tags: {} }` означает «есть хотя бы одна связанная строка». Связи можно вкладывать (`{ linkedUser: { roles: { role: 'admin' } } }`).
+
+Ограничения и гарантии:
+
+- **Только нешифрованные колонки**: `@YdbEncrypted`-поля связанной сущности (включая их `{field}_bi`) в related-фильтрах запрещены — попытка ищется понятной ошибкой.
+- Валидация путей по метаданным: неизвестная связь/колонка, необъявленная join-колонка, несовместимые типы join-колонок, составной PK на стороне соединения (для one-to-many — у корня, для many-to-one/one-to-one — у цели) или отсутствие `@JoinTable` у many-to-many отвергаются ошибкой **до выполнения SQL**.
+- Все значения биндятся параметрами запроса; литералы в SQL не попадают.
+- Работает во всех методах с общим конвейером WHERE: `find`/`findOneBy`, `findAll`/`findBy`, `count`, `updateBy`, `deleteBy` и в QueryBuilder (`where`/`andWhere`/`orWhere`); `{ trx }`/ambient-транзакции и лимиты сохраняются.
+
 ## Декораторы
 
 - `@YdbEntity('table')` — имя таблицы; класс попадает в глобальный реестр сущностей (используется schema sync).

--- a/src/persistence/entity-persistence.ts
+++ b/src/persistence/entity-persistence.ts
@@ -29,6 +29,12 @@ import type { YdbValidationProvider } from '../validation/ydb-validate.interface
 import { YdbEntityValidationError } from '../validation/validation-error.js';
 import { YdbQueryBuilder } from '../query/query-builder.js';
 import type { YdbBaseEntity } from '../entity/base-entity.js';
+import {
+  getYdbRelationsMetadata,
+  resolveRelationJoinColumn,
+  type RelationMetadata,
+} from '../decorators/relation.decorators.js';
+import { resolveManyToManyJoinTable } from '../relations/resolve-join-table.js';
 
 /**
  * Конструктор сущности, совместимый с YdbBaseEntity.
@@ -97,11 +103,23 @@ export function getEntityDbSchema(
   return schema;
 }
 
-interface WhereBuildContext {
+export interface WhereBuildContext {
   values: Record<string, any>;
   keys: string[];
   dbSchema: Record<string, YdbPrimitive>;
   counter: number;
+}
+
+/**
+ * Окружение построения одного WHERE-узла.
+ *
+ * `forbidEncrypted` включается внутри related-предикатов (#17): фильтрация
+ * по колонкам связанных сущностей разрешена только для нешифрованных колонок
+ * (blind index тоже запрещён — подзапрос по связанной таблице не имеет
+ * доступа к провайдеру хешей корневого запроса и усложнил бы семантику).
+ */
+export interface WhereBuildEnv {
+  forbidEncrypted: boolean;
 }
 
 /**
@@ -534,6 +552,7 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
     value: any,
     ctx: WhereBuildContext,
     isRoot: boolean,
+    env: WhereBuildEnv,
   ): Promise<string | undefined> {
     const meta = this.getMeta();
     const dbSchema = getEntityDbSchema(meta);
@@ -546,11 +565,27 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
       );
     }
 
+    // Synthetic {field}_bi колонки в related-предикатах запрещены (#17):
+    // это производное шифрованного поля, а не самостоятельная колонка.
+    if (env.forbidEncrypted && isSyntheticColumn(meta, field)) {
+      throw new Error(
+        `Cannot filter related entity ${this.entityClass.name} by blind index column "${field}": ` +
+          `encrypted columns (including their blind indexes) are not allowed in related filters (#17).`,
+      );
+    }
+
     const ef = meta.encryptedFields.find((e) => e.propertyKey === field);
     const fieldType = dbSchema[field];
 
     // Зашифрованные поля ищутся только по blind-index (равенство).
     if (ef) {
+      // В related-предикатах шифрованные поля запрещены полностью (#17).
+      if (env.forbidEncrypted) {
+        throw new Error(
+          `Cannot filter related entity ${this.entityClass.name} by encrypted field "${field}": ` +
+            `related-column filters support only non-encrypted columns (#17).`,
+        );
+      }
       const isEqOperatorObject =
         this.isOperatorObject(value) &&
         Object.keys(value).length === 1 &&
@@ -810,13 +845,19 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
 
   /**
    * Рекурсивно строит SQL-условие из WHERE-объекта.
+   *
+   * Ключи резолвятся по приоритету: логический комбинатор ($and/$or) →
+   * колонка сущности → related-фильтр (#17, свойство-связь с объектом
+   * условий по колонкам связанной сущности).
    */
   private async buildWhereNode(
     node: Record<string, any>,
     ctx: WhereBuildContext,
     isRoot: boolean,
+    env: WhereBuildEnv,
   ): Promise<string | undefined> {
     const parts: string[] = [];
+    const dbSchema = getEntityDbSchema(this.getMeta());
 
     for (const [key, value] of Object.entries(node)) {
       if (value === undefined) continue;
@@ -836,14 +877,26 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
               `Logical operator "${key}" on entity ${this.entityClass.name} expects objects, got ${typeof sub}.`,
             );
           }
-          const subSql = await this.buildWhereNode(sub, ctx, false);
+          const subSql = await this.buildWhereNode(sub, ctx, false, env);
           if (subSql) subs.push(subSql);
         }
         if (subs.length) {
           parts.push(`(${subs.join(` ${combiner} `)})`);
         }
+      } else if (!dbSchema[key] && this.findRelation(key)) {
+        // Related-фильтр (#17): ключ — свойство-связь, значение — предикат
+        // по колонкам связанной сущности. Колонки проверяются первыми:
+        // существующее поведение для полей не меняется.
+        const sql = await this.buildRelatedCondition(key, value, ctx);
+        parts.push(sql);
       } else {
-        const sql = await this.buildFieldCondition(key, value, ctx, isRoot);
+        const sql = await this.buildFieldCondition(
+          key,
+          value,
+          ctx,
+          isRoot,
+          env,
+        );
         if (sql) parts.push(sql);
       }
     }
@@ -871,7 +924,9 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
       counter: 0,
     };
 
-    const sql = await this.buildWhereNode(where, ctx, true);
+    const sql = await this.buildWhereNode(where, ctx, true, {
+      forbidEncrypted: false,
+    });
 
     return {
       whereClause: sql ? `WHERE ${sql}` : '',
@@ -879,6 +934,223 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
       keys: ctx.keys,
       dbSchema: ctx.dbSchema,
     };
+  }
+
+  // ---- Related-фильтры (#17): findAll({ relation: { column: value } }) ----
+
+  /** Ищет связь по имени свойства. */
+  private findRelation(propertyKey: string): RelationMetadata | undefined {
+    return getYdbRelationsMetadata(this.entityClass).find(
+      (r) => r.propertyKey === propertyKey,
+    );
+  }
+
+  /**
+   * @internal Строит WHERE-узел предиката связанной сущности в ОБЩИЙ контекст
+   * параметров родительского запроса (#17). Шифрованные колонки запрещены.
+   * Вызывается на persistence-инстансе целевой сущности, поэтому enum/JSON-
+   * нормализация значений работает по метаданным цели.
+   */
+  async buildRelatedPredicate(
+    node: Record<string, any>,
+    ctx: WhereBuildContext,
+  ): Promise<string | undefined> {
+    return this.buildWhereNode(node, ctx, false, { forbidEncrypted: true });
+  }
+
+  /**
+   * Условие фильтрации корня по колонкам связанной сущности (#17).
+   *
+   * Стратегия — полуслияние через IN с некоррелированным подзапросом:
+   * семантика EXISTS без дубликатов корневых строк. Классический EXISTS
+   * не генерируется намеренно: ядро YQL не поддерживает коррелированные
+   * подзапросы (ссылку на внешний запрос), а некоррелированный EXISTS
+   * менял бы семантику на «существует хотя бы одна строка вообще».
+   *
+   * Join-колонки и пути резолвятся только из существующих метаданных связи
+   * (@OneToMany/@ManyToOne/@OneToOne/@ManyToMany + @JoinTable); произвольные
+   * SQL-фрагменты невозможны. Все значения биндятся через общий контекст
+   * параметров (ctx) — интерполяции пользовательских значений нет.
+   *
+   * Поддержанные формы:
+   * - one-to-many: `root.pk IN (SELECT child.fk FROM target WHERE pred)`
+   * - many-to-one / one-to-one: `root.fk IN (SELECT target.pk FROM target WHERE pred)`
+   * - many-to-many: `root.pk IN (SELECT jt.owner FROM jt WHERE jt.inverse IN
+   *   (SELECT target.pk FROM target WHERE pred))`
+   *
+   * Формы, которые текущая рантайм-модель связей моделирует некорректно
+   * (составные PK на стороне соединения, необъявленные join-колонки,
+   * несовместимые типы, отсутствие @JoinTable), отвергаются с понятной
+   * ошибкой ДО выполнения SQL.
+   */
+  private async buildRelatedCondition(
+    relationPropertyKey: string,
+    predicate: unknown,
+    ctx: WhereBuildContext,
+  ): Promise<string> {
+    if (
+      predicate === null ||
+      typeof predicate !== 'object' ||
+      Array.isArray(predicate)
+    ) {
+      const got =
+        predicate === null
+          ? 'null'
+          : Array.isArray(predicate)
+            ? 'array'
+            : typeof predicate;
+      throw new Error(
+        `Invalid filter on relation "${relationPropertyKey}" of ${this.entityClass.name}: ` +
+          `expected an object with conditions on the related entity columns, got ${got}.`,
+      );
+    }
+
+    const relation = this.findRelation(relationPropertyKey);
+    if (!relation) {
+      throw new Error(
+        `Unknown relation: "${relationPropertyKey}" on entity ${this.entityClass.name}.`,
+      );
+    }
+
+    const Target = relation.target();
+    const targetMeta = getYdbEntityMetadata(Target);
+    if (!targetMeta) {
+      throw new Error(
+        `Cannot filter by relation "${relationPropertyKey}" of ${this.entityClass.name}: ` +
+          `target entity ${Target.name} is not decorated with @YdbEntity.`,
+      );
+    }
+
+    const rootMeta = this.getMeta();
+    const relationDesc = `"${relationPropertyKey}" (${relation.type}) of ${this.entityClass.name} -> ${Target.name}`;
+
+    // Предикат по колонкам цели строится persistence-инстансом ЦЕЛИ в общий
+    // контекст параметров родителя: уникальность имён обеспечивает общий
+    // счётчик, конвертация enum/JSON — метаданные цели.
+    const targetPersistence = new YdbEntityPersistence(Target, undefined, {});
+    const innerWhere = await targetPersistence.buildRelatedPredicate(
+      predicate as Record<string, any>,
+      ctx,
+    );
+    const innerSubquery = (selectColumn: string): string =>
+      `SELECT ${quoteIdentifier(selectColumn)} FROM ${quoteIdentifier(targetMeta.tableName)}` +
+      `${innerWhere ? ` WHERE ${innerWhere}` : ''}`;
+
+    switch (relation.type) {
+      case 'one-to-many': {
+        if (rootMeta.primaryKeys.length !== 1) {
+          throw new Error(
+            `Cannot filter by one-to-many relation "${relationPropertyKey}" of ${this.entityClass.name}: ` +
+              `the entity has a composite primary key (${rootMeta.primaryKeys.join(', ')}). ` +
+              `The current relation model joins children by a single primary key column.`,
+          );
+        }
+        const rootPk = rootMeta.primaryKeys[0];
+        const fkColumn = resolveRelationJoinColumn(relation.joinColumn, {
+          entityName: this.entityClass.name,
+          relationPropertyKey,
+        });
+        const fkType = targetMeta.schema[fkColumn];
+        if (!fkType) {
+          throw new Error(
+            `Invalid one-to-many relation "${relationPropertyKey}" of ${this.entityClass.name}: ` +
+              `join column "${fkColumn}" is not declared on target entity ${Target.name}.`,
+          );
+        }
+        this.assertCompatibleJoinTypes(
+          relationDesc,
+          `${this.entityClass.name}.${rootPk}`,
+          rootMeta.schema[rootPk],
+          `${Target.name}.${fkColumn}`,
+          fkType,
+        );
+        return `${quoteIdentifier(rootPk)} IN (${innerSubquery(fkColumn)})`;
+      }
+      case 'many-to-one':
+      case 'one-to-one': {
+        const fkColumn = resolveRelationJoinColumn(relation.joinColumn, {
+          entityName: this.entityClass.name,
+          relationPropertyKey,
+        });
+        const fkType = rootMeta.schema[fkColumn];
+        if (!fkType) {
+          throw new Error(
+            `Invalid ${relation.type} relation "${relationPropertyKey}" of ${this.entityClass.name}: ` +
+              `join column "${fkColumn}" is not declared on the entity.`,
+          );
+        }
+        if (targetMeta.primaryKeys.length !== 1) {
+          throw new Error(
+            `Cannot filter by ${relation.type} relation "${relationPropertyKey}" of ${this.entityClass.name}: ` +
+              `target entity ${Target.name} has a composite primary key (${targetMeta.primaryKeys.join(', ')}). ` +
+              `The current relation model joins parents by a single primary key column.`,
+          );
+        }
+        const targetPk = targetMeta.primaryKeys[0];
+        this.assertCompatibleJoinTypes(
+          relationDesc,
+          `${this.entityClass.name}.${fkColumn}`,
+          fkType,
+          `${Target.name}.${targetPk}`,
+          targetMeta.schema[targetPk],
+        );
+        return `${quoteIdentifier(fkColumn)} IN (${innerSubquery(targetPk)})`;
+      }
+      case 'many-to-many': {
+        const joinTable = resolveManyToManyJoinTable(
+          this.entityClass,
+          relation,
+        );
+        if (!joinTable) {
+          throw new Error(
+            `Cannot filter by many-to-many relation "${relationPropertyKey}" of ${this.entityClass.name}: ` +
+              `no @JoinTable is declared for it. Filtering through many-to-many relations ` +
+              `is supported from the owning side that declares the join table.`,
+          );
+        }
+        // resolveManyToManyJoinTable гарантирует одиночные PK обеих сторон:
+        // составной PK дал бы ошибку конфигурации выше по резолву.
+        const rootPk = rootMeta.primaryKeys[0];
+        const targetPk = targetMeta.primaryKeys[0];
+        return (
+          `${quoteIdentifier(rootPk)} IN (` +
+          `SELECT ${quoteIdentifier(joinTable.ownerColumn)} FROM ${quoteIdentifier(joinTable.tableName)} ` +
+          `WHERE ${quoteIdentifier(joinTable.inverseColumn)} IN (${innerSubquery(targetPk)}))`
+        );
+      }
+      default:
+        throw new Error(
+          `Cannot filter by relation "${relationPropertyKey}" of ${this.entityClass.name}: ` +
+            `unsupported relation type "${String(relation.type)}".`,
+        );
+    }
+  }
+
+  /**
+   * Совместимость типов join-колонок для related-фильтра (#17):
+   * сравнение разных YDB-типов в IN (...) упало бы уже на сервере —
+   * сообщаем о конфигурации связи раньше, с именами колонок и типов.
+   */
+  private assertCompatibleJoinTypes(
+    relationDesc: string,
+    outerColumn: string,
+    outerType: YdbPrimitive | undefined,
+    innerColumn: string,
+    innerType: YdbPrimitive | undefined,
+  ): void {
+    if (!outerType || !innerType) {
+      throw new Error(
+        `Cannot filter by relation ${relationDesc}: join column type is not declared ` +
+          `(${outerColumn}, ${innerColumn}). Declare both columns via @YdbColumn/@YdbPrimaryColumn.`,
+      );
+    }
+    if (outerType !== innerType) {
+      throw new Error(
+        `Cannot filter by relation ${relationDesc}: join column types differ — ` +
+          `${outerColumn} is ${outerType}, ${innerColumn} is ${innerType}. ` +
+          `IN (...) between different YDB types would fail at execution.`,
+      );
+    }
   }
 
   private async executeQuery<U>(

--- a/src/persistence/related-filter.spec.ts
+++ b/src/persistence/related-filter.spec.ts
@@ -1,0 +1,495 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import {
+  YdbEntity,
+  YdbColumn,
+  YdbPrimaryColumn,
+  YdbEncrypted,
+  OneToMany,
+  ManyToOne,
+  ManyToMany,
+  JoinTable,
+  YdbBaseEntity,
+} from '../index.js';
+import { getEntityRuntime } from '../entity/entity-runtime.js';
+import { createMockExecutor } from '../../test/helpers/mock-executor.js';
+import {
+  configureTransactionContext,
+  runWithTransactionContext,
+} from '../transaction/transaction-context.js';
+
+// ---- Тестовая модель (#17): все типы связей + формы для ошибок ----
+// Классы-цели объявляются ДО классов-владельцев singular-связей:
+// emitDecoratorMetadata порождает design:type со ссылкой на класс,
+// и прямая ссылка «вперёд» упала бы по TDZ.
+
+@YdbEntity('rf_profiles')
+class RfProfile extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @YdbColumn('Utf8')
+  bio: string;
+}
+
+@YdbEntity('rf_roles')
+class RfRole extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  // FK на владельца; составной PK дочерней сущности не мешает o2m-фильтру:
+  // соединение идёт по колонке user_uuid, а не по PK цели.
+  @YdbPrimaryColumn('Uuid')
+  user_uuid: string;
+
+  @YdbColumn('Utf8')
+  role: string;
+
+  @YdbColumn('Bool')
+  is_admin: boolean;
+}
+
+@YdbEntity('rf_tags')
+class RfTag extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @YdbColumn('Utf8')
+  name: string;
+
+  @ManyToMany(() => RfUser, (user) => user.tags)
+  users?: RfUser[];
+}
+
+@YdbEntity('rf_bigs')
+class RfBig extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  id: string;
+
+  @YdbPrimaryColumn('Uuid')
+  part: string;
+}
+
+class BareClass extends YdbBaseEntity {}
+
+@YdbEntity('rf_users')
+class RfUser extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @YdbColumn('Utf8')
+  status: string;
+
+  @YdbEncrypted()
+  email_encrypted: string;
+
+  @YdbColumn('Uuid')
+  profile_uuid: string;
+
+  @OneToMany(() => RfRole, (role) => role.user_uuid)
+  roles?: RfRole[];
+
+  @ManyToOne(() => RfProfile, (self) => self.profile_uuid)
+  profile?: RfProfile;
+
+  @ManyToMany(() => RfTag)
+  @JoinTable('rf_users_rf_tags')
+  tags?: RfTag[];
+}
+
+// Составной PK корня: one-to-many по первому PK смоделирован быть не может.
+@YdbEntity('rf_composites')
+class RfComposite extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  tenant_id: string;
+
+  @YdbPrimaryColumn('Uuid')
+  user_uuid: string;
+
+  @OneToMany(() => RfRole, (role) => role.user_uuid)
+  roles?: RfRole[];
+
+  // m2o на составной PK цели — неподдерживаемая форма.
+  @YdbColumn('Uuid')
+  big_ref: string;
+
+  @ManyToOne(() => RfBig, (self) => self.big_ref)
+  big?: RfBig;
+
+  // m2o с одиночным PK цели — для проверки запрета шифрованных колонок
+  // и вложенных related-путей.
+  @YdbColumn('Uuid')
+  user_link: string;
+
+  @ManyToOne(() => RfUser, (self) => self.user_link)
+  linkedUser?: RfUser;
+}
+
+// Несовпадение типов join-колонок: Int32 (корень) vs Uuid (FK цели).
+@YdbEntity('rf_mismatch_users')
+class RfMismatchUser extends YdbBaseEntity {
+  @YdbPrimaryColumn('Int32')
+  id: number;
+
+  @OneToMany(() => RfRole, (role) => role.user_uuid)
+  roles?: RfRole[];
+}
+
+// Join-колонка не объявлена на целевой сущности.
+@YdbEntity('rf_ghosts')
+class RfGhost extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @OneToMany(() => RfProfile, (profile) => profile.missing_col)
+  profiles?: RfProfile[];
+}
+
+// many-to-many без @JoinTable.
+@YdbEntity('rf_orphans')
+class RfOrphan extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @ManyToMany(() => RfTag)
+  tags?: RfTag[];
+}
+
+// Цель связи — класс без @YdbEntity.
+@YdbEntity('rf_to_bare')
+class RfToBare extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @ManyToOne(() => BareClass, (self) => self.bare_ref)
+  bare?: BareClass;
+
+  @YdbColumn('Uuid')
+  bare_ref: string;
+}
+
+const UUID = '11111111-1111-1111-1111-111111111111';
+
+function mockRuntime(rows: any[][] = [[]], sequential = false) {
+  const mock = createMockExecutor(rows, { sequential });
+  getEntityRuntime(RfUser).executor = mock.executor;
+  return mock;
+}
+
+describe('Related-entity filters (#17): findAll({ relation: { column } })', () => {
+  afterEach(() => {
+    // Глобальные настройки транзакций не должны протекать между тестами.
+    configureTransactionContext(undefined);
+  });
+
+  it('1. one-to-many: фильтр по одной колонке связанной сущности', async () => {
+    const mock = mockRuntime([
+      [{ uuid: UUID, status: 'active', profile_uuid: UUID }],
+    ]);
+
+    const users = await RfUser.findAll({ roles: { role: 'admin' } });
+
+    expect(users).toHaveLength(1);
+    expect(users[0].uuid).toBe(UUID);
+
+    const sql = mock.queries[0].sql;
+    expect(sql).toContain('FROM `rf_users`');
+    expect(sql).toContain(
+      '`uuid` IN (SELECT `user_uuid` FROM `rf_roles` WHERE `role` = $',
+    );
+    // Полуслияние, а не JOIN: дубликаты корневых строк невозможны.
+    expect(sql.toUpperCase()).not.toContain('JOIN');
+    expect(sql).not.toContain("'admin'");
+    expect(sql).toMatch(/LIMIT 100 OFFSET 0$/);
+  });
+
+  it('2. несколько related-предикатов AND с обычными условиями корня', async () => {
+    const mock = mockRuntime([]);
+
+    await RfUser.findAll({
+      status: 'active',
+      profile: { bio: 'engineer' },
+      roles: { is_admin: true },
+    });
+
+    const sql = mock.queries[0].sql;
+    // Корневое равенство + два независимых IN-подзапроса через AND.
+    expect(sql).toContain('`status` = $status');
+    expect(sql).toContain(
+      '`profile_uuid` IN (SELECT `uuid` FROM `rf_profiles` WHERE `bio` = $',
+    );
+    expect(sql).toContain(
+      '`uuid` IN (SELECT `user_uuid` FROM `rf_roles` WHERE `is_admin` = $',
+    );
+    expect(sql.match(/IN \(SELECT/g)?.length).toBe(2);
+    expect((mock.queries[0].params.status as any).value).toBe('active');
+  });
+
+  it('3. вложенные логические условия: $or/$and смешивают корень и связи', async () => {
+    const mock = mockRuntime([]);
+
+    await RfUser.findAll({
+      $or: [{ status: 'banned' }, { roles: { role: 'admin' } }],
+    });
+    const orSql = mock.queries[0].sql;
+    expect(orSql).toContain(
+      '(`status` = $status_0_eq OR `uuid` IN (SELECT `user_uuid` FROM `rf_roles` WHERE `role` = $',
+    );
+
+    // $or ВНУТРИ предиката связи.
+    await RfUser.findAll({
+      roles: { $or: [{ role: 'admin' }, { is_admin: true }] },
+    });
+    const innerOrSql = mock.queries[1].sql;
+    expect(innerOrSql).toContain(
+      '`uuid` IN (SELECT `user_uuid` FROM `rf_roles` WHERE (`role` = $',
+    );
+    expect(innerOrSql).toContain('OR `is_admin` = $');
+
+    // Та же связь дважды через $and: два отдельных подзапроса (семантика EXISTS).
+    await RfUser.findAll({
+      $and: [{ roles: { role: 'admin' } }, { roles: { is_admin: true } }],
+    });
+    const andSql = mock.queries[2].sql;
+    expect(andSql.match(/`uuid` IN \(SELECT `user_uuid`/g)?.length).toBe(2);
+    expect(andSql).toContain(') AND `uuid` IN (SELECT');
+
+    // Вложенный related-путь: связь связи.
+    getEntityRuntime(RfComposite).executor = mock.executor;
+    await RfComposite.findAll({ linkedUser: { roles: { role: 'admin' } } });
+    const nestedSql = mock.queries[3].sql;
+    expect(nestedSql).toContain(
+      '`user_link` IN (SELECT `uuid` FROM `rf_users` WHERE `uuid` IN ' +
+        '(SELECT `user_uuid` FROM `rf_roles` WHERE `role` = $',
+    );
+  });
+
+  it('4. several matching related rows still return the root once (no JOIN)', async () => {
+    const mock = mockRuntime([
+      [{ uuid: UUID, status: 'active', profile_uuid: UUID }],
+    ]);
+
+    const users = await RfUser.findAll({
+      roles: { role: 'admin' },
+    });
+
+    // Один запрос, одна строка: полуслияние IN не размножает корневые строки.
+    expect(mock.queries).toHaveLength(1);
+    expect(users).toHaveLength(1);
+    expect(mock.queries[0].sql.toUpperCase()).not.toContain('JOIN ');
+  });
+
+  it('5. unknown relation/column fails BEFORE executing SQL', async () => {
+    const mock = mockRuntime();
+
+    // Неизвестное свойство вообще (не колонка и не связь).
+    await expect(RfUser.findAll({ bogus_relation: { x: 1 } })).rejects.toThrow(
+      /Unknown field in WHERE: "bogus_relation"/,
+    );
+
+    // Связь существует, колонка на цели — нет.
+    await expect(RfUser.findAll({ roles: { nope: 1 } })).rejects.toThrow(
+      /Unknown field in WHERE: "nope" on entity RfRole/,
+    );
+
+    // Невалидная форма предиката.
+    await expect(RfUser.findAll({ roles: null as any })).rejects.toThrow(
+      /Invalid filter on relation "roles".*got null/,
+    );
+    await expect(RfUser.findAll({ roles: [{}] as any })).rejects.toThrow(
+      /Invalid filter on relation "roles".*got array/,
+    );
+
+    expect(mock.executor).not.toHaveBeenCalled();
+  });
+
+  it('6. encrypted related column is rejected clearly (incl. blind index)', async () => {
+    // RfComposite нужен собственный executor: проверка executor'а происходит
+    // до построения WHERE, а валидация шифрованных колонок — до выполнения SQL.
+    const mock = createMockExecutor([[[]]]);
+    getEntityRuntime(RfComposite).executor = mock.executor;
+
+    // Даже blind index запрещён внутри related-фильтров (#17).
+    await expect(
+      RfComposite.findAll({ linkedUser: { email_encrypted: 'a@b.c' } }),
+    ).rejects.toThrow(
+      /Cannot filter related entity RfUser by encrypted field "email_encrypted"/,
+    );
+
+    await expect(
+      RfComposite.findAll({
+        linkedUser: { email_encrypted_bi: 'hash' } as any,
+      }),
+    ).rejects.toThrow(/blind index column "email_encrypted_bi"/);
+
+    expect(mock.executor).not.toHaveBeenCalled();
+  });
+
+  it('7. empty predicate and no-match related rows return correct results', async () => {
+    // Пустой предикат {} = «есть хотя бы одна связанная строка».
+    const emptyMock = mockRuntime([]);
+    const none = await RfUser.findAll({ roles: {} });
+    expect(none).toEqual([]);
+    expect(emptyMock.queries[0].sql).toContain(
+      '`uuid` IN (SELECT `user_uuid` FROM `rf_roles`) LIMIT',
+    );
+
+    // Связанные строки есть, но предикат не совпал — пустой результат корней.
+    const noMatchMock = mockRuntime([[]]);
+    const noMatch = await RfUser.findAll({ roles: { role: 'admin' } });
+    expect(noMatch).toEqual([]);
+    expect(noMatchMock.queries[0].sql).toContain('WHERE `role` = $');
+  });
+
+  it('8. explicit { trx } and ambient transaction paths are preserved', async () => {
+    const base = createMockExecutor([[[]]]);
+    const trx = createMockExecutor([[[]]]);
+    getEntityRuntime(RfUser).executor = base.executor;
+
+    // Явная транзакция.
+    await RfUser.findAll({ roles: { role: 'admin' } }, { trx: trx.executor });
+    expect(trx.queries).toHaveLength(1);
+    expect(base.queries).toHaveLength(0);
+
+    // Ambient auto-join (#98).
+    configureTransactionContext({ ambient: true });
+    const ambTrx = createMockExecutor([[[]]]);
+    await runWithTransactionContext(
+      { trx: ambTrx.executor, db: base.executor, ambient: true },
+      async () => {
+        await RfUser.findAll({ roles: { role: 'admin' } });
+      },
+    );
+    expect(ambTrx.queries).toHaveLength(1);
+    expect(base.queries).toHaveLength(0);
+  });
+
+  it('9. generated YQL binds values via parameters only', async () => {
+    const mock = mockRuntime([]);
+
+    const { sql, values } = await RfUser.query()
+      .where({ status: 'active', roles: { role: 'admin' } })
+      .limit(10)
+      .toYql();
+
+    // Ни одного литерала значения в SQL — только плейсхолдеры $param.
+    expect(sql).not.toContain('admin');
+    expect(sql).not.toContain("'active'");
+    expect(sql).toContain('LIMIT 10');
+    expect(Object.keys(values)).toContain('role_0_eq');
+
+    await RfUser.count({ roles: { is_admin: true } });
+    const countSql = mock.queries[0].sql;
+    expect(countSql).toContain('SELECT COUNT(*) AS cnt FROM `rf_users`');
+    expect(countSql).toContain(
+      '`uuid` IN (SELECT `user_uuid` FROM `rf_roles` WHERE `is_admin` = $',
+    );
+  });
+});
+
+describe('Related-entity filters (#17): unsupported shapes fail clearly', () => {
+  beforeEach(() => {
+    getEntityRuntime(RfComposite).executor = undefined;
+    getEntityRuntime(RfMismatchUser).executor = undefined;
+    getEntityRuntime(RfGhost).executor = undefined;
+    getEntityRuntime(RfOrphan).executor = undefined;
+    getEntityRuntime(RfToBare).executor = undefined;
+  });
+
+  function failingRuntime(): ReturnType<typeof createMockExecutor> {
+    const mock = createMockExecutor([[[]]]);
+    for (const E of [
+      RfComposite,
+      RfMismatchUser,
+      RfGhost,
+      RfOrphan,
+      RfToBare,
+    ]) {
+      getEntityRuntime(E).executor = mock.executor;
+    }
+    return mock;
+  }
+
+  it('composite root PK with one-to-many is rejected', async () => {
+    const mock = failingRuntime();
+    await expect(
+      RfComposite.findAll({ roles: { role: 'admin' } }),
+    ).rejects.toThrow(/composite primary key \(tenant_id, user_uuid\)/);
+    expect(mock.executor).not.toHaveBeenCalled();
+  });
+
+  it('composite target PK with many-to-one is rejected', async () => {
+    const mock = failingRuntime();
+    await expect(RfComposite.findAll({ big: { part: 'x' } })).rejects.toThrow(
+      /target entity RfBig has a composite primary key/,
+    );
+    expect(mock.executor).not.toHaveBeenCalled();
+  });
+
+  it('mismatched join column types are rejected before execution', async () => {
+    const mock = failingRuntime();
+    await expect(
+      RfMismatchUser.findAll({ roles: { role: 'admin' } }),
+    ).rejects.toThrow(
+      /join column types differ.*RfMismatchUser\.id is Int32, RfRole\.user_uuid is Uuid/,
+    );
+    expect(mock.executor).not.toHaveBeenCalled();
+  });
+
+  it('undeclared join column on target is rejected', async () => {
+    const mock = failingRuntime();
+    await expect(RfGhost.findAll({ profiles: { bio: 'x' } })).rejects.toThrow(
+      /join column "missing_col" is not declared on target entity RfProfile/,
+    );
+    expect(mock.executor).not.toHaveBeenCalled();
+  });
+
+  it('many-to-many without @JoinTable is rejected', async () => {
+    const mock = failingRuntime();
+    await expect(RfOrphan.findAll({ tags: { name: 'x' } })).rejects.toThrow(
+      /no @JoinTable is declared/,
+    );
+    expect(mock.executor).not.toHaveBeenCalled();
+  });
+
+  it('target without @YdbEntity is rejected', async () => {
+    const mock = failingRuntime();
+    await expect(
+      RfToBare.findAll({ bare: { uuid: 'x' } as any }),
+    ).rejects.toThrow(
+      /target entity BareClass is not decorated with @YdbEntity/,
+    );
+    expect(mock.executor).not.toHaveBeenCalled();
+  });
+});
+
+describe('Related-entity filters (#17): many-to-many through join table', () => {
+  it('builds nested IN subquery via join table and returns hydrated roots', async () => {
+    const mock = createMockExecutor([
+      [{ uuid: UUID, status: 'active', profile_uuid: UUID }],
+    ]);
+    getEntityRuntime(RfUser).executor = mock.executor;
+
+    const users = await RfUser.findAll({ tags: { name: 'urgent' } });
+
+    const sql = mock.queries[0].sql;
+    expect(sql).toContain(
+      '`uuid` IN (SELECT `rf_users_uuid` FROM `rf_users_rf_tags` ' +
+        'WHERE `rf_tags_uuid` IN (SELECT `uuid` FROM `rf_tags` WHERE `name` = $',
+    );
+    expect(users).toHaveLength(1);
+    expect(users[0].uuid).toBe(UUID);
+  });
+
+  it('mirror side without own @JoinTable resolves flipped join columns', async () => {
+    const mock = createMockExecutor([[[]]]);
+    getEntityRuntime(RfTag).executor = mock.executor;
+
+    await RfTag.findAll({ users: { status: 'active' } });
+
+    expect(mock.queries[0].sql).toContain(
+      '`uuid` IN (SELECT `rf_tags_uuid` FROM `rf_users_rf_tags` ' +
+        'WHERE `rf_users_uuid` IN (SELECT `uuid` FROM `rf_users` WHERE `status` = $',
+    );
+  });
+});

--- a/src/relations/entity-relations.ts
+++ b/src/relations/entity-relations.ts
@@ -2,14 +2,11 @@ import type { YdbBaseEntity } from '../entity/base-entity.js';
 import type { YdbEntityConstructor } from '../persistence/entity-persistence.js';
 import { getYdbEntityMetadata } from '../metadata/entity-metadata.js';
 import {
-  assertNoForeignJoinTableConflicts,
-  getManyToManyJoinTables,
   getYdbRelationsMetadata,
   resolveRelationJoinColumn,
 } from '../decorators/relation.decorators.js';
 import type { QueryOptions } from '../core/query-options.js';
 import type { YdbExecutor } from '../core/interfaces.js';
-import type { YdbPrimitive } from '../core/types.js';
 import type {
   YdbBlindIndexProvider,
   YdbEncryptionProvider,
@@ -21,6 +18,10 @@ import { quoteIdentifier } from '../core/sql-utils.js';
 import { resolveOperationExecutor } from '../transaction/transaction-context.js';
 import { chunkInValues, dedupeInValues } from '../core/query-limits.js';
 import { mapToYdb } from '../core/mapper.js';
+import {
+  resolveManyToManyJoinTable,
+  type ResolvedJoinTable,
+} from './resolve-join-table.js';
 
 /**
  * Зависимости relations-модуля.
@@ -483,80 +484,4 @@ function getPrimaryKey(target: typeof YdbBaseEntity): string {
     throw new Error(`Entity ${target.name} must declare a primary key`);
   }
   return meta.primaryKeys[0];
-}
-
-/**
- * Находит метаданные join-таблицы для many-to-many,
- * ориентированные относительно запрашиваемой сущности (owner).
- *
- * Валидация и разрешение конфликтов выполняются тем же кодом, что и при
- * генерации схемы: getManyToManyJoinTables для пары сущностей. Поэтому
- * рантайм не может молча выбрать одно из расходящихся объявлений таблицы —
- * он упадёт с той же ошибкой конфликта, что и schema sync/migrations (#139).
- */
-interface ResolvedJoinTable {
-  tableName: string;
-  ownerColumn: string;
-  inverseColumn: string;
-  /**
-   * YDB-тип owner-колонки join-таблицы (#90): тип PK owner-сущности.
-   * Схема join-таблицы (schema sync) выводит те же имена и типы, поэтому
-   * чтение всегда совместимо со сгенерированной таблицей.
-   */
-  ownerColumnType: YdbPrimitive;
-  ownerEntity: typeof YdbBaseEntity;
-  inverseEntity: typeof YdbBaseEntity;
-}
-
-function resolveManyToManyJoinTable(
-  owner: typeof YdbBaseEntity,
-  relation: { propertyKey: string; target: () => typeof YdbBaseEntity },
-): ResolvedJoinTable | undefined {
-  const ownerMeta = getYdbEntityMetadata(owner);
-  const inverseEntity = relation.target();
-  const inverseMeta = getYdbEntityMetadata(inverseEntity);
-  if (!ownerMeta || !inverseMeta) return undefined;
-
-  // Все объявления join-таблиц, видимые для пары (владелец, inverse):
-  // здесь же проверяются PK и конфликты объявлений одного имени (#90/#139).
-  const definitions = getManyToManyJoinTables([owner, inverseEntity]);
-
-  // Декларация на самом владельце для этой связи.
-  const own = definitions.find(
-    (d) => d.ownerEntity === owner && d.ownerProperty === relation.propertyKey,
-  );
-  if (own) {
-    assertNoForeignJoinTableConflicts(own);
-    return {
-      tableName: own.tableName,
-      ownerColumn: own.joinColumn,
-      inverseColumn: own.inverseJoinColumn,
-      // Имя, тип и сущности берутся из того же определения, по которому
-      // строится схема join-таблицы (#87): расхождений между рантаймом
-      // и schema sync быть не может.
-      ownerColumnType: own.joinColumnType,
-      ownerEntity: owner,
-      inverseEntity,
-    };
-  }
-
-  // Зеркальная декларация на обратной стороне: колонки разворачиваются —
-  // joinColumn объявления принадлежит inverse-сущности, inverseJoinColumn — владельцу.
-  const inverseOwned = definitions.find(
-    (d) => d.ownerEntity === inverseEntity && d.inverseEntity === owner,
-  );
-  if (inverseOwned) {
-    assertNoForeignJoinTableConflicts(inverseOwned);
-    return {
-      tableName: inverseOwned.tableName,
-      ownerColumn: inverseOwned.inverseJoinColumn,
-      inverseColumn: inverseOwned.joinColumn,
-      // Тип owner-колонки = тип PK владельца = тип её колонки в объявлении.
-      ownerColumnType: inverseOwned.inverseJoinColumnType,
-      ownerEntity: owner,
-      inverseEntity,
-    };
-  }
-
-  return undefined;
 }

--- a/src/relations/resolve-join-table.ts
+++ b/src/relations/resolve-join-table.ts
@@ -1,0 +1,90 @@
+import type { YdbBaseEntity } from '../entity/base-entity.js';
+import { getYdbEntityMetadata } from '../metadata/entity-metadata.js';
+import {
+  assertNoForeignJoinTableConflicts,
+  getManyToManyJoinTables,
+} from '../decorators/relation.decorators.js';
+import type { YdbPrimitive } from '../core/types.js';
+
+/**
+ * Метаданные join-таблицы many-to-many, ориентированные относительно
+ * запрашиваемой сущности (owner).
+ *
+ * Вынесено из entity-relations в отдельный модуль (#17): related-фильтры
+ * в entity-persistence используют тот же резолв, что и eager/lazy-загрузка,
+ * а прямой импорт entity-relations из persistence породил бы цикл.
+ */
+export interface ResolvedJoinTable {
+  tableName: string;
+  ownerColumn: string;
+  inverseColumn: string;
+  /**
+   * YDB-тип owner-колонки join-таблицы (#90): тип PK owner-сущности.
+   * Схема join-таблицы (schema sync) выводит те же имена и типы, поэтому
+   * чтение всегда совместимо со сгенерированной таблицей.
+   */
+  ownerColumnType: YdbPrimitive;
+  ownerEntity: typeof YdbBaseEntity;
+  inverseEntity: typeof YdbBaseEntity;
+}
+
+/**
+ * Находит метаданные join-таблицы для many-to-many.
+ *
+ * Валидация и разрешение конфликтов выполняются тем же кодом, что и при
+ * генерации схемы: getManyToManyJoinTables для пары сущностей. Поэтому
+ * рантайм не может молча выбрать одно из расходящихся объявлений таблицы —
+ * он упадёт с той же ошибкой конфликта, что и schema sync/migrations (#139).
+ */
+export function resolveManyToManyJoinTable(
+  owner: typeof YdbBaseEntity,
+  relation: { propertyKey: string; target: () => typeof YdbBaseEntity },
+): ResolvedJoinTable | undefined {
+  const ownerMeta = getYdbEntityMetadata(owner);
+  const inverseEntity = relation.target();
+  const inverseMeta = getYdbEntityMetadata(inverseEntity);
+  if (!ownerMeta || !inverseMeta) return undefined;
+
+  // Все объявления join-таблиц, видимые для пары (владелец, inverse):
+  // здесь же проверяются PK и конфликты объявлений одного имени (#90/#139).
+  const definitions = getManyToManyJoinTables([owner, inverseEntity]);
+
+  // Декларация на самом владельце для этой связи.
+  const own = definitions.find(
+    (d) => d.ownerEntity === owner && d.ownerProperty === relation.propertyKey,
+  );
+  if (own) {
+    assertNoForeignJoinTableConflicts(own);
+    return {
+      tableName: own.tableName,
+      ownerColumn: own.joinColumn,
+      inverseColumn: own.inverseJoinColumn,
+      // Имя, тип и сущности берутся из того же определения, по которому
+      // строится схема join-таблицы (#87): расхождений между рантаймом
+      // и schema sync быть не может.
+      ownerColumnType: own.joinColumnType,
+      ownerEntity: owner,
+      inverseEntity,
+    };
+  }
+
+  // Зеркальная декларация на обратной стороне: колонки разворачиваются —
+  // joinColumn объявления принадлежит inverse-сущности, inverseJoinColumn — владельцу.
+  const inverseOwned = definitions.find(
+    (d) => d.ownerEntity === inverseEntity && d.inverseEntity === owner,
+  );
+  if (inverseOwned) {
+    assertNoForeignJoinTableConflicts(inverseOwned);
+    return {
+      tableName: inverseOwned.tableName,
+      ownerColumn: inverseOwned.inverseJoinColumn,
+      inverseColumn: inverseOwned.joinColumn,
+      // Тип owner-колонки = тип PK владельца = тип её колонки в объявлении.
+      ownerColumnType: inverseOwned.inverseJoinColumnType,
+      ownerEntity: owner,
+      inverseEntity,
+    };
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
## Что

Реализация #17: `findAll({ tags: { name: 'Ivan' } })` — фильтрация корневых сущностей по колонкам связанных сущностей.

## Стратегия генерации YQL

Полуслияние `IN (SELECT ...)` с некоррелированным подзапросом — эквивалент `EXISTS` без дубликатов корневых строк. Классический коррелированный `EXISTS` не генерируется намеренно: ядро YQL не поддерживает коррелированные подзапросы, а некоррелированный менял бы семантику. `JOIN + DISTINCT` не нужен: `IN`-полусоединение не размножает строки, поэтому существующие LIMIT/OFFSET/ORDER BY остаются точными.

| связь | условие |
| --- | --- |
| one-to-many | `root.pk IN (SELECT child.fk FROM target WHERE pred)` |
| many-to-one / one-to-one | `root.fk IN (SELECT target.pk FROM target WHERE pred)` |
| many-to-many | `root.pk IN (SELECT jt.owner FROM jt WHERE jt.inverse IN (SELECT target.pk FROM target WHERE pred))` |

## Гарантии

- **Пути только из метаданных**: ключи резолвятся через существующие `RelationMetadata`; произвольные SQL-фрагменты невозможны.
- **Только нешифрованные колонки** цели: `@YdbEncrypted` и synthetic `{field}_bi` в related-предикатах отвергаются понятной ошибкой.
- **Валидация до SQL**: неизвестная связь/колонка, необъявленная join-колонка, несовместимые типы join-колонок, составной PK на стороне соединения, отсутствие `@JoinTable`, невалидная форма предиката — ошибки до обращения к БД.
- **Без интерполяции значений**: все параметры через общий `ctx.values/keys/dbSchema` и `query.parameter(...)`.
- **Совместимость**: колонки проверяются раньше связей; вложенные related-пути и $or/$and на любом уровне; поддержка во всём конвейере WHERE и в QueryBuilder.
- **#98/#27 сохранены**: явный `{ trx }`, ambient auto-join, retry/idempotency и лимиты покрыты тестами.

## Рефакторинг

- `resolveManyToManyJoinTable` вынесен в `relations/resolve-join-table.ts` — переиспользование persistence без цикла импорта; логика резолва не изменена.

## Тесты

`src/persistence/related-filter.spec.ts` — 17 тестов, все 9 требуемых сценариев: одиночный фильтр; несколько предикатов AND; вложенная логика; отсутствие дубликатов без JOIN; отказ до SQL; запрет шифрованных колонок; пустой предикат/промах; explicit trx + ambient; параметризация YQL.

## Документация

- README.md: раздел «Фильтрация по связанным сущностям (#17)».
- docs-site: PR ycforge/docs#6 (ru+en).

## Проверка

`yarn build` ✅ · `yarn test` 945 passed ✅ · `yarn lint` 0 errors, warnings = baseline main ✅

Closes #17