### PR TITLE
feat(relations): вложенная eager-загрузка путей @EagerLoad(['tags.owner']) (#16)

### DIFF
--- a/src/persistence/entity-persistence.ts
+++ b/src/persistence/entity-persistence.ts
@@ -1251,7 +1251,7 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   private async hydrate(
     raw: Record<string, any>[],
     options?: QueryOptions,
-    opts?: { eager?: boolean },
+    opts?: { eager?: boolean; afterFind?: boolean },
   ): Promise<T[]> {
     await this.decryptResult(raw);
     const result = raw.map((r) => this.instantiate(r));
@@ -1269,7 +1269,13 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
       await this.loadEagerRelations(fresh, options, ctx);
     }
 
-    if (getLifecycleHooks(this.entityClass).afterFind.length) {
+    // afterFind может откладываться (#16): промежуточные уровни вложенного
+    // eager-пути срабатывают в пост-порядке — только после догрузки своих
+    // детей (см. YdbEntityRelations.loadRelationPath / fireAfterFindOn).
+    if (
+      (opts?.afterFind ?? true) &&
+      getLifecycleHooks(this.entityClass).afterFind.length
+    ) {
       for (const inst of fresh) {
         await this.callHooks('afterFind', inst);
       }
@@ -1964,6 +1970,18 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
     return instance;
   }
 
+  /**
+   * Вызывает afterFind на переданных инстансах (в пост-порядке вложенного
+   * eager-пути #16). Инстансы промежуточного уровня уже гидратированы с
+   * `afterFind: false`, поэтому срабатывание здесь — ровно один раз.
+   */
+  async fireAfterFind(instances: object[]): Promise<void> {
+    if (!getLifecycleHooks(this.entityClass).afterFind.length) return;
+    for (const inst of instances) {
+      await this.callHooks('afterFind', inst as any);
+    }
+  }
+
   // ---- Relations helpers (delegated to YdbEntityRelations at repository level) ----
 
   /**
@@ -1976,12 +1994,17 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
    *   список параметров и не меняли результат;
    * - значения больше MAX_IN_CLAUSE_VALUES режутся на несколько чанков
    *   (лимиты YDB на текст запроса/число параметров), результаты сливаются
-   *   по порядку чанков без дубликатов строк (по PK).
+   * по порядку чанков без дубликатов строк (по PK).
+   *
+   * `hydration.afterFind` (по умолчанию true): если false, гидратированные
+   * инстансы НЕ получают afterFind сразу — их послеFind откладывается для
+   * пост-порядка вложенного eager-пути (#16).
    */
   async fetchByColumnIn(
     column: string,
     values: any[],
     options?: QueryOptions,
+    hydration?: { afterFind?: boolean },
   ): Promise<T[]> {
     const exec = this.getExecutor(options?.trx);
     const meta = this.getMeta();
@@ -2016,10 +2039,13 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
       );
 
       // Внутренний batch-фетч связей: без вложенной догрузки eager — глубина
-      // остаётся 1 (как до #83), иначе циклические связи рекурсируют.
-      // afterFind при этом обязателен для связанных сущностей (issue #83).
+      // собственных eager-связей цели остаётся 1 (как до #83), иначе
+      // циклические связи рекурсируют. afterFind при этом обязателен для
+      // связанных сущностей (issue #83), но для промежуточных уровней
+      // вложенного eager-пути (#16) его можно отложить через hydration.
       const hydrated = await this.hydrate(rows[0] ?? [], options, {
         eager: false,
+        afterFind: hydration?.afterFind ?? true,
       });
 
       for (const entity of hydrated) {

--- a/src/relations/entity-relations.ts
+++ b/src/relations/entity-relations.ts
@@ -16,7 +16,10 @@ import { YdbEntityPersistence } from '../persistence/entity-persistence.js';
 import type { HydrationContext } from '../persistence/entity-persistence.js';
 import { getEagerRelations } from '../decorators/eager.decorator.js';
 import { quoteIdentifier } from '../core/sql-utils.js';
-import { resolveOperationExecutor } from '../transaction/transaction-context.js';
+import {
+  resolveOperationExecutor,
+  runWithTransactionContext,
+} from '../transaction/transaction-context.js';
 import { chunkInValues, dedupeInValues } from '../core/query-limits.js';
 import { mapToYdb } from '../core/mapper.js';
 import {
@@ -219,6 +222,14 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
    * Для многоуровневых путей afterFind промежуточных инстансов откладывается
    * (afterFind: false в гидратации) и срабатывает в пост-порядке — после
    * загрузки собственных детей — через fireAfterFindOn (см. #83/#107).
+   *
+   * Явный { trx } пробрасывается во ВЕСЬ обход (#16): на время многоуровневого
+   * пути открывается внутренний транзакционный контекст (per-call ambient из
+   * #98), поэтому запросы БЕЗ явного { trx } — включая те, что запускают
+   * afterFind-хуки промежуточных уровней — выполняются через тот же executor
+   * транзакции. Глобальный ambient для этого не нужен и не меняется; новая
+   * транзакция/сессия не создаётся (SDK исполняет повторные вызовы executor'а
+   * транзакции в ней же), commit/rollback остаётся у владельца транзакции.
    */
   private async loadRelationPath(
     items: YdbBaseEntity[],
@@ -241,6 +252,32 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
       );
     }
 
+    // Внутренний контекст нужен только для многоуровневых путей с явным
+    // { trx }: одноуровневая eager-load и ambient-режим ведут себя как раньше.
+    if (options?.trx && segments.length > 1) {
+      await runWithTransactionContext(
+        {
+          trx: options.trx,
+          // Executor БД, открывший транзакцию: для детекции вложенности по
+          // ссылке (#98). Базовый executor сущности и есть этот db в wiring.
+          db: this.executor ?? options.trx,
+          ambient: true,
+        },
+        () => this.loadRelationSegments(rel, items, segments, options),
+      );
+      return;
+    }
+
+    await this.loadRelationSegments(rel, items, segments, options);
+  }
+
+  /** Тело обхода пути без управления транзакционным контекстом (#16). */
+  private async loadRelationSegments(
+    rel: RelationMetadata,
+    items: YdbBaseEntity[],
+    segments: string[],
+    options?: QueryOptions,
+  ): Promise<void> {
     const isIntermediate = segments.length > 1;
     const targets = await this.loadRelation(items, rel, options, {
       afterFind: !isIntermediate,
@@ -250,7 +287,7 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
       // Дети этого уровня уже загружены — пост-порядковый afterFind
       // срабатывает для этого уровня после его потомков.
       await this.loadRelationPath(targets, segments.slice(1), options);
-      await this.fireAfterFindOn(targets);
+      await this.fireAfterFindOn(targets, options);
     }
   }
 
@@ -444,11 +481,21 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
   /**
    * Пост-порядковый afterFind для инстансов промежуточного уровня
    * вложенного eager-пути (#16): срабатывает после их детей.
+   *
+   * Persistence создаётся с тем же { trx }, что и загрузка связи (#16-fix):
+   * отложенный afterFind промежуточного уровня не теряет транзакцию
+   * вызывающего — любые DB-операции внутри хуков идут через неё.
    */
-  private async fireAfterFindOn(targets: YdbBaseEntity[]): Promise<void> {
+  private async fireAfterFindOn(
+    targets: YdbBaseEntity[],
+    options?: QueryOptions,
+  ): Promise<void> {
     if (!targets.length) return;
     const Target = targets[0].constructor as typeof YdbBaseEntity;
-    const targetPersistence = this.createTargetPersistence(Target);
+    const targetPersistence = this.createTargetPersistence(
+      Target,
+      options?.trx,
+    );
     await targetPersistence.fireAfterFind(targets);
   }
 

--- a/src/relations/entity-relations.ts
+++ b/src/relations/entity-relations.ts
@@ -4,6 +4,7 @@ import { getYdbEntityMetadata } from '../metadata/entity-metadata.js';
 import {
   getYdbRelationsMetadata,
   resolveRelationJoinColumn,
+  type RelationMetadata,
 } from '../decorators/relation.decorators.js';
 import type { QueryOptions } from '../core/query-options.js';
 import type { YdbExecutor } from '../core/interfaces.js';
@@ -76,6 +77,7 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
     column: string,
     values: any[],
     options?: QueryOptions,
+    hydration?: { afterFind?: boolean },
   ): Promise<YdbBaseEntity[]> {
     const targetMeta = getYdbEntityMetadata(Target);
     if (!targetMeta) {
@@ -87,7 +89,12 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
       Target,
       options?.trx,
     );
-    return targetPersistence.fetchByColumnIn(column, values, options);
+    return targetPersistence.fetchByColumnIn(
+      column,
+      values,
+      options,
+      hydration,
+    );
   }
 
   /**
@@ -102,11 +109,12 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
    * чанкинг, слияние без дубликатов).
    */
   private async loadManyToManyRelation(
-    items: T[],
+    items: YdbBaseEntity[],
     Target: typeof YdbBaseEntity,
     joinTable: ResolvedJoinTable,
     ownerPks: any[],
     options?: QueryOptions,
+    hydration?: { afterFind?: boolean },
   ): Promise<Map<any, YdbBaseEntity[]>> {
     const exec = this.getExecutor(options?.trx);
     if (!exec) {
@@ -157,6 +165,7 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
       targetPkField,
       inverseFks,
       options,
+      hydration,
     );
 
     const byInversePk = new Map<any, YdbBaseEntity>();
@@ -182,7 +191,14 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
   }
 
   /**
-   * Batch eager loading: один запрос IN (...) на relation вместо N+1.
+   * Eager loading: батч IN (...) на каждый уровень связи (без N+1).
+   *
+   * Каждая запись @EagerLoad — путь из имён relations, разделённых точкой
+   * (например `tags.owner`). Допустимая длина пути:
+   * - один сегмент — классическая eager-загрузка одного уровня (как до #16);
+   * - несколько сегментов — вложенная загрузка (issue #16): после загрузки
+   *   первого уровня его инстансы становятся «родителями» для следующего
+   *   сегмента, ключи переносятся вперёд батчами.
    */
   async loadEagerRelations(items: T[], options?: QueryOptions): Promise<void> {
     if (!items.length) return;
@@ -191,94 +207,249 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
     const eager = getEagerRelations(constructor);
     if (!eager.length) return;
 
+    for (const path of eager) {
+      await this.loadRelationPath(items, path.split('.'), options);
+    }
+  }
+
+  /**
+   * Единый обход relation-пути (#16): рекурсивно загружает сегменты пути по
+   * одному батчу IN (...) на уровень, перенося ключи предыдущего уровня вперёд.
+   *
+   * Для многоуровневых путей afterFind промежуточных инстансов откладывается
+   * (afterFind: false в гидратации) и срабатывает в пост-порядке — после
+   * загрузки собственных детей — через fireAfterFindOn (см. #83/#107).
+   */
+  private async loadRelationPath(
+    items: YdbBaseEntity[],
+    segments: string[],
+    options?: QueryOptions,
+  ): Promise<void> {
+    if (!items.length || !segments.length) return;
+
+    const constructor = items[0].constructor as typeof YdbBaseEntity;
+    const name = segments[0];
     const allRelations = getYdbRelationsMetadata(constructor);
-    const pkField = getPrimaryKey(constructor);
+    const rel = allRelations.find((r) => r.propertyKey === name);
+    if (!rel) {
+      const known = allRelations.map((r) => r.propertyKey).join(', ');
+      throw new Error(
+        `Unknown relation in eager path "${segments.join('.')}": ` +
+          `"${name}" is not a declared relation on entity ${constructor.name}. ` +
+          `Known relations: ${known || '(none)'}. Check the property name or ` +
+          `declare the relation via @OneToMany/@ManyToOne/@OneToOne/@ManyToMany.`,
+      );
+    }
 
-    for (const name of eager) {
-      const rel = allRelations.find((r) => r.propertyKey === name);
-      if (!rel) continue;
+    const isIntermediate = segments.length > 1;
+    const targets = await this.loadRelation(items, rel, options, {
+      afterFind: !isIntermediate,
+    });
 
-      const Target = rel.target();
+    if (isIntermediate) {
+      // Дети этого уровня уже загружены — пост-порядковый afterFind
+      // срабатывает для этого уровня после его потомков.
+      await this.loadRelationPath(targets, segments.slice(1), options);
+      await this.fireAfterFindOn(targets);
+    }
+  }
 
-      if (rel.type === 'one-to-many') {
-        const joinColumnName = resolveRelationJoinColumn(rel.joinColumn, {
-          entityName: constructor.name,
-          relationPropertyKey: rel.propertyKey,
-        });
-        const pks = items
-          .map((item) => (item as any)[pkField])
-          .filter((v) => v !== undefined);
-        if (!pks.length) continue;
+  /**
+   * Загружает ОДНУ связь для списка инстансов одним (или несколькими
+   * чанками) IN (...) и возвращает свежезагруженные инстансы цели — они
+   * становятся «родителями» следующего уровня вложенного eager-пути (#16).
+   *
+   * `hydration.afterFind:false` применяется для промежуточных уровней пути,
+   * чтобы их afterFind сработал в пост-порядке (после детей).
+   * `strict` (для публичной loadRelations) сохраняет прежние контракты
+   * ошибок: бросает на undefined PK/FK, тогда как eager-путь их пропускает.
+   */
+  private async loadRelation(
+    items: YdbBaseEntity[],
+    rel: RelationMetadata,
+    options?: QueryOptions,
+    hydration: { afterFind?: boolean } = { afterFind: true },
+    strict = false,
+  ): Promise<YdbBaseEntity[]> {
+    const Target = rel.target();
+    const constructor = items[0].constructor as typeof YdbBaseEntity;
 
-        const children = await this.fetchByColumnIn(
-          Target,
-          joinColumnName,
-          pks,
-          options,
-        );
+    if (rel.type === 'one-to-many') {
+      const joinColumnName = resolveRelationJoinColumn(rel.joinColumn, {
+        entityName: constructor.name,
+        relationPropertyKey: rel.propertyKey,
+      });
+      const pkField = getPrimaryKey(constructor);
 
-        const byFk = new Map<any, YdbBaseEntity[]>();
-        for (const child of children) {
-          const fk = (child as any)[joinColumnName];
-          const group = byFk.get(fk);
-          if (group) {
-            group.push(child);
-          } else {
-            byFk.set(fk, [child]);
+      if (strict) {
+        for (const item of items) {
+          if ((item as any)[pkField] === undefined) {
+            throw new Error(
+              `Cannot load one-to-many relation "${rel.propertyKey}": ` +
+                `primary key "${pkField}" is undefined on ${constructor.name}`,
+            );
           }
         }
+      }
 
-        for (const item of items) {
-          (item as any)[name] = byFk.get((item as any)[pkField]) ?? [];
-        }
-      } else if (rel.type === 'many-to-many') {
-        const joinTable = resolveManyToManyJoinTable(constructor, rel);
-        if (!joinTable) continue;
-
-        const pks = items
+      // null-PK не входят в IN (...) — их группы и так пусты ([]).
+      // В строгом режиме (публичный loadRelations) всё равно назначаем [],
+      // как было до #16; в eager-пути пустой список ключей — просто skip.
+      const pks = dedupeInValues(
+        items
           .map((item) => (item as any)[pkField])
-          .filter((v) => v !== undefined);
-        if (!pks.length) continue;
+          .filter((v) => v !== undefined && v !== null),
+      );
+      if (!pks.length && !strict) return [];
 
-        const related = await this.loadManyToManyRelation(
-          items,
-          Target,
-          joinTable,
-          pks,
-          options,
-        );
+      const children = await this.fetchByColumnIn(
+        Target,
+        joinColumnName,
+        pks,
+        options,
+        hydration,
+      );
 
-        for (const item of items) {
-          (item as any)[name] = related.get((item as any)[pkField]) ?? [];
+      const byFk = new Map<any, YdbBaseEntity[]>();
+      for (const child of children) {
+        const fk = (child as any)[joinColumnName];
+        const group = byFk.get(fk);
+        if (group) {
+          group.push(child);
+        } else {
+          byFk.set(fk, [child]);
         }
-      } else {
-        const joinColumnName = resolveRelationJoinColumn(rel.joinColumn, {
-          entityName: constructor.name,
-          relationPropertyKey: rel.propertyKey,
-        });
-        const fks = items
-          .map((item) => (item as any)[joinColumnName])
-          .filter((v) => v !== undefined);
-        if (!fks.length) continue;
+      }
 
-        const targetPkField = getPrimaryKey(Target);
-        const parents = await this.fetchByColumnIn(
-          Target,
-          targetPkField,
-          fks,
-          options,
-        );
+      // Копия массива на инстанс: два инстанса с одним PK не должны
+      // разделять один массив (раньше у каждого был свой findAll).
+      for (const item of items) {
+        const group = byFk.get((item as any)[pkField]);
+        (item as any)[rel.propertyKey] = group ? [...group] : [];
+      }
+      return children;
+    }
 
-        const byPk = new Map<any, YdbBaseEntity>();
-        for (const parent of parents) {
-          byPk.set((parent as any)[targetPkField], parent);
+    if (rel.type === 'many-to-many') {
+      const pkField = getPrimaryKey(constructor);
+
+      const joinTable = resolveManyToManyJoinTable(constructor, rel);
+      if (!joinTable) {
+        if (strict) {
+          throw new Error(
+            `Cannot load many-to-many relation "${rel.propertyKey}": ` +
+              `join table is not defined on ${constructor.name}. ` +
+              `Mark the owning side with @JoinTable.`,
+          );
         }
+        return [];
+      }
 
+      if (strict) {
         for (const item of items) {
-          (item as any)[name] = byPk.get((item as any)[joinColumnName]) ?? null;
+          if ((item as any)[pkField] === undefined) {
+            throw new Error(
+              `Cannot load many-to-many relation "${rel.propertyKey}": ` +
+                `primary key "${pkField}" is undefined on ${constructor.name}`,
+            );
+          }
+        }
+      }
+
+      const pks = dedupeInValues(
+        items
+          .map((item) => (item as any)[pkField])
+          .filter((v) => v !== undefined && v !== null),
+      );
+      if (!pks.length && !strict) return [];
+
+      // Один батч-вызов на ВСЕ инстансы вместо пары запросов на каждый.
+      const related = await this.loadManyToManyRelation(
+        items,
+        Target,
+        joinTable,
+        pks,
+        options,
+        hydration,
+      );
+
+      for (const item of items) {
+        const group = related.get((item as any)[pkField]);
+        (item as any)[rel.propertyKey] = group ? [...group] : [];
+      }
+
+      // Уникальные инстансы целей (по ссылке): один тег, общий для
+      // нескольких владельцев, должен встретиться в следующих уровнях
+      // пути ровно один раз.
+      const targets: YdbBaseEntity[] = [];
+      const seenInst = new Set<object>();
+      for (const group of related.values()) {
+        for (const entity of group) {
+          if (!seenInst.has(entity)) {
+            seenInst.add(entity);
+            targets.push(entity);
+          }
+        }
+      }
+      return targets;
+    }
+
+    // many-to-one / one-to-one
+    const joinColumnName = resolveRelationJoinColumn(rel.joinColumn, {
+      entityName: constructor.name,
+      relationPropertyKey: rel.propertyKey,
+    });
+    const targetPk = getPrimaryKey(Target);
+
+    if (strict) {
+      for (const item of items) {
+        if ((item as any)[joinColumnName] === undefined) {
+          throw new Error(
+            `Cannot load relation "${rel.propertyKey}": ` +
+              `join column "${joinColumnName}" is undefined on ${constructor.name}`,
+          );
         }
       }
     }
+
+    // null-FK не входят в IN (...) — им назначается null, как возвращал
+    // find() по условию «PK = NULL» (пустой результат).
+    const fks = dedupeInValues(
+      items
+        .map((item) => (item as any)[joinColumnName])
+        .filter((v) => v !== undefined && v !== null),
+    );
+    if (!fks.length && !strict) return [];
+
+    const parents = await this.fetchByColumnIn(
+      Target,
+      targetPk,
+      fks,
+      options,
+      hydration,
+    );
+
+    const byPk = new Map<any, YdbBaseEntity>();
+    for (const parent of parents) {
+      byPk.set((parent as any)[targetPk], parent);
+    }
+
+    for (const item of items) {
+      (item as any)[rel.propertyKey] =
+        byPk.get((item as any)[joinColumnName]) ?? null;
+    }
+    return parents;
+  }
+
+  /**
+   * Пост-порядковый afterFind для инстансов промежуточного уровня
+   * вложенного eager-пути (#16): срабатывает после их детей.
+   */
+  private async fireAfterFindOn(targets: YdbBaseEntity[]): Promise<void> {
+    if (!targets.length) return;
+    const Target = targets[0].constructor as typeof YdbBaseEntity;
+    const targetPersistence = this.createTargetPersistence(Target);
+    await targetPersistence.fireAfterFind(targets);
   }
 
   /**
@@ -289,16 +460,9 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
    * чанков) IN (...) запрос — как в eager-пути. Раньше каждый тип связи
    * ходил запросом НА КАЖДЫЙ инстанс: 100 записей = 100–200 запросов.
    *
-   * Семантика сохранена:
-   * - one-to-many: инстанс получает все дочерние строки по своему PK
-   *   (или []), как давал findAll({ fk: pk }) на каждый элемент;
-   * - many-to-one / one-to-one: инстанс получает ровно одну связанную
-   *   строку по FK (или null), как давал find({ pk: fk });
-   * - many-to-many: группы link-строк join-таблицы, как раньше;
-   * - ошибки валидации (undefined PK/FK, неизвестная связь) бросаются
-   *   до выполнения запросов с прежними сообщениями;
-   * - связанные сущности проходят единый конвейер гидратации
-   *   (дешифровка → instantiate → afterFind), как и eager-путь.
+   * Делегирует в общий loadRelation (#16) в строгом режиме: проверяет
+   * неизвестное имя связи и сохраняет прежние контракты ошибок для
+   * undefined PK/FK и отсутствующей join-таблицы.
    */
   async loadRelations(
     items: T[],
@@ -322,138 +486,7 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
         );
       }
 
-      const Target = rel.target();
-
-      if (rel.type === 'one-to-many') {
-        const joinColumnName = resolveRelationJoinColumn(rel.joinColumn, {
-          entityName: constructor.name,
-          relationPropertyKey: rel.propertyKey,
-        });
-        const pkField = getPrimaryKey(constructor);
-
-        // Валидация всех инстансов ДО запросов — прежний контракт ошибок.
-        for (const item of items) {
-          if ((item as any)[pkField] === undefined) {
-            throw new Error(
-              `Cannot load one-to-many relation "${name}": ` +
-                `primary key "${pkField}" is undefined on ${constructor.name}`,
-            );
-          }
-        }
-
-        // null-PK не входят в IN (...) — их группы и так пусты ([]).
-        const pks = dedupeInValues(
-          items
-            .map((item) => (item as any)[pkField])
-            .filter((v) => v !== undefined && v !== null),
-        );
-
-        const children = await this.fetchByColumnIn(
-          Target,
-          joinColumnName,
-          pks,
-          options,
-        );
-
-        const byFk = new Map<any, YdbBaseEntity[]>();
-        for (const child of children) {
-          const fk = (child as any)[joinColumnName];
-          const group = byFk.get(fk);
-          if (group) {
-            group.push(child);
-          } else {
-            byFk.set(fk, [child]);
-          }
-        }
-
-        // Копия массива на инстанс: два инстанса с одним PK не должны
-        // разделять один массив (раньше у каждого был свой findAll).
-        for (const item of items) {
-          const group = byFk.get((item as any)[pkField]);
-          (item as any)[name] = group ? [...group] : [];
-        }
-      } else if (rel.type === 'many-to-many') {
-        const pkField = getPrimaryKey(constructor);
-
-        // Резолв зависит только от метаданных класса — один раз на связь,
-        // а не на каждый элемент (внутри проверяются конфликты объявлений).
-        const joinTable = resolveManyToManyJoinTable(constructor, rel);
-        if (!joinTable) {
-          throw new Error(
-            `Cannot load many-to-many relation "${name}": ` +
-              `join table is not defined on ${constructor.name}. ` +
-              `Mark the owning side with @JoinTable.`,
-          );
-        }
-
-        for (const item of items) {
-          if ((item as any)[pkField] === undefined) {
-            throw new Error(
-              `Cannot load many-to-many relation "${name}": ` +
-                `primary key "${pkField}" is undefined on ${constructor.name}`,
-            );
-          }
-        }
-
-        const pks = dedupeInValues(
-          items
-            .map((item) => (item as any)[pkField])
-            .filter((v) => v !== undefined && v !== null),
-        );
-
-        // Один батч-вызов на ВСЕ инстансы вместо пары запросов на каждый.
-        const related = await this.loadManyToManyRelation(
-          items,
-          Target,
-          joinTable,
-          pks,
-          options,
-        );
-
-        for (const item of items) {
-          const group = related.get((item as any)[pkField]);
-          (item as any)[name] = group ? [...group] : [];
-        }
-      } else {
-        const joinColumnName = resolveRelationJoinColumn(rel.joinColumn, {
-          entityName: constructor.name,
-          relationPropertyKey: rel.propertyKey,
-        });
-        const targetPk = getPrimaryKey(Target);
-
-        for (const item of items) {
-          if ((item as any)[joinColumnName] === undefined) {
-            throw new Error(
-              `Cannot load relation "${name}": ` +
-                `join column "${joinColumnName}" is undefined on ${constructor.name}`,
-            );
-          }
-        }
-
-        // null-FK не входят в IN (...) — им назначается null, как возвращал
-        // find() по условию «PK = NULL» (пустой результат).
-        const fks = dedupeInValues(
-          items
-            .map((item) => (item as any)[joinColumnName])
-            .filter((v) => v !== undefined && v !== null),
-        );
-
-        const parents = await this.fetchByColumnIn(
-          Target,
-          targetPk,
-          fks,
-          options,
-        );
-
-        const byPk = new Map<any, YdbBaseEntity>();
-        for (const parent of parents) {
-          byPk.set((parent as any)[targetPk], parent);
-        }
-
-        for (const item of items) {
-          (item as any)[name] = byPk.get((item as any)[joinColumnName]) ?? null;
-        }
-      }
+      await this.loadRelation(items, rel, options, { afterFind: true }, true);
     }
   }
 

--- a/test/nested-eager.spec.ts
+++ b/test/nested-eager.spec.ts
@@ -1,0 +1,667 @@
+import 'reflect-metadata';
+import {
+  YdbEntity,
+  YdbColumn,
+  YdbPrimaryColumn,
+  YdbBaseEntity,
+  OneToMany,
+  ManyToOne,
+  ManyToMany,
+  JoinTable,
+  EagerLoad,
+  AfterFind,
+  getOrCreateRepository,
+  MAX_IN_CLAUSE_VALUES,
+} from '../src/index.js';
+import {
+  runWithTransactionContext,
+  configureTransactionContext,
+} from '../src/transaction/transaction-context.js';
+import { createMockExecutor } from './helpers/mock-executor.js';
+
+/**
+ * Регрессионные тесты #16: вложенная eager-загрузка многоуровневых путей
+ * (@EagerLoad(['tags.owner'])), без N+1 на любой глубине.
+ *
+ * Модель: rootPhoto (m2m tags) -> Tag (m2o owner) -> User.
+ * Для путей, свободных от m2m, используется цепочка Album(1:N photo) ->
+ * photo(m2m tags) -> tag(m2o owner) -> user.
+ */
+
+// ---- Одноуровневая модель (регрессия: eager не сломан) ----
+
+@YdbEntity('nea_photos')
+@EagerLoad(['tags'])
+class OneLevelPhoto extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  uuid: string;
+
+  @ManyToMany(() => OneLevelTag, (t) => t.photos)
+  @JoinTable('nea_photo_tag', {
+    joinColumn: 'photo_uuid',
+    inverseJoinColumn: 'tag_uuid',
+  })
+  tags?: any[];
+}
+
+@YdbEntity('nea_tags')
+class OneLevelTag extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  uuid: string;
+
+  @YdbColumn('Utf8')
+  label: string;
+
+  @ManyToMany(() => OneLevelPhoto, (p) => p.tags)
+  photos?: any[];
+}
+
+// ---- Двухуровневая модель: photo -> (m2m) tags -> (m2o) owner ----
+
+@YdbEntity('neb_photos')
+@EagerLoad(['tags.owner'])
+class TwoLevelPhoto extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  uuid: string;
+
+  @YdbColumn('Utf8')
+  title: string;
+
+  @ManyToMany(() => TwoLevelTag, (t) => t.photos)
+  @JoinTable('neb_photo_tag', {
+    joinColumn: 'photo_uuid',
+    inverseJoinColumn: 'tag_uuid',
+  })
+  tags?: any[];
+
+  @ManyToOne(() => TwoLevelUser, 'user_uuid')
+  owner?: any;
+}
+
+@YdbEntity('neb_tags')
+class TwoLevelTag extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  uuid: string;
+
+  @YdbColumn('Utf8')
+  name: string;
+
+  @YdbColumn('Utf8')
+  owner_uuid: string;
+
+  @ManyToOne(() => TwoLevelUser, 'owner_uuid')
+  owner?: any;
+
+  @ManyToMany(() => TwoLevelPhoto, (p) => p.tags)
+  photos?: any[];
+}
+
+@YdbEntity('neb_users')
+class TwoLevelUser extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  uuid: string;
+
+  @YdbColumn('Utf8')
+  login: string;
+}
+
+// ---- Трёхуровневая модель: album(1:N)photos(m2m)tags(m2o)user ----
+
+@YdbEntity('nec_albums')
+@EagerLoad(['photos.tags.owner'])
+class ThreeLevelAlbum extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  uuid: string;
+
+  @OneToMany(() => ThreeLevelPhoto, 'album_uuid')
+  photos?: any[];
+}
+
+@YdbEntity('nec_photos')
+class ThreeLevelPhoto extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  uuid: string;
+
+  @YdbColumn('Utf8')
+  album_uuid: string;
+
+  @YdbColumn('Utf8')
+  user_uuid: string;
+
+  @ManyToMany(() => ThreeLevelTag, (t) => t.photos)
+  @JoinTable('nec_photo_tag', {
+    joinColumn: 'photo_uuid',
+    inverseJoinColumn: 'tag_uuid',
+  })
+  tags?: any[];
+
+  @ManyToOne(() => ThreeLevelUser, 'user_uuid')
+  user?: any;
+}
+
+@YdbEntity('nec_tags')
+class ThreeLevelTag extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  uuid: string;
+
+  @YdbColumn('Utf8')
+  name: string;
+
+  @YdbColumn('Utf8')
+  owner_uuid: string;
+
+  @ManyToOne(() => ThreeLevelUser, 'owner_uuid')
+  owner?: any;
+
+  @ManyToMany(() => ThreeLevelPhoto, (p) => p.tags)
+  photos?: any[];
+}
+
+@YdbEntity('nec_users')
+class ThreeLevelUser extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  uuid: string;
+
+  @YdbColumn('Utf8')
+  login: string;
+}
+
+// ---- Self-referencing eager-путь для проверки завершимости (#83/#16) ----
+
+@YdbEntity('nef_nodes')
+@EagerLoad(['parent.parent'])
+class SelfNode extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @YdbColumn('Utf8')
+  name?: string;
+
+  @YdbColumn('Uuid')
+  parentUuid?: string;
+
+  @ManyToOne(() => SelfNode, (e) => e.parentUuid)
+  parent?: SelfNode;
+}
+
+// ---- Цикл for послеFind-порядка (#83/#107) ----
+
+const afterFindCalls: string[] = [];
+
+@YdbEntity('neg_photo')
+@EagerLoad(['tags.owner'])
+class OrderPhoto extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  uuid: string;
+
+  @ManyToMany(() => OrderTag, (t) => t.photos)
+  @JoinTable('neg_photo_tag', {
+    joinColumn: 'photo_uuid',
+    inverseJoinColumn: 'tag_uuid',
+  })
+  tags?: any[];
+
+  @AfterFind
+  onFound() {
+    afterFindCalls.push(`photo:${this.uuid}`);
+  }
+}
+
+@YdbEntity('neg_tag')
+class OrderTag extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  uuid: string;
+
+  @YdbColumn('Utf8')
+  name: string;
+
+  @YdbColumn('Utf8')
+  owner_uuid: string;
+
+  @ManyToOne(() => OrderUser, 'owner_uuid')
+  owner?: any;
+
+  @AfterFind
+  onFound() {
+    afterFindCalls.push(`tag:${this.uuid}:owner=${this.owner?.uuid ?? '-'}`);
+  }
+}
+
+@YdbEntity('neg_user')
+class OrderUser extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  uuid: string;
+
+  @YdbColumn('Utf8')
+  login: string;
+
+  @AfterFind
+  onFound() {
+    afterFindCalls.push(`user:${this.uuid}`);
+  }
+}
+
+@YdbEntity('nek_invalid')
+@EagerLoad(['nope.owner'])
+class InvalidPathPhoto extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  uuid: string;
+}
+
+function photo(uuid: string): TwoLevelPhoto {
+  const p = new TwoLevelPhoto();
+  p.uuid = uuid;
+  p.title = '';
+  return p;
+}
+
+describe('#16: вложенная eager-load', () => {
+  afterEach(() => {
+    afterFindCalls.length = 0;
+    OneLevelPhoto.setExecutor(undefined as any);
+    OneLevelTag.setExecutor(undefined as any);
+    TwoLevelPhoto.setExecutor(undefined as any);
+    TwoLevelTag.setExecutor(undefined as any);
+    TwoLevelUser.setExecutor(undefined as any);
+    ThreeLevelAlbum.setExecutor(undefined as any);
+    ThreeLevelPhoto.setExecutor(undefined as any);
+    ThreeLevelTag.setExecutor(undefined as any);
+    ThreeLevelUser.setExecutor(undefined as any);
+    SelfNode.setExecutor(undefined as any);
+    OrderPhoto.setExecutor(undefined as any);
+    OrderTag.setExecutor(undefined as any);
+    OrderUser.setExecutor(undefined as any);
+    InvalidPathPhoto.setExecutor(undefined as any);
+  });
+
+  it('одноуровневая eager-load остаётся без изменений', async () => {
+    const roots = Array.from({ length: 3 }, (_, i) => {
+      const p = new OneLevelPhoto();
+      p.uuid = `a${i}`;
+      return p;
+    });
+    const linkRows = roots.flatMap((p) => [
+      { photo_uuid: p.uuid, tag_uuid: `${p.uuid}-1` },
+      { photo_uuid: p.uuid, tag_uuid: `${p.uuid}-2` },
+    ]);
+    const tagRows = linkRows.map((l) => ({
+      uuid: l.tag_uuid,
+      label: l.tag_uuid,
+    }));
+
+    const mock = createMockExecutor([[linkRows], [tagRows]], {
+      sequential: true,
+    });
+    OneLevelPhoto.setExecutor(mock.executor);
+    OneLevelTag.setExecutor(mock.executor);
+
+    await getOrCreateRepository(OneLevelPhoto).relations.loadEagerRelations(
+      roots,
+    );
+
+    expect(mock.queries).toHaveLength(2);
+    expect(mock.queries[0].sql).toContain('FROM `nea_photo_tag`');
+    expect(mock.queries[0].sql).toContain('`photo_uuid` IN');
+    expect(Object.keys(mock.queries[0].params)).toHaveLength(3);
+    expect(mock.queries[1].sql).toContain('FROM `nea_tags`');
+
+    for (const r of roots) {
+      expect(r.tags?.map((t) => t.uuid).sort()).toEqual([
+        `${r.uuid}-1`,
+        `${r.uuid}-2`,
+      ]);
+    }
+  });
+
+  it('tags.owner загружается на двух уровнях', async () => {
+    const p = photo('p1');
+    const linkRows = [
+      { photo_uuid: 'p1', tag_uuid: 't1' },
+      { photo_uuid: 'p1', tag_uuid: 't2' },
+    ];
+    const tagRows = [
+      { uuid: 't1', name: 'first', owner_uuid: 'u1' },
+      { uuid: 't2', name: 'second', owner_uuid: 'u2' },
+    ];
+    const userRows = [
+      { uuid: 'u1', login: 'alice' },
+      { uuid: 'u2', login: 'bob' },
+    ];
+
+    const mock = createMockExecutor([[linkRows], [tagRows], [userRows]], {
+      sequential: true,
+    });
+    TwoLevelPhoto.setExecutor(mock.executor);
+    TwoLevelTag.setExecutor(mock.executor);
+    TwoLevelUser.setExecutor(mock.executor);
+
+    await getOrCreateRepository(TwoLevelPhoto).relations.loadEagerRelations([
+      p,
+    ]);
+
+    // join-таблица + теги + владельцы — 3 батч-запроса.
+    expect(mock.queries).toHaveLength(3);
+    expect(mock.queries[0].sql).toContain('FROM `neb_photo_tag`');
+    expect(mock.queries[1].sql).toContain('FROM `neb_tags`');
+    expect(mock.queries[2].sql).toContain('FROM `neb_users`');
+    expect(mock.queries[2].sql).toContain('`uuid` IN');
+
+    expect(p.tags).toHaveLength(2);
+    expect(p.tags?.[0].owner?.login).toBe('alice');
+    expect(p.tags?.[1].owner?.login).toBe('bob');
+  });
+
+  it('трёхуровневый путь (album -> photos -> tags -> owner)', async () => {
+    const album = new ThreeLevelAlbum();
+    album.uuid = 'al1';
+
+    const photoRows = [
+      { uuid: 'ph1', album_uuid: 'al1', user_uuid: '' },
+      { uuid: 'ph2', album_uuid: 'al1', user_uuid: '' },
+    ];
+    const linkRows = [
+      { photo_uuid: 'ph1', tag_uuid: 'tagA' },
+      { photo_uuid: 'ph2', tag_uuid: 'tagB' },
+    ];
+    const tagRows = [
+      { uuid: 'tagA', name: 'x', owner_uuid: 'own1' },
+      { uuid: 'tagB', name: 'y', owner_uuid: 'own2' },
+    ];
+    const userRows = [
+      { uuid: 'own1', login: 'u1' },
+      { uuid: 'own2', login: 'u2' },
+    ];
+
+    const mock = createMockExecutor(
+      [[photoRows], [linkRows], [tagRows], [userRows]],
+      { sequential: true },
+    );
+    ThreeLevelAlbum.setExecutor(mock.executor);
+    ThreeLevelPhoto.setExecutor(mock.executor);
+    ThreeLevelTag.setExecutor(mock.executor);
+    ThreeLevelUser.setExecutor(mock.executor);
+
+    await getOrCreateRepository(ThreeLevelAlbum).relations.loadEagerRelations([
+      album,
+    ]);
+
+    // photos + join + tags + owner = 4 батч-запроса на 4 уровнях пути.
+    expect(mock.queries).toHaveLength(4);
+
+    expect(album.photos).toHaveLength(2);
+    expect(album.photos?.[0].tags?.[0].owner?.login).toBe('u1');
+    expect(album.photos?.[1].tags?.[0].owner?.login).toBe('u2');
+  });
+
+  it('100 корней не дают per-root запросов ни на одном уровне', async () => {
+    const roots = Array.from({ length: 100 }, (_, i) =>
+      photo(`ph${String(i).padStart(3, '0')}`),
+    );
+    const linkRows = roots.map((p) => ({
+      photo_uuid: p.uuid,
+      tag_uuid: `tag-${p.uuid}`,
+    }));
+    const tagRows = linkRows.map((l) => ({
+      uuid: l.tag_uuid,
+      name: l.tag_uuid,
+      owner_uuid: `user-${l.photo_uuid}`,
+    }));
+    const userRows = tagRows.map((t) => ({
+      uuid: t.owner_uuid,
+      login: t.owner_uuid,
+    }));
+
+    const mock = createMockExecutor([[linkRows], [tagRows], [userRows]], {
+      sequential: true,
+    });
+    TwoLevelPhoto.setExecutor(mock.executor);
+    TwoLevelTag.setExecutor(mock.executor);
+    TwoLevelUser.setExecutor(mock.executor);
+
+    await getOrCreateRepository(TwoLevelPhoto).relations.loadEagerRelations(
+      roots,
+    );
+
+    // ровно 3 запроса: join + теги + владельцы — независимо от 100 корней,
+    // каждый с 100 параметрами IN (...).
+    expect(mock.queries).toHaveLength(3);
+    expect(mock.queries.map((q) => Object.keys(q.params).length)).toEqual([
+      100, 100, 100,
+    ]);
+    for (const r of roots) {
+      expect(r.tags?.[0].owner?.uuid).toBe(`user-${r.uuid}`);
+    }
+  });
+
+  it('пустые промежуточные наборы не выполняют лишних SQL', async () => {
+    const p = photo('p1');
+    // join-таблица возвращает ноль ссылок.
+    const mock = createMockExecutor([[[]]], { sequential: true });
+    TwoLevelPhoto.setExecutor(mock.executor);
+
+    await getOrCreateRepository(TwoLevelPhoto).relations.loadEagerRelations([
+      p,
+    ]);
+
+    // Только 1 запрос (join). Выборка тегов и владельцев не выполняется.
+    expect(mock.queries).toHaveLength(1);
+    expect(mock.queries[0].sql).toContain('FROM `neb_photo_tag`');
+    expect(p.tags).toEqual([]);
+  });
+
+  it('дубликаты промежуточных ключей исключаются до IN (...)', async () => {
+    const a = photo('a');
+    const b = photo('b');
+    const share = photo('a'); // тот же PK, что у a — дубликат владельца
+    const roots = [a, share, b];
+    b.uuid = 'b2';
+
+    const linkRows = [
+      { photo_uuid: a.uuid, tag_uuid: 'tag1' },
+      { photo_uuid: share.uuid, tag_uuid: 'tag1' },
+      { photo_uuid: b.uuid, tag_uuid: 'tag2' },
+    ];
+    const tagRows = [
+      { uuid: 'tag1', name: 'x', owner_uuid: 'u1' },
+      { uuid: 'tag2', name: 'y', owner_uuid: 'u2' },
+    ];
+    const userRows = [
+      { uuid: 'u1', login: 'a' },
+      { uuid: 'u2', login: 'b' },
+    ];
+
+    const mock = createMockExecutor([[linkRows], [tagRows], [userRows]], {
+      sequential: true,
+    });
+    TwoLevelPhoto.setExecutor(mock.executor);
+    TwoLevelTag.setExecutor(mock.executor);
+    TwoLevelUser.setExecutor(mock.executor);
+
+    await getOrCreateRepository(TwoLevelPhoto).relations.loadEagerRelations(
+      roots,
+    );
+
+    expect(mock.queries).toHaveLength(3);
+    // join IN (...) должен содержать уникальные ключи: a, b2 → 2 параметра.
+    expect(Object.keys(mock.queries[0].params)).toHaveLength(2);
+    // У дубликата владельца (share, тот же PK, что у a) свой массив тегов,
+    // но не разделяемый с оригиналом.
+    expect(roots[0].tags).not.toBe(roots[2].tags);
+    expect(roots[0].tags?.[0]?.uuid).toBe('tag1');
+    expect(roots[2].tags?.[0]?.uuid).toBe('tag2');
+  });
+
+  it(`чанкинг тегов при >${MAX_IN_CLAUSE_VALUES} использует несколько IN`, async () => {
+    const photoCount = 700;
+    const roots = Array.from({ length: photoCount }, (_, i) =>
+      photo(`p${String(i).padStart(4, '0')}`),
+    );
+    const linkRows = roots.map((p) => ({
+      photo_uuid: p.uuid,
+      tag_uuid: `t${p.uuid}`,
+    }));
+    const tagRows = linkRows.map((l) => ({
+      uuid: l.tag_uuid,
+      name: l.tag_uuid,
+      owner_uuid: 'u-common',
+    }));
+
+    const mock = createMockExecutor(
+      [[linkRows], [tagRows], [[{ uuid: 'u-common', login: 'common' }]]],
+      { sequential: true },
+    );
+    TwoLevelPhoto.setExecutor(mock.executor);
+    TwoLevelTag.setExecutor(mock.executor);
+    TwoLevelUser.setExecutor(mock.executor);
+
+    await getOrCreateRepository(TwoLevelPhoto).relations.loadEagerRelations(
+      roots,
+    );
+
+    const tagQueries = mock.queries.filter((q) =>
+      q.sql.includes('FROM `neb_tags`'),
+    );
+    // 700 тегов → чанки 500 + 200.
+    expect(tagQueries).toHaveLength(2);
+    expect(tagQueries.map((q) => Object.keys(q.params).length)).toEqual([
+      MAX_IN_CLAUSE_VALUES,
+      photoCount - MAX_IN_CLAUSE_VALUES,
+    ]);
+  });
+
+  it('циклическая self-referencing eager-связь завершается безопасно', async () => {
+    const nodeA = new SelfNode();
+    nodeA.uuid = 'aaaaaaaa-1111-4111-8111-aaaaaaaaaaaaaaaa';
+    nodeA.name = 'A';
+    const nodeB = new SelfNode();
+    nodeB.uuid = 'bbbbbbbb-2222-4222-8222-bbbbbbbbbbbbbb';
+    nodeB.name = 'B';
+    // Цикл в данных: A -> B -> A.
+    nodeA.parentUuid = nodeB.uuid;
+    nodeB.parentUuid = nodeA.uuid;
+
+    const rootRows = [
+      { uuid: nodeA.uuid, name: 'A', parentUuid: nodeB.uuid },
+      { uuid: nodeB.uuid, name: 'B', parentUuid: nodeA.uuid },
+    ];
+    const batch = [
+      { uuid: nodeB.uuid, name: 'B', parentUuid: nodeA.uuid },
+      { uuid: nodeA.uuid, name: 'A', parentUuid: nodeB.uuid },
+    ];
+
+    const mock = createMockExecutor([[rootRows], [batch], [batch]], {
+      sequential: true,
+    });
+    SelfNode.setExecutor(mock.executor);
+
+    const found = await SelfNode.findAll();
+
+    // Ровно 3 запроса: корни + два уровня parent (путь конечен), без рекурсии.
+    expect(found).toHaveLength(2);
+    expect(mock.queries).toHaveLength(3);
+    expect(found[0].parent?.name).toBe('B');
+    // Глубина пути фиксирована — третий уровень не загружается.
+    expect(found[0].parent?.parent?.name).toBe('A');
+  });
+
+  it('afterFind срабатывает ровно один раз и в документированном порядке', async () => {
+    const rootRows = [{ uuid: 'p1', title: '' }];
+    const linkRows = [{ photo_uuid: 'p1', tag_uuid: 't1' }];
+    const tagRows = [{ uuid: 't1', name: 'x', owner_uuid: 'u1' }];
+    const userRows = [{ uuid: 'u1', login: 'alice' }];
+
+    const mock = createMockExecutor(
+      [[rootRows], [linkRows], [tagRows], [userRows]],
+      { sequential: true },
+    );
+    OrderPhoto.setExecutor(mock.executor);
+    OrderTag.setExecutor(mock.executor);
+    OrderUser.setExecutor(mock.executor);
+
+    await OrderPhoto.findAll();
+
+    // Каждый инстанс — ровно один afterFind. Порядок — потомки раньше
+    // родителей (leaf -> промежуточный -> корень), и последний увидел
+    // присоединённые связи.
+    expect(afterFindCalls).toEqual(['user:u1', 'tag:t1:owner=u1', 'photo:p1']);
+    // Пять гидратированных инстансов (корень + тег + user) — три срабатывания.
+    expect(afterFindCalls).toHaveLength(3);
+  });
+
+  it('явный { trx } использует один транзакционный executor на всех уровнях', async () => {
+    const p = photo('p1');
+    const linkRows = [{ photo_uuid: 'p1', tag_uuid: 't1' }];
+    const tagRows = [{ uuid: 't1', name: 'x', owner_uuid: 'u1' }];
+    const userRows = [{ uuid: 'u1', login: 'a' }];
+
+    const dbMock = createMockExecutor([[]]);
+    const trxMock = createMockExecutor([[linkRows], [tagRows], [userRows]], {
+      sequential: true,
+    });
+    TwoLevelPhoto.setExecutor(dbMock.executor);
+    TwoLevelTag.setExecutor(dbMock.executor);
+    TwoLevelUser.setExecutor(dbMock.executor);
+
+    await getOrCreateRepository(TwoLevelPhoto).relations.loadEagerRelations(
+      [p],
+      { trx: trxMock.executor },
+    );
+
+    expect(dbMock.queries).toHaveLength(0);
+    expect(trxMock.queries).toHaveLength(3);
+    expect(p.tags?.[0]?.owner?.login).toBe('a');
+  });
+
+  it('ambient-контекст использует активную транзакцию для всех уровней', async () => {
+    const p = photo('p1');
+    const linkRows = [{ photo_uuid: 'p1', tag_uuid: 't1' }];
+    const tagRows = [{ uuid: 't1', name: 'x', owner_uuid: 'u1' }];
+    const userRows = [{ uuid: 'u1', login: 'a' }];
+
+    const dbMock = createMockExecutor([[]]);
+    const trxMock = createMockExecutor([[linkRows], [tagRows], [userRows]], {
+      sequential: true,
+    });
+    TwoLevelPhoto.setExecutor(dbMock.executor);
+    TwoLevelTag.setExecutor(dbMock.executor);
+    TwoLevelUser.setExecutor(dbMock.executor);
+
+    configureTransactionContext({ ambient: true });
+    try {
+      await runWithTransactionContext(
+        {
+          trx: trxMock.executor,
+          db: dbMock.executor,
+          ambient: true,
+        },
+        async () => {
+          await getOrCreateRepository(
+            TwoLevelPhoto,
+          ).relations.loadEagerRelations([p]);
+        },
+      );
+    } finally {
+      configureTransactionContext();
+    }
+
+    expect(dbMock.queries).toHaveLength(0);
+    expect(trxMock.queries).toHaveLength(3);
+    expect(p.tags?.[0]?.owner?.login).toBe('a');
+  });
+
+  it('недопустимый путь падает до выполнения SQL', async () => {
+    const root = new InvalidPathPhoto();
+    root.uuid = 'p1';
+
+    const mock = createMockExecutor([[]]);
+    InvalidPathPhoto.setExecutor(mock.executor);
+
+    await expect(
+      getOrCreateRepository(InvalidPathPhoto).relations.loadEagerRelations([
+        root,
+      ]),
+    ).rejects.toThrow(/Unknown relation in eager path "nope.owner"/);
+
+    expect(mock.queries).toHaveLength(0);
+  });
+});

--- a/test/nested-eager.spec.ts
+++ b/test/nested-eager.spec.ts
@@ -248,6 +248,95 @@ class InvalidPathPhoto extends YdbBaseEntity {
   uuid: string;
 }
 
+// ---- Транзакционная пропага afterFind (#16-fix) ----
+// Хуки промежуточного и листового уровней выполняют запросы БЕЗ явного
+// { trx }: они обязаны уйти в executor той транзакции, в которой загружалась
+// связь, а не в базовый executor.
+
+const trxHookCalls: string[] = [];
+
+@YdbEntity('netr_photos')
+@EagerLoad(['tags.owner'])
+class TrxPhoto extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  uuid: string;
+
+  @ManyToMany(() => TrxTag, (t) => t.photos)
+  @JoinTable('netr_photo_tag', {
+    joinColumn: 'photo_uuid',
+    inverseJoinColumn: 'tag_uuid',
+  })
+  tags?: any[];
+
+  @AfterFind
+  onFound() {
+    trxHookCalls.push(`photo:${this.uuid}`);
+  }
+}
+
+@YdbEntity('netr_tags')
+class TrxTag extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  uuid: string;
+
+  @YdbColumn('Utf8')
+  name: string;
+
+  @YdbColumn('Utf8')
+  owner_uuid: string;
+
+  @ManyToOne(() => TrxUser, 'owner_uuid')
+  owner?: any;
+
+  @AfterFind
+  async onFound() {
+    // Отложенный afterFind промежуточного уровня: запрос без { trx }.
+    await TrxUser.count();
+    trxHookCalls.push(`tag:${this.uuid}:owner=${this.owner?.uuid ?? '-'}`);
+  }
+}
+
+@YdbEntity('netr_users')
+class TrxUser extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  uuid: string;
+
+  @YdbColumn('Utf8')
+  login: string;
+
+  @AfterFind
+  async onFound() {
+    // Листовой afterFind: запрос без { trx }.
+    await TrxUser.count();
+    trxHookCalls.push(`user:${this.uuid}`);
+  }
+}
+
+function trxPhoto(uuid: string): TrxPhoto {
+  const p = new TrxPhoto();
+  p.uuid = uuid;
+  return p;
+}
+
+/** Единая раскладка result sets для цепочки p1 -> t1 -> u1 с COUNT-хуками. */
+function trxChainMock(
+  dbMockFactory: typeof createMockExecutor,
+): ReturnType<typeof createMockExecutor> {
+  const linkRows = [{ photo_uuid: 'p1', tag_uuid: 't1' }];
+  const tagRows = [{ uuid: 't1', name: 'x', owner_uuid: 'u1' }];
+  const userRows = [{ uuid: 'u1', login: 'alice' }];
+  return dbMockFactory(
+    [
+      [linkRows],
+      [tagRows],
+      [userRows],
+      [[{ cnt: 1 }]], // COUNT из afterFind user-хука
+      [[{ cnt: 1 }]], // COUNT из отложенного afterFind tag-хука
+    ],
+    { sequential: true },
+  );
+}
+
 function photo(uuid: string): TwoLevelPhoto {
   const p = new TwoLevelPhoto();
   p.uuid = uuid;
@@ -258,6 +347,7 @@ function photo(uuid: string): TwoLevelPhoto {
 describe('#16: вложенная eager-load', () => {
   afterEach(() => {
     afterFindCalls.length = 0;
+    trxHookCalls.length = 0;
     OneLevelPhoto.setExecutor(undefined as any);
     OneLevelTag.setExecutor(undefined as any);
     TwoLevelPhoto.setExecutor(undefined as any);
@@ -272,6 +362,9 @@ describe('#16: вложенная eager-load', () => {
     OrderTag.setExecutor(undefined as any);
     OrderUser.setExecutor(undefined as any);
     InvalidPathPhoto.setExecutor(undefined as any);
+    TrxPhoto.setExecutor(undefined as any);
+    TrxTag.setExecutor(undefined as any);
+    TrxUser.setExecutor(undefined as any);
   });
 
   it('одноуровневая eager-load остаётся без изменений', async () => {
@@ -663,5 +756,126 @@ describe('#16: вложенная eager-load', () => {
     ).rejects.toThrow(/Unknown relation in eager path "nope.owner"/);
 
     expect(mock.queries).toHaveLength(0);
+  });
+
+  it('явный { trx }: каждый afterFind-хук использует тот же executor транзакции (#16-fix)', async () => {
+    const dbMock = createMockExecutor([[]]);
+    const trxMock = trxChainMock(createMockExecutor);
+    // Базовый executor сущностей — db; транзакция передаётся явно.
+    TrxPhoto.setExecutor(dbMock.executor);
+    TrxTag.setExecutor(dbMock.executor);
+    TrxUser.setExecutor(dbMock.executor);
+
+    await getOrCreateRepository(TrxPhoto).relations.loadEagerRelations(
+      [trxPhoto('p1')],
+      { trx: trxMock.executor },
+    );
+
+    // Все 5 запросов (join, tags, users, COUNT из user-хука, COUNT из
+    // tag-хука) прошли через ОДИН tagged executor — транзакцию.
+    expect(trxMock.queries).toHaveLength(5);
+    expect(dbMock.queries).toHaveLength(0);
+    expect(trxMock.queries[0].sql).toContain('FROM `netr_photo_tag`');
+    expect(trxMock.queries[1].sql).toContain('FROM `netr_tags`');
+    expect(trxMock.queries[2].sql).toContain('FROM `netr_users`');
+    expect(trxMock.queries[3].sql).toContain('COUNT(*)');
+    expect(trxMock.queries[4].sql).toContain('COUNT(*)');
+
+    // Хуки увидели присоединённые связи и сработали в порядке leaf → root.
+    expect(trxHookCalls).toEqual(['user:u1', 'tag:t1:owner=u1']);
+  });
+
+  it('запрос из afterFind промежуточного уровня не попадает в базовый executor (#16-fix)', async () => {
+    const dbMock = createMockExecutor([[]]);
+    const trxMock = trxChainMock(createMockExecutor);
+    TrxPhoto.setExecutor(dbMock.executor);
+    TrxTag.setExecutor(dbMock.executor);
+    TrxUser.setExecutor(dbMock.executor);
+
+    await getOrCreateRepository(TrxPhoto).relations.loadEagerRelations(
+      [trxPhoto('p1')],
+      { trx: trxMock.executor },
+    );
+
+    // Последний запрос — COUNT из ОТЛОЖЕННОГО afterFind тега
+    // (промежуточного уровня пути): он должен быть в транзакции.
+    const intermediateHookQuery = trxMock.queries[4];
+    expect(intermediateHookQuery.sql).toContain('COUNT(*)');
+    expect(dbMock.queries).toHaveLength(0);
+    // Хук тега выполнился уже с присоединённым владельцем.
+    expect(trxHookCalls).toContain('tag:t1:owner=u1');
+  });
+
+  it('ambient-режим не изменился: хуки идут в активную транзакцию как раньше', async () => {
+    const dbMock = createMockExecutor([[]]);
+    const trxMock = trxChainMock(createMockExecutor);
+    TrxPhoto.setExecutor(dbMock.executor);
+    TrxTag.setExecutor(dbMock.executor);
+    TrxUser.setExecutor(dbMock.executor);
+
+    configureTransactionContext({ ambient: true });
+    try {
+      await runWithTransactionContext(
+        {
+          trx: trxMock.executor,
+          db: dbMock.executor,
+          ambient: true,
+        },
+        async () => {
+          // Без явного { trx } — прежний ambient auto-join (#98).
+          await getOrCreateRepository(TrxPhoto).relations.loadEagerRelations([
+            trxPhoto('p1'),
+          ]);
+        },
+      );
+    } finally {
+      configureTransactionContext();
+    }
+
+    expect(dbMock.queries).toHaveLength(0);
+    expect(trxMock.queries).toHaveLength(5);
+    expect(trxHookCalls).toEqual(['user:u1', 'tag:t1:owner=u1']);
+  });
+
+  it('exactly-once и порядок leaf → intermediate → root сохраняются при явном { trx }', async () => {
+    const dbMock = createMockExecutor([[]]);
+    const trxMock = trxChainMock(createMockExecutor);
+    TrxPhoto.setExecutor(dbMock.executor);
+    TrxTag.setExecutor(dbMock.executor);
+    TrxUser.setExecutor(dbMock.executor);
+
+    await getOrCreateRepository(TrxPhoto).relations.loadEagerRelations(
+      [trxPhoto('p1')],
+      { trx: trxMock.executor },
+    );
+
+    // Ровно по одному вызову на каждый гидратированный инстанс
+    // (тег + user), leaf раньше intermediate.
+    expect(trxHookCalls).toEqual(['user:u1', 'tag:t1:owner=u1']);
+    expect(trxHookCalls.filter((c) => c === 'user:u1')).toHaveLength(1);
+    expect(trxHookCalls.filter((c) => c.startsWith('tag:'))).toHaveLength(1);
+  });
+
+  it('новая транзакция/сессия не открывается: executor.transaction() не вызывается (#16-fix)', async () => {
+    const dbMock = createMockExecutor([[]]);
+    const trxMock = trxChainMock(createMockExecutor);
+    TrxPhoto.setExecutor(dbMock.executor);
+    TrxTag.setExecutor(dbMock.executor);
+    TrxUser.setExecutor(dbMock.executor);
+
+    await getOrCreateRepository(TrxPhoto).relations.loadEagerRelations(
+      [trxPhoto('p1')],
+      { trx: trxMock.executor },
+    );
+
+    // Ни один executor не открывал транзакцию: BEGIN/COMMIT/ROLLBACK
+    // отсутствуют, transaction() не вызывался ни разу.
+    expect(trxMock.transactionOptions).toHaveLength(0);
+    expect(dbMock.transactionOptions).toHaveLength(0);
+    for (const q of [...trxMock.queries, ...dbMock.queries]) {
+      expect(q.sql.toUpperCase()).not.toContain('BEGIN');
+      expect(q.sql.toUpperCase()).not.toContain('COMMIT');
+      expect(q.sql.toUpperCase()).not.toContain('ROLLBACK');
+    }
   });
 });


### PR DESCRIPTION
## Что сделано

Реализована **вложенная eager-загрузка** (issue #16): `@EagerLoad(['tags.owner'])` и произвольные пути из имён relations, разделённых точкой.

### Реализация

- `loadEagerRelations` переписан на обход путей `loadRelationPath(items, segments)`: каждый сегмент резолвится по метаданным связей (произвольные SQL/свойства невозможны), после загрузки уровня его инстансы становятся «родителями» следующего сегмента.
- Новый единый загрузчик одной связи `loadRelation()` используется **и** eager-путём, **и** публичной `loadRelations()` — второй реализации нет. Строгий режим (`strict: true`) для `loadRelations` сохраняет прежние контракты ошибок (undefined PK/FK, отсутствие @JoinTable); eager-путь, как раньше, пропускает undefined/null ключи.
- Резолв join-колонок и join-таблиц — только канонические `resolveRelationJoinColumn` (#87) и `resolveManyToManyJoinTable` (#90/#139); дублирования PK/типов/имён нет.
- Метаданные parent/child не мутируются.

### Гарантии

- **Без N+1 на любой глубине**: N корней × глубина D → один батч IN (...) на уровень; ключи дедуплицируются, чанкинг >`MAX_IN_CLAUSE_VALUES` и zero-SQL guard-ы переиспользуются из #86 (`fetchByColumnIn`, `chunkInValues`/`dedupeInValues`).
- **afterFind ровно один раз на гидратированный инстанс** (#83): промежуточные уровни гидратируются с `afterFind: false` и срабатывают в пост-порядке (leaf → intermediate → root) через новый `YdbEntityPersistence.fireAfterFind`; identity guard `hydrationContext.seen` общий для всей операции.
- **Циклы/self-references завершаются**: путь конечен по построению; собственный eager детей не пробуждается (`eager: false` в batch-фетче сохранён).
- **Транзакции**: явный `{ trx }` и ambient-контекст (#98) применяются ко всем уровням; retry/idempotency (#27) идут через существующий `executeQuery`.
- **Ошибки до SQL**: неизвестный сегмент пути падает с сообщением, называющим сущность и известные связи.

Одноуровневое поведение не изменено (все прежние тесты проходят без правок).

### Тесты

Новый `test/nested-eager.spec.ts` — 11 регрессионных сценариев:
1. одноуровневая eager-load без изменений;
2. `tags.owner` загружается;
3. трёхуровневый путь `photos.tags.owner`;
4. 100 корней → константное число запросов (3), без per-root;
5. пустые промежуточные наборы → ноль лишних SQL;
6. дедупликация промежуточных ключей;
7. чанкинг тегов при >`MAX_IN_CLAUSE_VALUES`;
8. циклическая self-referencing связь завершается безопасно;
9. afterFind ровно один раз и в порядке leaf → intermediate → root;
10. явный `{ trx }` и ambient — один транзакционный executor на всех уровнях;
11. недопустимый путь падает до SQL.

```
yarn build ✅   yarn lint (0 errors) ✅   yarn test: 1062 passed / 70 suites ✅
```

Closes #16