### PR TITLE
fix(query-logger): forward interpolation args in wrapExecutorWithLogging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ycforge/ydb-orm",
-  "version": "0.2.0-beta.0",
+  "version": "0.2.0",
   "description": "TypeORM-like ORM для YDB (Yandex Database): Active Record, relations, шифрование полей, schema sync, транзакции и миграции. Опциональная интеграция с NestJS — подпакет @ycforge/ydb-orm/nest",
   "keywords": [
     "ydb",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ycforge/ydb-orm",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "TypeORM-like ORM для YDB (Yandex Database): Active Record, relations, шифрование полей, schema sync, транзакции и миграции. Опциональная интеграция с NestJS — подпакет @ycforge/ydb-orm/nest",
   "keywords": [
     "ydb",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ycforge/ydb-orm",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "TypeORM-like ORM для YDB (Yandex Database): Active Record, relations, шифрование полей, schema sync, транзакции и миграции. Опциональная интеграция с NestJS — подпакет @ycforge/ydb-orm/nest",
   "keywords": [
     "ydb",

--- a/src/core/query-logger.ts
+++ b/src/core/query-logger.ts
@@ -157,13 +157,13 @@ export function wrapExecutorWithLogging(
   executor: YdbExecutor,
   logger: QueryLogger,
 ): YdbExecutor {
-  const wrapped: any = (strings: TemplateStringsArray) => {
+  const wrapped: any = (strings: TemplateStringsArray, ...args: any[]) => {
     const sql = strings[0];
     const startTime = performance.now();
     const paramNames: string[] = [];
     const maskedParams: Record<string, unknown> = {};
 
-    const query = executor(strings);
+    const query = executor(strings, ...args);
     const originalParameter = query.parameter.bind(query);
 
     const proxied: any = {


### PR DESCRIPTION
## Problem

`wrapExecutorWithLogging` silently dropped tagged template interpolation values by accepting only `strings` in its function signature. This caused `mismatched input ','` errors in YDB when query parameters were passed via tagged templates.

## Root cause

Line 160 in `src/core/query-logger.ts`:

```diff
- const wrapped: any = (strings: TemplateStringsArray) => {
+ const wrapped: any = (strings: TemplateStringsArray, ...args: any[]) => {
    ...
-     const query = executor(strings);
+     const query = executor(strings, ...args);
```

The tagged template literal passes interpolation values as rest args after `strings`. Without forwarding `...args`, all parameterized queries using `db`...` templates were broken.

## Impact

Every ORM query using tagged template parameters failed with YDB syntax errors when the logging wrapper was active (the default). This was masked because `insertMany` bypasses the wrapper, but direct `db`...` raw SQL queries were affected.

## Verification

46 e2e tests pass on the test stand against a local YDB instance.