### PR TITLE
fix(retry): preserve single-settlement and cancellation in retry query proxy (#172)

### DIFF
--- a/src/core/retry-executor.ts
+++ b/src/core/retry-executor.ts
@@ -3,7 +3,11 @@ import type {
   YdbQuery,
   YdbTransactionOptions,
 } from './interfaces.js';
-import { resolveYdbRetryPolicy, runWithRetry } from './retry.js';
+import {
+  abortReasonToError,
+  resolveYdbRetryPolicy,
+  runWithRetry,
+} from './retry.js';
 import type {
   YdbResolvedRetryPolicy,
   YdbRetryPolicyInput,
@@ -61,6 +65,18 @@ function policyToOptions(
  * воспроизводятся на КАЖДОЙ попытке политики (у SDK-запроса результат
  * выполнения кешируется в инстансе — переиспользовать его нельзя).
  *
+ * Прокси владеет ОДНИМ общим исполнением операции (#172): первый же
+ * `.then()`/await создаёт промис исполнения и кеширует его; повторные
+ * подписки того же запроса цепляются за тот же промис и НЕ вызывают
+ * `makeBase()` повторно. Это касается и непомеченных (fail-safe)
+ * запросов — дублирования обращения к БД из-за двух await нет.
+ *
+ * Отмена (.cancel()) — тоже на уровне прокси (#172): общий AbortController
+ * собирается в сигнал операции (вместе с пользовательским и политики) и
+ * используется И для попыток SDK, И для backoff политики. Поэтому cancel()
+ * полностью останавливает операцию: отменяет летящую попытку, прерывает
+ * ожидание задержки и запрещает новые попытки.
+ *
  * Правило безопасности (#27): повторять можно ТОЛЬКО запрос, явно
  * помеченный идемпотентным (`.idempotent(true)` / `{ idempotent: true }`).
  * Непомеченный запрос выполняется РОВНО ОДИН раз даже при включённой
@@ -80,6 +96,55 @@ function createPolicyQuery(
   let markedIdempotent: boolean | undefined;
   let current: YdbQuery | undefined;
 
+  // Общий сигнал отмены прокси (#172): cancel() абортит его — он отменяет
+  // и текущую попытку SDK (сигнал доходит до запроса через combineSignals),
+  // и backoff политики (signal в runWithRetry), и запрещает новые попытки.
+  const controller = new AbortController();
+  const cancelError: Error = new Error('The operation was aborted');
+  cancelError.name = 'AbortError';
+
+  // Единственное исполнение операции на весь прокси-запрос (#172):
+  // два .then()/await на одном запросе НЕ дублируют обращение к БД.
+  let settled: Promise<unknown> | undefined;
+
+  const runOnce = async (policySignal?: AbortSignal): Promise<unknown> => {
+    // Отмена до старта (cancel() до первого await) — ни одного обращения
+    // к БД (#172); для помеченных запросов дублирует проверку runWithRetry.
+    if (policySignal?.aborted) throw abortReasonToError(policySignal.reason);
+
+    const query = makeBase();
+    current = query;
+    for (const [name, value] of params) query.parameter(name, value);
+    if (timeoutMs !== undefined) query.timeout(timeoutMs);
+    if (markedIdempotent === true) query.idempotent?.(true);
+
+    // Гашение внутреннего ретрая SDK: после первой неудачи SDK хочет
+    // повторить (событие 'retry' после своей задержки) — отменяем сигнал
+    // попытки, SDK бросает AbortError ДО следующего обращения к БД, а мы
+    // подменяем его исходной ошибкой из контекста события. Для
+    // непомеченного запроса это даёт строго однократное исполнение.
+    const attemptController = new AbortController();
+    let captured = false;
+    let capturedError: unknown;
+    query.on?.('retry', (ctx) => {
+      if (!captured) {
+        captured = true;
+        capturedError = ctx.error;
+      }
+      attemptController.abort();
+    });
+
+    const combined = combineSignals([policySignal, attemptController.signal]);
+    if (combined) query.signal(combined);
+
+    try {
+      return await query;
+    } catch (error) {
+      if (captured && isAbortLike(error)) throw capturedError;
+      throw error;
+    }
+  };
+
   const proxy: YdbQuery = {
     parameter(name: string, value: unknown): YdbQuery {
       params.push([name, value]);
@@ -98,55 +163,37 @@ function createPolicyQuery(
       return proxy;
     },
     cancel(): YdbQuery {
+      // Текущая попытка SDK + весь жизненный цикл операции.
       current?.cancel();
+      controller.abort(cancelError);
       return proxy;
     },
     then(onFulfilled?, onRejected?) {
-      const runOnce = async (policySignal?: AbortSignal): Promise<unknown> => {
-        const query = makeBase();
-        current = query;
-        for (const [name, value] of params) query.parameter(name, value);
-        if (timeoutMs !== undefined) query.timeout(timeoutMs);
-        if (markedIdempotent === true) query.idempotent?.(true);
-
-        // Гашение внутреннего ретрая SDK: после первой неудачи SDK хочет
-        // повторить (событие 'retry' после своей задержки) — отменяем сигнал
-        // попытки, SDK бросает AbortError ДО следующего обращения к БД, а мы
-        // подменяем его исходной ошибкой из контекста события. Для
-        // непомеченного запроса это даёт строго однократное исполнение.
-        const attemptController = new AbortController();
-        let captured = false;
-        let capturedError: unknown;
-        query.on?.('retry', (ctx) => {
-          if (!captured) {
-            captured = true;
-            capturedError = ctx.error;
-          }
-          attemptController.abort();
-        });
-
-        const combined = combineSignals([
+      // Первый подписчик создаёт и кеширует общее исполнение операции
+      // (#172); последующие подписки цепляются за тот же промис и не
+      // трогают БД повторно.
+      if (settled === undefined) {
+        const operationSignal = combineSignals([
           userSignal,
-          policySignal,
-          attemptController.signal,
+          policy.signal,
+          controller.signal,
         ]);
-        if (combined) query.signal(combined);
+        const options = {
+          ...policyToOptions(policy),
+          signal: operationSignal,
+        };
 
-        try {
-          return await query;
-        } catch (error) {
-          if (captured && isAbortLike(error)) throw capturedError;
-          throw error;
-        }
-      };
-
-      // Fail-safe (#27): без явной пометки идемпотентности политика НЕ
-      // применяется — ровно одна попытка БД.
-      const result =
-        markedIdempotent === true
-          ? runWithRetry(runOnce, policyToOptions(policy))
-          : Promise.resolve().then(() => runOnce());
-      return result.then(onFulfilled, onRejected);
+        // Fail-safe (#27): без явной пометки идемпотентности политика НЕ
+        // применяется — ровно одна попытка БД.
+        settled =
+          markedIdempotent === true
+            ? runWithRetry(runOnce, options)
+            : Promise.resolve().then(() => runOnce(operationSignal));
+        // Кешированное отклонение не должно стать unhandled rejection,
+        // пока у операции нет подписчиков (#172).
+        settled.catch(() => {});
+      }
+      return settled.then(onFulfilled, onRejected);
     },
   };
   return proxy;

--- a/src/core/retry.ts
+++ b/src/core/retry.ts
@@ -294,7 +294,7 @@ export function computeRetryDelayMs(
  * попадают и в сообщение; произвольные объекты не строковятся
  * (небезопасно) — они видны только через cause.
  */
-function abortReasonToError(reason: unknown): Error {
+export function abortReasonToError(reason: unknown): Error {
   if (reason instanceof Error) return reason;
   const detail =
     typeof reason === 'string'

--- a/test/retry-proxy.spec.ts
+++ b/test/retry-proxy.spec.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from '@jest/globals';
+import { YDBError } from '@ydbjs/error';
+import { StatusIds_StatusCode as Code } from '@ydbjs/api/operation';
+import { withRetryPolicy } from '../src/index.js';
+import type { YdbRetrySleepFn } from '../src/index.js';
+import { createScriptedExecutor, abortError } from './helpers/ydb-mock.js';
+
+/**
+ * Регресс-тесты одиночного исполнения и отмены прокси retry-политики
+ * (#172): два await/подписчика на одном запросе не дублируют обращение
+ * к БД, а cancel() останавливает операцию целиком — до исполнения, во
+ * время попытки и на backoff между попытками.
+ */
+
+function ydbErr(code: number): YDBError {
+  return new YDBError(code, []);
+}
+
+function recordingSleep(): YdbRetrySleepFn {
+  return () => Promise.resolve();
+}
+
+/** Ждёт, пока запрошенное число реальных обращений к БД состоялось. */
+async function waitForCalls(db: { calls: { awaited: boolean }[] }, n: number) {
+  await new Promise<void>((resolve) => {
+    const timer = setInterval(() => {
+      if (db.calls.length >= n && db.calls[n - 1].awaited) {
+        clearInterval(timer);
+        resolve();
+      }
+    }, 5);
+  });
+}
+
+describe('retry-прокси: одиночное исполнение операции (#172)', () => {
+  it('два .then() одного запроса выполняют запрос один раз (idempotent)', async () => {
+    const db = createScriptedExecutor({ label: 'settle' });
+    db.expect('SELECT 1').returnsRows({ id: 1 });
+    const wrapped = withRetryPolicy(db.executor, {});
+    const query = wrapped`SELECT 1`.idempotent(true);
+
+    const [a, b] = await Promise.all([query, query]);
+
+    expect(a).toEqual([[{ id: 1 }]]);
+    expect(b).toEqual([[{ id: 1 }]]);
+    // Ровно одна попытка БД: второй await не тронул сценарий.
+    db.assertComplete();
+    expect(db.calls).toHaveLength(1);
+  });
+
+  it('повторный await того же запроса не дублирует запрос (не idempotent)', async () => {
+    const db = createScriptedExecutor({ label: 'settle' });
+    db.expect('UPSERT INTO t').returns([[]]);
+    const wrapped = withRetryPolicy(db.executor, {});
+    const query = wrapped`UPSERT INTO t (id) VALUES (1)`;
+
+    await query;
+    await query;
+
+    db.assertComplete();
+    expect(db.calls).toHaveLength(1);
+  });
+
+  it('подписки через .then() не порождают дополнительных попыток при повторе', async () => {
+    const db = createScriptedExecutor({ label: 'retry' });
+    db.expect('SELECT 2').throws(ydbErr(Code.ABORTED));
+    db.expect('SELECT 2').returnsRows({ ok: true });
+    const wrapped = withRetryPolicy(db.executor, {
+      jitterRatio: 0,
+      rng: () => 0,
+      sleep: recordingSleep(),
+    });
+    const query = wrapped`SELECT 2`.idempotent(true);
+
+    // Обе подписки висят на ОДНОМ общем исполнении: сценарий из двух шагов
+    // (попытка 1 — ошибка, попытка 2 — успех) потребляется ровно один раз.
+    const results = await Promise.all([query.then(), query.then()]);
+    expect(results[0]).toEqual([[{ ok: true }]]);
+    expect(results[1]).toEqual([[{ ok: true }]]);
+    db.assertComplete();
+  });
+});
+
+describe('retry-прокси: отмена до исполнения (#172)', () => {
+  it('cancel() до первого .then() — ни одного обращения к БД', async () => {
+    const db = createScriptedExecutor({ label: 'cancel' });
+    db.expect('SELECT 1').returnsRows({ id: 1 });
+    const wrapped = withRetryPolicy(db.executor, {});
+    const query = wrapped`SELECT 1`;
+
+    query.cancel();
+
+    await expect(query).rejects.toMatchObject({ name: 'AbortError' });
+    // Сценарий не потреблён — обращения к БД не было вовсе.
+    expect(db.calls).toHaveLength(0);
+  });
+
+  it('cancel() до исполнения не даёт стартовать и idempotent-запросу', async () => {
+    const db = createScriptedExecutor({ label: 'cancel' });
+    db.expect('SELECT 1').returnsRows({ id: 1 });
+    const wrapped = withRetryPolicy(db.executor, {});
+    const query = wrapped`SELECT 1`.idempotent(true);
+
+    query.cancel();
+
+    await expect(query).rejects.toMatchObject({ name: 'AbortError' });
+    expect(db.calls).toHaveLength(0);
+  });
+});
+
+describe('retry-прокси: отмена во время попытки (#172)', () => {
+  it('cancel() гасит летящую попытку и не запускает новые', async () => {
+    const db = createScriptedExecutor({ label: 'cancel' });
+    db.expect('SELECT 1').hangsUntilAbort();
+    const wrapped = withRetryPolicy(db.executor, {
+      maxAttempts: 5,
+      sleep: recordingSleep(),
+    });
+    const query = wrapped`SELECT 1`.idempotent(true);
+
+    // Запускаем исполнение в фоне: первый .then() создаёт общую операцию.
+    const running = Promise.resolve(query);
+    await waitForCalls(db, 1);
+    query.cancel();
+
+    await expect(running).rejects.toMatchObject({ name: 'AbortError' });
+    // cancel() дошёл и до SDK-запроса (current.cancel()).
+    expect(db.calls[0]?.cancelled).toBe(true);
+    // Ровно одна попытка: последующие не стартовали.
+    expect(db.calls).toHaveLength(1);
+  });
+});
+
+describe('retry-прокси: отмена на backoff (#172)', () => {
+  function pendingSleep(): {
+    sleep: YdbRetrySleepFn;
+  } {
+    // Задержка никогда не резолвится сама по себе — только отменой сигнала.
+    const sleep: YdbRetrySleepFn = (_ms, signal) =>
+      new Promise<void>((_resolve, reject) => {
+        if (signal?.aborted) {
+          reject(abortError('aborted by cancel'));
+          return;
+        }
+        signal?.addEventListener(
+          'abort',
+          () => reject(abortError('aborted by cancel')),
+          {
+            once: true,
+          },
+        );
+      });
+    return { sleep };
+  }
+
+  it('cancel() на паузе между попытками останавливает операцию', async () => {
+    const db = createScriptedExecutor({ label: 'cancel' });
+    db.expect('SELECT 1').throws(ydbErr(Code.ABORTED));
+    const { sleep } = pendingSleep();
+    const wrapped = withRetryPolicy(db.executor, {
+      maxAttempts: 5,
+      jitterRatio: 0,
+      rng: () => 0,
+      sleep,
+    });
+    const query = wrapped`SELECT 1`.idempotent(true);
+
+    // Первая попытка упала и ушла в backoff (sleep больше не резолвится).
+    const running = Promise.resolve(query);
+    await waitForCalls(db, 1);
+    query.cancel();
+
+    await expect(running).rejects.toMatchObject({
+      name: 'AbortError',
+      message: expect.stringContaining('aborted by cancel'),
+    });
+    // Вторая попытка НЕ стартовала: backoff прерван отменой.
+    expect(db.calls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Closes #172

## Проблема

Прокси-запрос retry-политики (`createPolicyQuery` в `src/core/retry-executor.ts`) создавал новую операцию `runWithRetry()` внутри каждого `.then()`. Два подписчика или два `await` на одном запросе вызывали `makeBase()` и исполняли запрос к БД дважды — в т.ч. для непомеченных неидемпотентных запросов (нарушение fail-safe). `cancel()` звал только `current?.cancel()`: до первого `.then()` `current` пуст, а на backoff указывал на уже упавшую попытку и новую отменить не мог.

## Изменение

- Кешируем на прокси ОДИН общий промис исполнения операции (`.then()` первого подписчика его создаёт, остальные цепляются за результат).
- Прокси владеет общим `AbortController`; его сигнал собирается в сигнал операции вместе с пользовательским и сигналом политики и используется и для попыток SDK, и для backoff `runWithRetry` (options.signal).
- `cancel()`: `current.cancel()` + `controller.abort()` — гасит летящую попытку, прерывает backoff, запрещает новые попытки. Отмена до первого `await` — проверка `signal.aborted` в начале `runOnce`, обращений к БД нет.
- `abortReasonToError` экспортирован из `retry.ts` для единой семантики причин отмены.

## Тесты

`test/retry-proxy.spec.ts` (скриптовый мок `createScriptedExecutor`):

1. два `.then()` / `Promise.all([query, query])` — одно исполнение (idempotent и non-idempotent);
2. повторный подписчик при ретрае не порождает лишних попыток;
3. `cancel()` до исполнения — ноль обращений к БД (оба режима);
4. `cancel()` во время летящей попытки (hangsUntilAbort) + `cancelled` на запросе;
5. `cancel()` на backoff между попытками — вторая попытка не стартует.

Вся логика проверена: `yarn build`, `yarn lint` (0 errors), `yarn test` (1194 passed).