### PR TITLE
fix(query): make QueryBuilder.orWhere combine with the accumulated predicate (#173)

### DIFF
--- a/src/query/query-builder.ts
+++ b/src/query/query-builder.ts
@@ -71,20 +71,30 @@ export class YdbQueryBuilder<T extends YdbBaseEntity> {
   }
 
   /**
-   * Добавить условие, объединённое с предыдущими через OR.
-   * Формирует объектный оператор $or, поддерживаемый buildWhere.
+   * Добавить условие, объединённое со ВСЕМ накопленным предикатом через OR
+   * (#173): `.where(A).orWhere(B)` — `A OR B`, а не `A AND (B)`.
+   *
+   * Повторные orWhere выстраивают плоскую цепочку `A OR B OR C`; следующий
+   * andWhere/where связывается через AND: `(A OR B OR C) AND D`.
    */
   orWhere(criteria: Record<string, any>): this {
-    const existing = this.whereValues.$or;
-    const currentOr = Array.isArray(existing)
-      ? existing
-      : existing !== undefined
-        ? [existing]
-        : [];
-    this.whereValues = {
-      ...this.whereValues,
-      $or: [...currentOr, criteria],
-    };
+    const keys = Object.keys(this.whereValues).filter(
+      (key) => this.whereValues[key] !== undefined,
+    );
+    // Накопленного предиката нет — первый orWhere задаёт просто предикат.
+    if (keys.length === 0) {
+      this.whereValues = criteria;
+      return this;
+    }
+    // Накопленный предикат — ровно $or: дополняем существующий список,
+    // сохраняя плоскую цепочку `A OR B OR C` без вложенности.
+    if (keys.length === 1 && keys[0] === '$or') {
+      const existing = this.whereValues.$or;
+      const list = Array.isArray(existing) ? existing : [existing];
+      this.whereValues = { $or: [...list, criteria] };
+      return this;
+    }
+    this.whereValues = { $or: [this.whereValues, criteria] };
     return this;
   }
 

--- a/test/where-operators.spec.ts
+++ b/test/where-operators.spec.ts
@@ -246,7 +246,7 @@ describe('WHERE operators', () => {
   });
 
   describe('QueryBuilder', () => {
-    it('supports orWhere()', async () => {
+    it('orWhere combines with the accumulated predicate: A OR B OR C (#173)', async () => {
       const mock = createMockExecutor([[]]);
       WhereOperatorEntity.setExecutor(mock.executor);
 
@@ -257,9 +257,60 @@ describe('WHERE operators', () => {
         .getMany();
 
       const [q] = mock.queries;
-      expect(q.sql).toContain('`is_banned` = $is_banned');
+      // Полный предикат: условия объединены через OR, на корне НЕ AND.
       expect(q.sql).toContain(
-        '(`is_admin` = $is_admin_0_eq OR `balance` >= $balance_1_gte)',
+        'WHERE (`is_banned` = $is_banned_0_eq OR `is_admin` = $is_admin_1_eq ' +
+          'OR `balance` >= $balance_2_gte)',
+      );
+    });
+
+    it('where(A).orWhere(B) evaluates as A OR B (#173)', async () => {
+      const mock = createMockExecutor([[]]);
+      WhereOperatorEntity.setExecutor(mock.executor);
+
+      await WhereOperatorEntity.query()
+        .where({ is_banned: false })
+        .orWhere({ is_admin: true })
+        .getMany();
+
+      const [q] = mock.queries;
+      expect(q.sql).toContain(
+        'WHERE (`is_banned` = $is_banned_0_eq OR `is_admin` = $is_admin_1_eq)',
+      );
+    });
+
+    it('andWhere after orWhere links through AND: (A OR B) AND C (#173)', async () => {
+      const mock = createMockExecutor([[]]);
+      WhereOperatorEntity.setExecutor(mock.executor);
+
+      await WhereOperatorEntity.query()
+        .where({ is_banned: false })
+        .orWhere({ is_admin: true })
+        .andWhere({ balance: { $gte: 100n } })
+        .getMany();
+
+      const [q] = mock.queries;
+      expect(q.sql).toContain(
+        'WHERE (`is_banned` = $is_banned_0_eq OR `is_admin` = $is_admin_1_eq) ' +
+          'AND `balance` >= $balance_2_gte',
+      );
+    });
+
+    it('where(A).orWhere(B).orWhere(C).andWhere(D) = (A OR B OR C) AND D (#173)', async () => {
+      const mock = createMockExecutor([[]]);
+      WhereOperatorEntity.setExecutor(mock.executor);
+
+      await WhereOperatorEntity.query()
+        .where({ is_banned: false })
+        .orWhere({ is_admin: true })
+        .orWhere({ balance: { $gte: 100n } })
+        .andWhere({ name: 'admin' })
+        .getMany();
+
+      const [q] = mock.queries;
+      expect(q.sql).toContain(
+        'WHERE (`is_banned` = $is_banned_0_eq OR `is_admin` = $is_admin_1_eq ' +
+          'OR `balance` >= $balance_2_gte) AND `name` = $name',
       );
     });
 
@@ -273,8 +324,9 @@ describe('WHERE operators', () => {
         .getMany();
 
       const [q] = mock.queries;
-      expect(q.sql).toContain('`status` = $status_0_eq');
-      expect(q.sql).toContain('`is_admin` = $is_admin_1_eq');
+      expect(q.sql).toContain(
+        'WHERE (`status` = $status_0_eq OR `is_admin` = $is_admin_1_eq)',
+      );
     });
   });
 });


### PR DESCRIPTION
Closes #173

## Проблема

`.where(A).orWhere(B)` хранил `A` как корневое поле и клал `B` только под `$or`. Компилятор WHERE соединяет корневые записи через AND → `A AND (B)` вместо `A OR B`; цепочка `orWhere` давала `A AND (B OR C)`.

## Изменение

`orWhere(criteria)` (src/query/query-builder.ts:76) объединяет ВЕСЬ накопленный предикат с новым через OR:
- `.where(A).orWhere(B)` → `{ $or: [A, B] }` → `A OR B`
- при накопленном предикате ровно `$or` список дополняется (плоская `A OR B OR C`, без вложенности); не-массив `$or` (single-object) сохраняется через обёртку в массив
- последующий `andWhere`/`where` связывает цепочку через AND → `(A OR B OR C) AND D`

## Тесты

`test/where-operators.spec.ts` — тесты переведены на полный SQL-предикат:
- `.where(A).orWhere(B)` → `A OR B`
- `.where(A).orWhere(B).orWhere(C)` → `A OR B OR C`
- `.where(A).orWhere(B).andWhere(C)` → `(A OR B) AND C`
- `.where(A).orWhere(B).orWhere(C).andWhere(D)` → `(A OR B OR C) AND D`
- сохранение существующего `$or` объекта

`yarn build`, `yarn lint` (0 errors), `yarn test` (1190 passed).