### PR TITLE
fix(relations): compare Bytes and Date relation keys by value (#174)

### DIFF
--- a/src/core/query-limits.ts
+++ b/src/core/query-limits.ts
@@ -27,6 +27,7 @@ export const MAX_IN_CLAUSE_VALUES = 500;
  * Режет список значений на чанки по MAX_IN_CLAUSE_VALUES (или явному size).
  * Порядок элементов сохраняется; последний чанк может быть меньше.
  */
+import { valueIdentityKey } from './value-identity.js';
 export function chunkInValues<T>(
   values: readonly T[],
   size: number = MAX_IN_CLAUSE_VALUES,
@@ -43,13 +44,19 @@ export function chunkInValues<T>(
 
 /**
  * Дедупликация значений FK/PK с сохранением порядка первого вхождения.
- * Set сравнивает по SameValueZero: скаляры (string/number/bigint/boolean)
- * дедуплицируются по значению, а объекты (Uint8Array и т.п.) — по ссылке,
- * поэтому бинарные значения дедуплицируются только при повторе той же
- * ссылки (для FK/PK-потоков это приемлемо).
+ *
+ * Ключ дедупликации — канонический value-ключ (#174): скаляры
+ * (string/number/bigint/boolean) сравниваются по значению, а Bytes и
+ * Date — ПО ЗНАЧЕНИЮ (два равных `Uint8Array` или две равные `Date`)
+ * тоже схлопываются в одно значение, хотя по ссылке это разные объекты.
  */
 export function dedupeInValues<T>(values: readonly T[]): T[] {
-  return [...new Set(values)];
+  const seen = new Map<string, T>();
+  for (const value of values) {
+    const key = valueIdentityKey([value]);
+    if (!seen.has(key)) seen.set(key, value);
+  }
+  return [...seen.values()];
 }
 
 /** Защитный лимит строк по умолчанию для SELECT без явного limit (#133). */

--- a/src/core/value-identity.ts
+++ b/src/core/value-identity.ts
@@ -1,0 +1,130 @@
+/**
+ * Инъективная каноническая кодировка YDB-значений в строковый ключ (#174).
+ *
+ * Нужна везде, где Map/Set идентифицируют строки по значению колонки:
+ * - дедупликация PK/FK между IN(...)-чанками в fetchByColumnIn (#86);
+ * - группировка inverse-строк и владельцев в relations-мапах (#174);
+ * - повторяющиеся PK-компоненты, гидратированные в РАЗНЫЕ инстансы
+ *   (два `Uint8Array([1,2])` и две равные `Date`) должны считаться одним
+ *   значением — сравнение по ссылке дало бы «не найден» для валидных связей.
+ *
+ * Конкатенация с разделителем (`String(a) + '|' + String(b)`) НЕинъективна:
+ * ('a|b', 'c') и ('a', 'b|c') дают один ключ 'a|b|c'. Поэтому используется
+ * двоичная кодировка без разделителей:
+ * [тег типа][длина payload (4 байта, big-endian)][payload].
+ * Границы компонентов восстанавливаются однозначно по объявленной длине,
+ * типы различаются тегом, поэтому разные значения не могут дать одинаковый
+ * ключ.
+ */
+
+const valueTag = {
+  nullValue: 0,
+  undefinedValue: 1,
+  string: 2,
+  number: 3,
+  bigint: 4,
+  boolean: 5,
+  bytes: 6,
+  date: 7,
+} as const;
+
+const textEncoder = new TextEncoder();
+
+/** Добавляет payload с префиксом длины (4 байта BE) — самоделимитация. */
+function appendLengthPrefixed(out: number[], payload: Uint8Array): void {
+  const len = payload.length;
+  out.push(
+    (len >>> 24) & 0xff,
+    (len >>> 16) & 0xff,
+    (len >>> 8) & 0xff,
+    len & 0xff,
+  );
+  for (let i = 0; i < len; i++) out.push(payload[i]);
+}
+
+/** IEEE-754 double как 8 байт BE. */
+function appendFloat64(out: number[], value: number): void {
+  const buf = new ArrayBuffer(8);
+  new DataView(buf).setFloat64(0, value);
+  appendLengthPrefixed(out, new Uint8Array(buf));
+}
+
+const VALUE_HEX_CHARS = '0123456789abcdef';
+
+/**
+ * Канонический value-ключ кортежа YDB-значений: инъективное отображение
+ * компонентов (string | number | bigint | boolean | Uint8Array | Date |
+ * null/undefined) в hex-строку. Детерминировано: одинаковые значения —
+ * одинаковый ключ, разные — гарантированно разные. Bytes и Date
+ * сравниваются ПО ЗНАЧЕНИЮ, а не по ссылке.
+ */
+export function valueIdentityKey(components: readonly unknown[]): string {
+  const out: number[] = [];
+  for (const value of components) {
+    if (value === null) {
+      out.push(valueTag.nullValue);
+      continue;
+    }
+    switch (typeof value) {
+      case 'string':
+        out.push(valueTag.string);
+        appendLengthPrefixed(out, textEncoder.encode(value));
+        break;
+      case 'number': {
+        // -0 и 0 — одно значение по SameValueZero (как в Set).
+        out.push(valueTag.number);
+        appendFloat64(out, Object.is(value, -0) ? 0 : value);
+        break;
+      }
+      case 'bigint':
+        out.push(valueTag.bigint);
+        appendLengthPrefixed(out, textEncoder.encode(value.toString()));
+        break;
+      case 'boolean':
+        out.push(valueTag.boolean, value ? 1 : 0);
+        break;
+      case 'object': {
+        if (ArrayBuffer.isView(value)) {
+          // Bytes-колонки YDB гидратируются в Uint8Array; сравнение
+          // побайтовое (String() дал бы '[object Uint8Array]' для всех).
+          const view = value;
+          out.push(valueTag.bytes);
+          appendLengthPrefixed(
+            out,
+            new Uint8Array(view.buffer, view.byteOffset, view.byteLength),
+          );
+        } else if (value instanceof Date) {
+          // Date/Datetime/Timestamp-колонки; невалидная дата — ошибка
+          // конфигурации, а не источник коллизий.
+          if (Number.isNaN(value.getTime())) {
+            throw new Error(
+              'Invalid Date in value identity key: cannot build identity key',
+            );
+          }
+          out.push(valueTag.date);
+          appendFloat64(out, value.getTime());
+        } else {
+          throw new Error(
+            `Unsupported value identity component type: ${typeof value}. ` +
+              'Value components must be YDB primitives',
+          );
+        }
+        break;
+      }
+      case 'undefined':
+        out.push(valueTag.undefinedValue);
+        break;
+      default:
+        throw new Error(
+          `Unsupported value identity component type: ${typeof value}. ` +
+            'Value components must be YDB primitives',
+        );
+    }
+  }
+
+  let hex = '';
+  for (const byte of out) {
+    hex += VALUE_HEX_CHARS[byte >> 4] + VALUE_HEX_CHARS[byte & 0x0f];
+  }
+  return hex;
+}

--- a/src/persistence/entity-persistence.ts
+++ b/src/persistence/entity-persistence.ts
@@ -1,4 +1,5 @@
 import type { YdbExecutor, YdbQuery } from '../core/interfaces.js';
+import { valueIdentityKey } from '../core/value-identity.js';
 import {
   getYdbEntityMetadata,
   type YdbEntityMetadata,
@@ -2038,7 +2039,7 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
       for (const entity of hydrated) {
         // Инъективный ключ идентичности PK (#86): без разделительной
         // конкатенации — 'a|b'+'c' и 'a'+'b|c' не должны совпадать.
-        const key = pkIdentityKey(pkFields.map((f) => (entity as any)[f]));
+        const key = valueIdentityKey(pkFields.map((f) => (entity as any)[f]));
         if (seenPks.has(key)) continue;
         seenPks.add(key);
         result.push(entity);
@@ -2087,124 +2088,8 @@ export function isSyntheticColumn(
   );
 }
 
-// ---- Инъективная каноническая кодировка значений PK (#86) ----
-//
-// Дедупликация результатов между IN(...)-чанками в fetchByColumnIn строит
-// строковый ключ идентичности PK. Конкатенация с разделителем
-// (`String(a) + '|' + String(b)`) НЕинъективна: ('a|b', 'c') и ('a', 'b|c')
-// дают один ключ 'a|b|c' — реальная сущность теряется при слиянии чанков.
-// Поэтому используется двоичная кодировка без разделителей:
-// [тег типа][длина payload (4 байта, big-endian)][payload].
-// Границы компонентов восстанавливаются однозначно по объявленной длине,
-// типы различаются тегом, поэтому разные PK не могут дать одинаковый ключ.
-
-const pkValueTag = {
-  nullValue: 0,
-  undefinedValue: 1,
-  string: 2,
-  number: 3,
-  bigint: 4,
-  boolean: 5,
-  bytes: 6,
-  date: 7,
-} as const;
-
-const pkTextEncoder = new TextEncoder();
-
-/** Добавляет payload с префиксом длины (4 байта BE) — самоделимитация. */
-function appendLengthPrefixed(out: number[], payload: Uint8Array): void {
-  const len = payload.length;
-  out.push(
-    (len >>> 24) & 0xff,
-    (len >>> 16) & 0xff,
-    (len >>> 8) & 0xff,
-    len & 0xff,
-  );
-  for (let i = 0; i < len; i++) out.push(payload[i]);
-}
-
-/** IEEE-754 double как 8 байт BE. */
-function appendFloat64(out: number[], value: number): void {
-  const buf = new ArrayBuffer(8);
-  new DataView(buf).setFloat64(0, value);
-  appendLengthPrefixed(out, new Uint8Array(buf));
-}
-
-const PK_HEX_CHARS = '0123456789abcdef';
-
 /**
- * Канонический ключ идентичности PK: инъективное отображение кортежа
- * компонентов (string | number | bigint | boolean | Uint8Array | Date |
- * null/undefined) в hex-строку. Детерминировано: одинаковые значения —
- * одинаковый ключ, разные — гарантированно разные.
+ * Обратно-совместимый алиас канонического ключа PK: реализация перенесена
+ * в core/value-identity.ts (#174) и обобщена до valueIdentityKey.
  */
-export function pkIdentityKey(components: unknown[]): string {
-  const out: number[] = [];
-  for (const value of components) {
-    if (value === null) {
-      out.push(pkValueTag.nullValue);
-      continue;
-    }
-    switch (typeof value) {
-      case 'string':
-        out.push(pkValueTag.string);
-        appendLengthPrefixed(out, pkTextEncoder.encode(value));
-        break;
-      case 'number': {
-        // -0 и 0 — одно значение по SameValueZero (как в Set).
-        out.push(pkValueTag.number);
-        appendFloat64(out, Object.is(value, -0) ? 0 : value);
-        break;
-      }
-      case 'bigint':
-        out.push(pkValueTag.bigint);
-        appendLengthPrefixed(out, pkTextEncoder.encode(value.toString()));
-        break;
-      case 'boolean':
-        out.push(pkValueTag.boolean, value ? 1 : 0);
-        break;
-      case 'object': {
-        if (ArrayBuffer.isView(value)) {
-          // Bytes-колонки YDB гидратируются в Uint8Array; сравнение
-          // побайтовое (String() дал бы '[object Uint8Array]' для всех).
-          const view = value;
-          out.push(pkValueTag.bytes);
-          appendLengthPrefixed(
-            out,
-            new Uint8Array(view.buffer, view.byteOffset, view.byteLength),
-          );
-        } else if (value instanceof Date) {
-          // Date/Datetime/Timestamp-колонки; невалидная дата — ошибка
-          // конфигурации, а не источник коллизий.
-          if (Number.isNaN(value.getTime())) {
-            throw new Error(
-              'Invalid Date in primary key component: cannot build identity key',
-            );
-          }
-          out.push(pkValueTag.date);
-          appendFloat64(out, value.getTime());
-        } else {
-          throw new Error(
-            `Unsupported primary key component type: ${typeof value}. ` +
-              'PK components must be YDB primitives',
-          );
-        }
-        break;
-      }
-      case 'undefined':
-        out.push(pkValueTag.undefinedValue);
-        break;
-      default:
-        throw new Error(
-          `Unsupported primary key component type: ${typeof value}. ` +
-            'PK components must be YDB primitives',
-        );
-    }
-  }
-
-  let hex = '';
-  for (const byte of out) {
-    hex += PK_HEX_CHARS[byte >> 4] + PK_HEX_CHARS[byte & 0x0f];
-  }
-  return hex;
-}
+export { valueIdentityKey as pkIdentityKey } from '../core/value-identity.js';

--- a/src/relations/entity-relations.ts
+++ b/src/relations/entity-relations.ts
@@ -27,6 +27,14 @@ import {
   resolveManyToManyJoinTable,
   type ResolvedJoinTable,
 } from './resolve-join-table.js';
+import { valueIdentityKey } from '../core/value-identity.js';
+
+/** Канонический value-ключ отношений (#174): Bytes и Date сравниваются
+ * по значению, а не по ссылке (гидрация создаёт независимые инстансы
+ * Uint8Array/Date — по ссылке валидные связи «не находились»). */
+function relationKey(value: unknown): string {
+  return valueIdentityKey([value]);
+}
 
 /**
  * Зависимости relations-модуля.
@@ -172,22 +180,22 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
       hydration,
     );
 
-    const byInversePk = new Map<any, YdbBaseEntity>();
+    const byInversePk = new Map<string, YdbBaseEntity>();
     for (const entity of relatedEntities) {
-      byInversePk.set((entity as any)[targetPkField], entity);
+      byInversePk.set(relationKey((entity as any)[targetPkField]), entity);
     }
 
-    const result = new Map<any, YdbBaseEntity[]>();
+    const result = new Map<string, YdbBaseEntity[]>();
     for (const row of links) {
       const ownerFk = row[joinTable.ownerColumn];
       const inverseFk = row[joinTable.inverseColumn];
-      const entity = byInversePk.get(inverseFk);
+      const entity = byInversePk.get(relationKey(inverseFk));
       if (!entity) continue;
-      const group = result.get(ownerFk);
+      const group = result.get(relationKey(ownerFk));
       if (group) {
         group.push(entity);
       } else {
-        result.set(ownerFk, [entity]);
+        result.set(relationKey(ownerFk), [entity]);
       }
     }
 
@@ -348,21 +356,21 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
         hydration,
       );
 
-      const byFk = new Map<any, YdbBaseEntity[]>();
+      const byFk = new Map<string, YdbBaseEntity[]>();
       for (const child of children) {
         const fk = (child as any)[joinColumnName];
-        const group = byFk.get(fk);
+        const group = byFk.get(relationKey(fk));
         if (group) {
           group.push(child);
         } else {
-          byFk.set(fk, [child]);
+          byFk.set(relationKey(fk), [child]);
         }
       }
 
       // Копия массива на инстанс: два инстанса с одним PK не должны
       // разделять один массив (раньше у каждого был свой findAll).
       for (const item of items) {
-        const group = byFk.get((item as any)[pkField]);
+        const group = byFk.get(relationKey((item as any)[pkField]));
         (item as any)[rel.propertyKey] = group ? [...group] : [];
       }
       return children;
@@ -412,7 +420,7 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
       );
 
       for (const item of items) {
-        const group = related.get((item as any)[pkField]);
+        const group = related.get(relationKey((item as any)[pkField]));
         (item as any)[rel.propertyKey] = group ? [...group] : [];
       }
 
@@ -467,14 +475,14 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
       hydration,
     );
 
-    const byPk = new Map<any, YdbBaseEntity>();
+    const byPk = new Map<string, YdbBaseEntity>();
     for (const parent of parents) {
-      byPk.set((parent as any)[targetPk], parent);
+      byPk.set(relationKey((parent as any)[targetPk]), parent);
     }
 
     for (const item of items) {
       (item as any)[rel.propertyKey] =
-        byPk.get((item as any)[joinColumnName]) ?? null;
+        byPk.get(relationKey((item as any)[joinColumnName])) ?? null;
     }
     return parents;
   }

--- a/test/relation-value-keys.spec.ts
+++ b/test/relation-value-keys.spec.ts
@@ -1,0 +1,242 @@
+import 'reflect-metadata';
+import {
+  YdbEntity,
+  YdbColumn,
+  YdbPrimaryColumn,
+  YdbBaseEntity,
+  OneToMany,
+  ManyToOne,
+  ManyToMany,
+  JoinTable,
+  getOrCreateRepository,
+} from '../src/index.js';
+import { createMockExecutor } from './helpers/mock-executor.js';
+
+/**
+ * Регрессионные тесты #174: Keys (Bytes/Date) relations по значению.
+ *
+ * Гидрация создаёт для каждой строки НОВЫЙ инстанс Uint8Array/Date.
+ * Раньше relations-мапы (byFk/byPk/byInversePk/related) индексировались
+ * по ССЫЛКЕ: владелец с PK-инстансом A не «находил» строку, у которой FK
+ * — байт-равный, но другой инстанс B. Валидные связи на Bytes/Date-ключах
+ * схлопывались в пустые/null. Теперь ключ — канонический value-ключ.
+ */
+
+// ---- Bytes-фикстура: doc → pages (1:N), pages → doc (N:1), doc ↔ tags (N:M) ----
+
+@YdbEntity('vk_docs')
+class ValueKeyDocEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Bytes')
+  id: Uint8Array;
+
+  @YdbColumn('Utf8')
+  title: string;
+
+  @OneToMany(() => ValueKeyPageEntity, 'doc_id')
+  pages?: any[];
+
+  @ManyToMany(() => ValueKeyTagEntity, (tag) => tag.docs)
+  @JoinTable('vk_doc_tag', {
+    joinColumn: 'doc_id',
+    inverseJoinColumn: 'tag_id',
+  })
+  tags?: any[];
+}
+
+@YdbEntity('vk_pages')
+class ValueKeyPageEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Bytes')
+  id: Uint8Array;
+
+  @YdbColumn('Bytes')
+  doc_id: Uint8Array;
+
+  @ManyToOne(() => ValueKeyDocEntity, 'doc_id')
+  doc?: any;
+}
+
+@YdbEntity('vk_tags')
+class ValueKeyTagEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Bytes')
+  id: Uint8Array;
+
+  @YdbColumn('Utf8')
+  label: string;
+
+  @ManyToMany(() => ValueKeyDocEntity, (doc) => doc.tags)
+  docs?: any[];
+}
+
+// ---- Date-фикстура: event (Datetime PK) → tickets (1:N), ticket → event (N:1) ----
+
+@YdbEntity('vk_events')
+class ValueKeyEventEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Datetime')
+  at: Date;
+
+  @YdbColumn('Utf8')
+  name: string;
+
+  @OneToMany(() => ValueKeyTicketEntity, 'event_at')
+  tickets?: any[];
+}
+
+@YdbEntity('vk_tickets')
+class ValueKeyTicketEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Utf8')
+  code: string;
+
+  @YdbColumn('Datetime')
+  event_at: Date;
+
+  @ManyToOne(() => ValueKeyEventEntity, 'event_at')
+  event?: any;
+}
+
+const DOC_ID = new Uint8Array([1, 2, 3]);
+const EVENT_AT = new Date('2026-08-28T10:00:00.000Z');
+
+describe('#174: relation keys по значению (Bytes/Date)', () => {
+  describe('Bytes-ключи', () => {
+    it('one-to-many: FK ребёнка — другой инстанс Uint8Array, байт-равный PK владельца', async () => {
+      const doc = Object.assign(new ValueKeyDocEntity(), {
+        id: DOC_ID,
+        title: 'doc',
+      });
+      // Второй инстанс владельца с байт-равным PK — дедупликация IN.
+      const dupe = Object.assign(new ValueKeyDocEntity(), {
+        id: new Uint8Array([1, 2, 3]),
+        title: 'dup',
+      });
+
+      const childRows = [
+        { id: new Uint8Array([10]), doc_id: new Uint8Array([1, 2, 3]) },
+        { id: new Uint8Array([11]), doc_id: new Uint8Array([1, 2, 3]) },
+      ];
+      const mock = createMockExecutor([childRows]);
+      ValueKeyDocEntity.setExecutor(mock.executor);
+      ValueKeyPageEntity.setExecutor(mock.executor);
+
+      await getOrCreateRepository(ValueKeyDocEntity).relations.loadRelations(
+        [doc, dupe],
+        ['pages'],
+      );
+
+      // Байт-равные PK → один параметр, а не два.
+      expect(mock.queries).toHaveLength(1);
+      expect(Object.keys(mock.queries[0].params)).toHaveLength(1);
+
+      expect(doc.pages?.length).toBe(2);
+      expect(doc.pages!.map((p) => p.id)).toEqual([
+        new Uint8Array([10]),
+        new Uint8Array([11]),
+      ]);
+      expect(dupe.pages?.length).toBe(2);
+    });
+
+    it('many-to-one: FK строки — другой инстанс, PK родителя — третий', async () => {
+      const page = Object.assign(new ValueKeyPageEntity(), {
+        id: new Uint8Array([10]),
+        doc_id: new Uint8Array([1, 2, 3]),
+      });
+
+      const parentRows = [{ id: new Uint8Array([1, 2, 3]), title: 'doc' }];
+      const mock = createMockExecutor([parentRows]);
+      ValueKeyPageEntity.setExecutor(mock.executor);
+      ValueKeyDocEntity.setExecutor(mock.executor);
+
+      await getOrCreateRepository(ValueKeyPageEntity).relations.loadRelations(
+        [page],
+        ['doc'],
+      );
+
+      expect(page.doc).not.toBeNull();
+      expect(page.doc!.title).toBe('doc');
+      expect(page.doc!.id).toEqual(DOC_ID);
+    });
+
+    it('many-to-many: инверсный PK и owner-FK — независимые инстансы', async () => {
+      const doc = Object.assign(new ValueKeyDocEntity(), {
+        id: new Uint8Array([9]),
+        title: 'doc',
+      });
+
+      const linkRows = [
+        { doc_id: new Uint8Array([9]), tag_id: new Uint8Array([21]) },
+        { doc_id: new Uint8Array([9]), tag_id: new Uint8Array([22]) },
+        // Ссылка на тег, отсутствующий в tagRows (напр. удалённый) — skip.
+        { doc_id: new Uint8Array([9]), tag_id: new Uint8Array([99]) },
+      ];
+      const tagRows = [
+        { id: new Uint8Array([21]), label: 'a' },
+        { id: new Uint8Array([22]), label: 'b' },
+      ];
+
+      const mock = createMockExecutor([[linkRows], [tagRows]], {
+        sequential: true,
+      });
+      ValueKeyDocEntity.setExecutor(mock.executor);
+      ValueKeyTagEntity.setExecutor(mock.executor);
+
+      await getOrCreateRepository(ValueKeyDocEntity).relations.loadRelations(
+        [doc],
+        ['tags'],
+      );
+
+      expect(doc.tags?.length).toBe(2);
+      expect(doc.tags!.map((t) => t.label).sort()).toEqual(['a', 'b']);
+      expect(doc.tags!.map((t) => t.id)).toEqual([
+        new Uint8Array([21]),
+        new Uint8Array([22]),
+      ]);
+    });
+  });
+
+  describe('Date-ключи', () => {
+    it('many-to-one: FK строки — другой Date-инстанс, равный PK родителя', async () => {
+      const ticket = Object.assign(new ValueKeyTicketEntity(), {
+        code: 't1',
+        event_at: new Date('2026-08-28T10:00:00.000Z'),
+      });
+
+      const parentRows = [{ at: EVENT_AT, name: 'party' }];
+      const mock = createMockExecutor([parentRows]);
+      ValueKeyTicketEntity.setExecutor(mock.executor);
+      ValueKeyEventEntity.setExecutor(mock.executor);
+
+      await getOrCreateRepository(ValueKeyTicketEntity).relations.loadRelations(
+        [ticket],
+        ['event'],
+      );
+
+      expect(ticket.event).not.toBeNull();
+      expect(ticket.event!.name).toBe('party');
+      expect(ticket.event!.at.getTime()).toBe(EVENT_AT.getTime());
+    });
+
+    it('one-to-many: FK детей — отдельные Date-инстансы по event_at владельца', async () => {
+      const event = Object.assign(new ValueKeyEventEntity(), {
+        at: EVENT_AT,
+        name: 'party',
+      });
+
+      const childRows = [
+        { code: 't1', event_at: new Date('2026-08-28T10:00:00.000Z') },
+        { code: 't2', event_at: new Date('2026-08-28T10:00:00.000Z') },
+        // Чужой event — другой слот времени, в группе быть не должен.
+        { code: 't-other', event_at: new Date('2026-08-28T11:00:00.000Z') },
+      ];
+      const mock = createMockExecutor([childRows]);
+      ValueKeyEventEntity.setExecutor(mock.executor);
+      ValueKeyTicketEntity.setExecutor(mock.executor);
+
+      await getOrCreateRepository(ValueKeyEventEntity).relations.loadRelations(
+        [event],
+        ['tickets'],
+      );
+
+      expect(event.tickets?.length).toBe(2);
+      expect(event.tickets!.map((t) => t.code).sort()).toEqual(['t1', 't2']);
+    });
+  });
+});


### PR DESCRIPTION
Closes #174

Связи на Bytes/Date-ключах не находили совпадения, потому что relations-мапы (byFk/byPk/byInversePk/related) индексировались по ссылке, а гидрация создаёт для каждой строки НОВЫЙ инстанс Uint8Array/Date. Два байт-равных \`Uint8Array\` или две равные \`Date\` — разные объекты, Map.get() возвращал undefined, и валидные связи схлопывались в пустые/null.

Изменения:
- \`src/core/value-identity.ts\` (новый): \`valueIdentityKey\` — инъективная каноническая кодировка кортежа YDB-значений (обобщение \`pkIdentityKey\`, перенесённого из entity-persistence).
- \`entity-persistence.ts\`: реализация \`pkIdentityKey\` заменена на алиас \`valueIdentityKey\` (обратная совместимость экспорта).
- \`query-limits.ts\`: \`dedupeInValues\` теперь дедуплицирует Bytes/Date ПО ЗНАЧЕНИЮ (Map по \`valueIdentityKey\` вместо Set-по-ссылке) — байт-равные дубли PK/FK схлопываются в один IN-параметр.
- \`entity-relations.ts\`: все вставки/lookup отношений идут через \`relationKey()\` (value-ключ).

Тесты: \`test/relation-value-keys.spec.ts\` — 5 регресс-тестов (1:N, N:1, N:M с Bytes; N:1 и 1:N с Date/Datetime), подтверждено: на старом коде все 5 падают, на новом проходят. Полный прогон 1192 passed, lint 0 errors.