### PR TITLE
fix(data): exclude undeclared database columns from hydrated entities (#164)

### DIFF
--- a/src/persistence/entity-persistence.ts
+++ b/src/persistence/entity-persistence.ts
@@ -1183,7 +1183,10 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
     const instance = new Ctor();
     const enums = getYdbEnumMetadata(this.entityClass);
     for (const [key, value] of Object.entries(row)) {
-      if (isSyntheticColumn(meta, key)) continue;
+      // Только объявленные колонки. Synthetic {field}_bi и ЛЮБЫЕ столбцы,
+      // выпиленные из метаданных (#164), в инстанс не попадают — иначе
+      // legacy-секреты утекли бы в toJSON()/JSON.stringify().
+      if (!meta.schema[key]) continue;
       const enumMeta = enums.find((e) => e.propertyKey === key);
       let converted = this.convertEnumIn(value, enumMeta);
       converted = this.convertJsonIn(key, converted);
@@ -1278,6 +1281,16 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
     }
   }
 
+  /**
+   * Дефолтная проекция SELECT: только объявленные (физические) колонки
+   * сущности (#164). SELECT * утянул бы и столбцы, выпиленные из
+   * метаданных (например legacy recovery_token) — в инстансы и JSON
+   * они попадать не должны.
+   */
+  private buildDefaultSelect(meta: YdbEntityMetadata): string {
+    return Object.keys(meta.schema).map(quoteIdentifier).join(', ');
+  }
+
   async find(
     where: Record<string, any>,
     options?: QueryOptions,
@@ -1297,7 +1310,7 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
 
     const selectClause = options?.select?.length
       ? options.select.map(quoteIdentifier).join(', ')
-      : '*';
+      : this.buildDefaultSelect(meta);
     const sql = `SELECT ${selectClause} FROM ${quoteIdentifier(meta.tableName)} ${whereClause} LIMIT 1`;
 
     const query = exec([sql] as unknown as TemplateStringsArray);
@@ -1326,7 +1339,7 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
       await this.buildWhere(where);
     const selectClause = options?.select?.length
       ? options.select.map(quoteIdentifier).join(', ')
-      : '*';
+      : this.buildDefaultSelect(meta);
     const sql = `SELECT ${selectClause} FROM ${quoteIdentifier(meta.tableName)} ${whereClause} LIMIT ${resolveRetrieveLimit(options?.limit)} OFFSET ${resolveRetrieveOffset(options?.offset)}`;
 
     const query = exec([sql] as unknown as TemplateStringsArray);
@@ -2013,7 +2026,8 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
 
     for (const chunk of chunkInValues(uniqueValues)) {
       const inParams = chunk.map((_, i) => `$p${i}`).join(', ');
-      const sql = `SELECT * FROM ${quoteIdentifier(meta.tableName)} WHERE ${quoteIdentifier(column)} IN (${inParams})`;
+      const selectClause = this.buildDefaultSelect(meta);
+      const sql = `SELECT ${selectClause} FROM ${quoteIdentifier(meta.tableName)} WHERE ${quoteIdentifier(column)} IN (${inParams})`;
 
       const query = exec([sql] as unknown as TemplateStringsArray);
       chunk.forEach((value, i) => {

--- a/src/query/query-builder.spec.ts
+++ b/src/query/query-builder.spec.ts
@@ -39,7 +39,7 @@ describe('YdbQueryBuilder', () => {
       .toYql();
 
     expect(sql).toBe(
-      'SELECT * FROM `qb_photos` ' +
+      'SELECT `uuid`, `title`, `is_public`, `rating` FROM `qb_photos` ' +
         'WHERE `is_public` = $is_public AND `title` = $title ' +
         'ORDER BY `rating` DESC, `title` ASC LIMIT 20 OFFSET 10',
     );
@@ -49,7 +49,9 @@ describe('YdbQueryBuilder', () => {
   it('builds SELECT without WHERE', async () => {
     mockRuntime();
     const { sql } = await QbPhotoEntity.query().toYql();
-    expect(sql).toBe('SELECT * FROM `qb_photos` LIMIT 100 OFFSET 0');
+    expect(sql).toBe(
+      'SELECT `uuid`, `title`, `is_public`, `rating` FROM `qb_photos` LIMIT 100 OFFSET 0',
+    );
   });
 
   it('throws on unknown ORDER BY field', async () => {

--- a/src/query/query-builder.ts
+++ b/src/query/query-builder.ts
@@ -266,7 +266,9 @@ export class YdbQueryBuilder<T extends YdbBaseEntity> {
 
     const selectClause = this.selectColumns?.length
       ? this.selectColumns.map(quoteIdentifier).join(', ')
-      : '*';
+      : // Дефолтная проекция — только объявленные колонки (#164):
+        // SELECT * утянул бы и столбцы, выпиленные из метаданных.
+        Object.keys(meta.schema).map(quoteIdentifier).join(', ');
 
     const sql =
       `SELECT ${selectClause} FROM ${quoteIdentifier(meta.tableName)}` +

--- a/test/base-entity-crud.spec.ts
+++ b/test/base-entity-crud.spec.ts
@@ -40,7 +40,7 @@ describe('BaseEntity CRUD (mock executor)', () => {
       expect(user?.full_name).toBe('Ivan');
 
       const [q] = mock.queries;
-      expect(q.sql).toContain('SELECT * FROM `users`');
+      expect(q.sql).toContain('SELECT `uuid`, `email_encrypted`, `full_name`');
       expect(q.sql).toContain('WHERE `uuid` = $uuid');
       expect(q.sql).toContain('LIMIT 1');
       expect(q.params.uuid).toBeInstanceOf(Uuid);
@@ -101,7 +101,7 @@ describe('BaseEntity CRUD (mock executor)', () => {
       await UserEntity.find({ uuid: userRow.uuid }, { timeout: 100, signal });
 
       const [q] = mock.queries;
-      expect(q.sql).toContain('SELECT *');
+      expect(q.sql).toContain('SELECT `uuid`, `email_encrypted`, `full_name`');
     });
   });
 

--- a/test/composite-pk.spec.ts
+++ b/test/composite-pk.spec.ts
@@ -285,7 +285,9 @@ describe('Composite PK CRUD', () => {
       expect(membership.user?.uuid).toBe(userRow.uuid);
       // #86: many-to-one грузится одним батч-IN по PK вместо find() на элемент.
       const [q] = mock.queries;
-      expect(q.sql).toContain('SELECT * FROM `users`');
+      expect(q.sql).toContain(
+        'SELECT `uuid`, `email_encrypted`, `full_name` FROM `users`',
+      );
       expect(q.sql).toContain('WHERE `uuid` IN ($p0)');
     });
   });

--- a/test/nestjs/encryption.spec.ts
+++ b/test/nestjs/encryption.spec.ts
@@ -128,7 +128,9 @@ describe('NestJS integration: encryption providers', () => {
     );
     expect(photo).toBeInstanceOf(PhotoEntity);
     expect(photo?.author_email).toBe('a@b.c');
-    expect(mock.queries[0].sql).toContain('SELECT * FROM `photos`');
+    expect(mock.queries[0].sql).toContain(
+      'SELECT `uuid`, `title`, `description`, `width`, `height`, `file_size`, `rating`, `is_public`, `like_count`, `author_email` FROM `photos`',
+    );
   });
 
   it('searches by encrypted field via blind index hash', async () => {

--- a/test/nestjs/module-wiring.spec.ts
+++ b/test/nestjs/module-wiring.spec.ts
@@ -78,7 +78,9 @@ describe('NestJS integration: module wiring', () => {
     expect(user?.uuid).toBe(userRow.uuid);
 
     const [findQuery] = mock.queries;
-    expect(findQuery.sql).toContain('SELECT * FROM `users`');
+    expect(findQuery.sql).toContain(
+      'SELECT `uuid`, `email_encrypted`, `full_name` FROM `users`',
+    );
     expect(findQuery.sql).toContain('WHERE `uuid` = $uuid');
     expect(findQuery.params.uuid).toBeInstanceOf(Uuid);
     expect(String(findQuery.params.uuid)).toBe(userRow.uuid);

--- a/test/scripted-transactions.spec.ts
+++ b/test/scripted-transactions.spec.ts
@@ -149,7 +149,7 @@ describe('#109: транзакции через DI: точная семанти�
   it('откат не мешает следующей транзакции: вторая транзакция коммитится со своими шагами', async () => {
     const failure = unavailableError();
     db.expect('UPSERT INTO `fixture_orders`').inTransaction().throws(failure);
-    db.expect('SELECT * FROM `fixture_orders`')
+    db.expect('SELECT `uuid`, `title`, `status` FROM `fixture_orders`')
       .inTransaction()
       .returnsRows({ uuid: UUID_B, title: 'b', status: 1 });
     db.expect(/UPDATE `fixture_orders`/)
@@ -214,7 +214,9 @@ describe('#109: транзакции через DI: точная семанти�
     const controller = new AbortController();
     controller.abort();
 
-    db.expect('SELECT * FROM `fixture_orders`').returnsRows({
+    db.expect(
+      'SELECT `uuid`, `title`, `status` FROM `fixture_orders`',
+    ).returnsRows({
       uuid: UUID_A,
       title: 'x',
       status: 0,

--- a/test/select-columns.spec.ts
+++ b/test/select-columns.spec.ts
@@ -22,22 +22,28 @@ describe('select columns (issue #10)', () => {
       expect(mock.queries[0].sql).not.toContain('SELECT *');
     });
 
-    it('без select — SELECT * (обратная совместимость)', async () => {
+    it('без select — проекция всех объявленных колонок (#164), не SELECT *', async () => {
       const mock = createMockExecutor([[{ uuid: uuid1, full_name: 'Alice' }]]);
       UserEntity.setExecutor(mock.executor);
 
       await UserEntity.find({ uuid: uuid1 });
 
-      expect(mock.queries[0].sql).toContain('SELECT *');
+      expect(mock.queries[0].sql).toContain(
+        'SELECT `uuid`, `email_encrypted`, `full_name`',
+      );
+      expect(mock.queries[0].sql).not.toContain('SELECT *');
     });
 
-    it('с пустым select — SELECT *', async () => {
+    it('с пустым select — проекция всех объявленных колонок (#164), не SELECT *', async () => {
       const mock = createMockExecutor([[{ uuid: uuid1, full_name: 'Alice' }]]);
       UserEntity.setExecutor(mock.executor);
 
       await UserEntity.find({ uuid: uuid1 }, { select: [] });
 
-      expect(mock.queries[0].sql).toContain('SELECT *');
+      expect(mock.queries[0].sql).toContain(
+        'SELECT `uuid`, `email_encrypted`, `full_name`',
+      );
+      expect(mock.queries[0].sql).not.toContain('SELECT *');
     });
 
     it('возвращает только запрошенные колонки (остальные undefined)', async () => {
@@ -76,13 +82,16 @@ describe('select columns (issue #10)', () => {
       expect(result).toHaveLength(2);
     });
 
-    it('без select — SELECT * (обратная совместимость)', async () => {
+    it('без select — проекция всех объявленных колонок (#164), не SELECT *', async () => {
       const mock = createMockExecutor([[{ uuid: uuid1, full_name: 'Alice' }]]);
       UserEntity.setExecutor(mock.executor);
 
       await UserEntity.findAll({});
 
-      expect(mock.queries[0].sql).toContain('SELECT *');
+      expect(mock.queries[0].sql).toContain(
+        'SELECT `uuid`, `email_encrypted`, `full_name`',
+      );
+      expect(mock.queries[0].sql).not.toContain('SELECT *');
     });
   });
 
@@ -101,13 +110,16 @@ describe('select columns (issue #10)', () => {
       expect(result).toHaveLength(1);
     });
 
-    it('без select — SELECT * (обратная совместимость)', async () => {
+    it('без select — проекция всех объявленных колонок (#164), не SELECT *', async () => {
       const mock = createMockExecutor([[{ uuid: uuid1, full_name: 'Alice' }]]);
       UserEntity.setExecutor(mock.executor);
 
       await UserEntity.query().where({ uuid: uuid1 }).getMany();
 
-      expect(mock.queries[0].sql).toContain('SELECT *');
+      expect(mock.queries[0].sql).toContain(
+        'SELECT `uuid`, `email_encrypted`, `full_name`',
+      );
+      expect(mock.queries[0].sql).not.toContain('SELECT *');
     });
 
     it('цепочка select + orderBy + limit', async () => {

--- a/test/undeclared-columns.spec.ts
+++ b/test/undeclared-columns.spec.ts
@@ -1,0 +1,217 @@
+import 'reflect-metadata';
+import {
+  YdbEntity,
+  YdbColumn,
+  YdbPrimaryColumn,
+  YdbBaseEntity,
+  YdbEncrypted,
+  YdbEnum,
+  OneToMany,
+  ManyToOne,
+  getOrCreateRepository,
+} from '../src/index.js';
+import { TestOnlyEncryptionProvider } from '@ycforge/js-dev-tools';
+import {
+  createMockExecutor,
+  type MockExecutor,
+} from './helpers/mock-executor.js';
+
+/**
+ * Регрессионные тесты #164: колонки, отсутствующие в метаданных, не должны
+ * попадать на гидратированные инстансы и в JSON.stringify().
+ *
+ * Раньше SELECT * + копирование всех колонок строки означали, что legacy
+ * секретная колонка, выпиленная из entity (recovery_token и т.п.), всё ещё
+ * читается и утекает в JSON() — сериализуются ВСЕ enumerable-свойства.
+ */
+
+@YdbEntity('udc_users')
+class UndeclaredUserEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @YdbColumn('Utf8')
+  name: string;
+
+  @YdbEncrypted({ blindIndex: true })
+  email: string | null;
+
+  @YdbEncrypted({ lazy: true, blindIndex: true })
+  note: string | null;
+
+  @YdbColumn('Int32')
+  @YdbEnum({ values: ['active', 'banned'], storage: 'Int32' })
+  status?: string | undefined;
+
+  @YdbColumn('Json')
+  profile?: Record<string, unknown> | undefined;
+
+  @OneToMany(() => UndeclaredLogEntity, 'user_uuid')
+  logs?: any[];
+}
+
+@YdbEntity('udc_logs')
+class UndeclaredLogEntity extends YdbBaseEntity {
+  @YdbPrimaryColumn('Uuid')
+  uuid: string;
+
+  @YdbColumn('Utf8')
+  text: string;
+
+  @YdbColumn('Utf8')
+  user_uuid: string;
+
+  @ManyToOne(() => UndeclaredUserEntity, 'user_uuid')
+  user?: any;
+}
+
+const UUID = '5ad91505-d4f6-4a81-ab65-9dbc68cf4ed5';
+
+function makeRow(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    uuid: UUID,
+    name: 'Alice',
+    email: new TextEncoder().encode('a@b.c'),
+    note: null,
+    status: 0,
+    profile: '{"city":"Msk"}',
+    // Необъявленная колонка — legacy-секрет из БД.
+    legacy_secret: 'top-secret',
+    ...over,
+  };
+}
+
+function configure(provider: TestOnlyEncryptionProvider, mock: MockExecutor) {
+  UndeclaredUserEntity.setExecutor(mock.executor);
+  UndeclaredUserEntity.setEncryptionProvider(provider);
+  UndeclaredUserEntity.setBlindIndexProvider(provider);
+  UndeclaredLogEntity.setExecutor(mock.executor);
+  UndeclaredLogEntity.setEncryptionProvider(provider);
+  UndeclaredLogEntity.setBlindIndexProvider(provider);
+}
+
+const PROJECTION =
+  'SELECT `uuid`, `name`, `status`, `profile`, `email`, `note`';
+
+describe('#164: необъявленные колонки исключаются из инстансов и JSON', () => {
+  afterEach(() => {
+    UndeclaredUserEntity.setExecutor(undefined);
+    UndeclaredUserEntity.setEncryptionProvider(undefined);
+    UndeclaredUserEntity.setBlindIndexProvider(undefined);
+    UndeclaredLogEntity.setExecutor(undefined);
+    UndeclaredLogEntity.setEncryptionProvider(undefined);
+    UndeclaredLogEntity.setBlindIndexProvider(undefined);
+  });
+
+  it('findAll: лишние колонки НЕ на инстансе и НЕ в JSON; объявленные декодируются', async () => {
+    const provider = new TestOnlyEncryptionProvider();
+    const mock = createMockExecutor([[makeRow()]]);
+    configure(provider, mock);
+
+    const users = await UndeclaredUserEntity.findAll({});
+
+    // Дефолтная проекция — только объявленные колонки (#164).
+    expect(mock.queries[0].sql).toContain(`${PROJECTION} FROM `);
+    expect(mock.queries[0].sql).not.toContain('SELECT *');
+
+    const user = users[0];
+    expect((user as any).legacy_secret).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(user, 'legacy_secret')).toBe(
+      false,
+    );
+
+    // Объявленные колонки декодируются как раньше: шифрование, enum, JSON.
+    expect(user.name).toBe('Alice');
+    expect(user.email).toBe('a@b.c');
+    expect(user.status).toBe('active');
+    expect(user.profile).toEqual({ city: 'Msk' });
+
+    const json = JSON.stringify(user);
+    expect(json).not.toContain('top-secret');
+    expect(json).not.toContain('legacy_secret');
+  });
+
+  it('find(): лишняя колонка не попадает в инстанс и JSON', async () => {
+    const provider = new TestOnlyEncryptionProvider();
+    const mock = createMockExecutor([[makeRow()]]);
+    configure(provider, mock);
+
+    const user = await UndeclaredUserEntity.find({ uuid: UUID });
+
+    expect(user).not.toBeNull();
+    expect((user as any).legacy_secret).toBeUndefined();
+    expect(JSON.stringify(user)).not.toContain('top-secret');
+  });
+
+  it('explicit select по-прежнему выбирает только указанные колонки', async () => {
+    const provider = new TestOnlyEncryptionProvider();
+    // Строка как вернул бы YDB при SELECT uuid, name: только эти колонки.
+    const mock = createMockExecutor([
+      [{ uuid: UUID, name: 'Alice', legacy_secret: 'top-secret' }],
+    ]);
+    configure(provider, mock);
+
+    const user = await UndeclaredUserEntity.find(
+      { uuid: UUID },
+      { select: ['uuid', 'name'] },
+    );
+
+    expect(mock.queries[0].sql).toContain('SELECT `uuid`, `name` FROM ');
+    expect(mock.queries[0].sql).not.toContain('SELECT *');
+    expect(user!.name).toBe('Alice');
+    expect((user as any).email).toBeUndefined();
+    expect((user as any).legacy_secret).toBeUndefined();
+  });
+
+  it('lazy-поле дешифруется как раньше, лишняя колонка не утекает', async () => {
+    const provider = new TestOnlyEncryptionProvider();
+    const mock = createMockExecutor([
+      [makeRow({ note: new TextEncoder().encode('secret-note') })],
+    ]);
+    configure(provider, mock);
+
+    const [user] = await UndeclaredUserEntity.findAll({});
+
+    // Lazy-поле хранит ciphertext до явной дешифровки.
+    expect(user.note).toEqual(new TextEncoder().encode('secret-note'));
+    await user.decryptLazyFields();
+    expect(user.note).toBe('secret-note');
+
+    // После дешифровки JSON включает note, но не legacy-секрет.
+    const json = JSON.stringify(user);
+    expect(json).toContain('secret-note');
+    expect(json).not.toContain('top-secret');
+    expect(json).not.toContain('legacy_secret');
+  });
+
+  it('relations: лишние колонки связанных строк тоже исключаются', async () => {
+    const provider = new TestOnlyEncryptionProvider();
+    const mock = createMockExecutor([
+      [
+        {
+          uuid: '00000000-0000-0000-0000-0000000000a1',
+          text: 'log-1',
+          user_uuid: UUID,
+          // Необъявленная колонка в связанной сущности.
+          legacy_token: 'leak',
+        },
+      ],
+    ]);
+    configure(provider, mock);
+
+    const user = Object.assign(new UndeclaredUserEntity(), {
+      uuid: UUID,
+      name: 'Alice',
+    });
+    await getOrCreateRepository(UndeclaredUserEntity).relations.loadRelations(
+      [user],
+      ['logs'],
+    );
+
+    expect(user.logs).toHaveLength(1);
+    const log = user.logs![0];
+    expect(log.legacy_token).toBeUndefined();
+    expect(log.text).toBe('log-1');
+    expect(JSON.stringify(log)).not.toContain('leak');
+  });
+});


### PR DESCRIPTION
Closes #164

Изменения:
- `YdbEntityPersistence`: `buildDefaultSelect(meta)` (только объявленные колонки из `meta.schema`) применяется в `find`/`findAll`/`fetchByColumnIn` вместо `SELECT *`.
- `instantiate`: гидратируются только колонки из `meta.schema` (фильтр вместо проверки only-`isSyntheticColumn`) — legacy колонки, выпиленные из entity, больше не попадают на инстанс и не утекают в `JSON.stringify()`.
- `query-builder`: дефолтная проекция из `Object.keys(meta.schema)`.
- Тесты: новый регресс-spec `test/undeclared-columns.spec.ts` (5 тестов), обновлены `select-columns`, `query-builder.spec`, `scripted-transactions`, `composite-pk`, `base-entity-crud`, NestJS-модуль/шифрование.
- Полный прогон: 1192 passed; lint — 0 errors.