### PR TITLE
fix(encryption): reject non-unique AAD predicates in updateBy() (#166)

### DIFF
--- a/src/persistence/entity-persistence.ts
+++ b/src/persistence/entity-persistence.ts
@@ -535,6 +535,67 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 
   /**
+   * Извлекает однозначный скаляр для AAD-поля из where-предиката (#166).
+   * Разрешено только прямое скалярное равенство или { $eq: scalar }.
+   * Всё, что не задаёт ровно один экземпляр ($in, $between, диапазоны,
+   * $ne, $like, логические группы, массивы, null) — отклоняется до запроса:
+   * запись шифруется с одним AAD, а при чтении контекст AAD у строк разный —
+   * дешифровка вернёт мусор или упадёт.
+   */
+  private extractUniqueAadValue(
+    field: string,
+    raw: unknown,
+  ): { value: string } | null {
+    if (raw === null || raw === undefined) return null;
+    let operand = raw;
+    if (this.isOperatorObject(raw)) {
+      const opKeys = Object.keys(raw).filter((k) => k.startsWith('$'));
+      if (opKeys.length === 1 && '$eq' in raw) {
+        operand = raw.$eq;
+      } else {
+        throw new Error(
+          `updateBy() on ${this.entityClass.name} cannot resolve a unique AAD predicate ` +
+            `for field "${field}": expected a direct scalar equality or { $eq: value }, ` +
+            `got ${this.formatWhereValue(raw)}`,
+        );
+      }
+    }
+    if (Array.isArray(operand) || operand === null || operand === undefined) {
+      throw new Error(
+        `updateBy() on ${this.entityClass.name} cannot resolve a unique AAD predicate ` +
+          `for field "${field}": expected a direct scalar equality or { $eq: value }, ` +
+          `got ${this.formatWhereValue(raw)}`,
+      );
+    }
+    return { value: this.scalarToAadString(operand) };
+  }
+
+  /**
+   * Детерминированное строковое представление скаляра для AAD-контекста.
+   * Примитивы — как в String(); объектные скаляры (напр. JSON-значения) —
+   * через JSON.stringify.
+   */
+  private scalarToAadString(value: unknown): string {
+    if (typeof value === 'string') return value;
+    if (
+      typeof value === 'number' ||
+      typeof value === 'bigint' ||
+      typeof value === 'boolean'
+    ) {
+      return String(value);
+    }
+    return this.formatWhereValue(value);
+  }
+
+  private formatWhereValue(value: unknown): string {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+
+  /**
    * Возвращает хеш blind index для зашифрованного поля.
    */
   private async hashBlindIndexForWhere(field: string, value: string) {
@@ -1713,9 +1774,18 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
                 `are not fixed by the where predicate; set them in where or use aadOverride`,
             );
           }
-          aadFields = Object.fromEntries(
-            meta.aadFields.map((f) => [f, String(where[f])]),
-          );
+          const resolved: Record<string, string> = {};
+          for (const f of meta.aadFields) {
+            const unique = this.extractUniqueAadValue(f, where[f]);
+            if (!unique) {
+              throw new Error(
+                `updateBy() on ${this.entityClass.name} cannot resolve a unique AAD predicate ` +
+                  `for field "${f}"`,
+              );
+            }
+            resolved[f] = unique.value;
+          }
+          aadFields = resolved;
         }
         const aad = ef.aadOverride ?? this.buildAAD(aadFields, meta.aadFields);
         const context: YdbEncryptionContext = {

--- a/test/aad-predicates.spec.ts
+++ b/test/aad-predicates.spec.ts
@@ -1,0 +1,165 @@
+import 'reflect-metadata';
+import {
+  YdbEntity,
+  YdbColumn,
+  YdbPrimaryColumn,
+  YdbEncrypted,
+  YdbSecurityAAD,
+  YdbBaseEntity,
+} from '../src/index.js';
+import type { YdbEncryptionContext } from '../src/index.js';
+import { TestOnlyEncryptionProvider } from '@ycforge/js-dev-tools';
+import { createMockExecutor } from './helpers/mock-executor.js';
+
+/**
+ * Регрессионные тесты #166: updateBy() для зашифрованного поля принимает
+ * только однозначные AAD-предикаты (прямое скалярное равенство или
+ * { $eq: scalar }). $in, $between, диапазоны, $ne, логические группы,
+ * массивы и null-формы отклоняются ДО запроса: иначе один ciphertext
+ * записали бы в строки, контексты AAD которых различаются — при чтении
+ * дешифровка вернула бы мусор.
+ */
+
+@YdbEntity('aad_unique_test')
+class AadUniqueEntity extends YdbBaseEntity {
+  @YdbSecurityAAD()
+  @YdbPrimaryColumn('Utf8')
+  declare tenant_id: string;
+
+  @YdbSecurityAAD()
+  @YdbPrimaryColumn('Utf8')
+  declare org_id: string;
+
+  @YdbEncrypted({ blindIndex: true })
+  @YdbColumn('Utf8')
+  secret?: string;
+
+  @YdbEncrypted({ aadOverride: 'fixed-aad' })
+  @YdbColumn('Utf8')
+  pinned_secret?: string;
+}
+
+/** Провайдер, записывающий AAD/контекст encrypt для проверки. */
+class RecordingEncryptionProvider extends TestOnlyEncryptionProvider {
+  encrypts: { aad: string; context: YdbEncryptionContext }[] = [];
+
+  override async encrypt(
+    plaintext: string,
+    aad: string,
+    context: YdbEncryptionContext,
+  ): Promise<Uint8Array> {
+    this.encrypts.push({ aad, context });
+    return super.encrypt(plaintext, aad, context);
+  }
+}
+
+const FIXED_WHERE = { tenant_id: 't1', org_id: 'o1' };
+
+describe('#166: updateBy() требует однозначный AAD-предикат', () => {
+  afterEach(() => {
+    AadUniqueEntity.setExecutor(undefined);
+    AadUniqueEntity.setEncryptionProvider(undefined);
+    AadUniqueEntity.setBlindIndexProvider(undefined);
+  });
+
+  it('прямое скалярное равенство по всем AAD-полям', async () => {
+    const provider = new RecordingEncryptionProvider();
+    AadUniqueEntity.setEncryptionProvider(provider);
+    AadUniqueEntity.setBlindIndexProvider(provider);
+    const mock = createMockExecutor([[]]);
+    AadUniqueEntity.setExecutor(mock.executor);
+
+    await AadUniqueEntity.updateBy(FIXED_WHERE, { secret: 's1' });
+
+    expect(mock.queries).toHaveLength(1);
+    expect(mock.queries[0].sql).toContain(
+      'WHERE `tenant_id` = $tenant_id AND `org_id` = $org_id',
+    );
+    expect(provider.encrypts).toHaveLength(1);
+    expect(provider.encrypts[0].context.aadFields).toEqual(FIXED_WHERE);
+  });
+
+  it('одиночный { $eq: scalar } для каждого AAD-поля', async () => {
+    const provider = new RecordingEncryptionProvider();
+    AadUniqueEntity.setEncryptionProvider(provider);
+    AadUniqueEntity.setBlindIndexProvider(provider);
+    const mock = createMockExecutor([[]]);
+    AadUniqueEntity.setExecutor(mock.executor);
+
+    await AadUniqueEntity.updateBy(
+      { tenant_id: { $eq: 't1' }, org_id: { $eq: 'o1' } },
+      { secret: 's1' },
+    );
+
+    expect(mock.queries).toHaveLength(1);
+    expect(mock.queries[0].sql).toContain(
+      'WHERE `tenant_id` = $tenant_id AND `org_id` = $org_id',
+    );
+    expect(provider.encrypts[0].context.aadFields).toEqual(FIXED_WHERE);
+  });
+
+  const ambiguousWhere: Array<[string, Record<string, any>]> = [
+    ['$in', { tenant_id: { $in: ['t1', 't2'] }, org_id: 'o1' }],
+    ['$between', { tenant_id: { $between: ['t1', 't2'] }, org_id: 'o1' }],
+    ['$gt range', { tenant_id: { $gt: 't0' }, org_id: 'o1' }],
+    ['$lte range', { tenant_id: { $lte: 't5' }, org_id: 'o1' }],
+    ['$ne', { tenant_id: { $ne: 't2' }, org_id: 'o1' }],
+    ['$or logical group', { tenant_id: { $or: ['t1', 't2'] }, org_id: 'o1' }],
+    ['multi-operator', { tenant_id: { $eq: 't1', $gt: 't0' }, org_id: 'o1' }],
+    ['array value', { tenant_id: ['t1', 't2'], org_id: 'o1' }],
+    ['$eq null', { tenant_id: { $eq: null }, org_id: 'o1' }],
+  ];
+
+  for (const [label, where] of ambiguousWhere) {
+    it(`отклоняет неоднозначный предикат: ${label} — до любого запроса`, async () => {
+      const provider = new RecordingEncryptionProvider();
+      AadUniqueEntity.setEncryptionProvider(provider);
+      AadUniqueEntity.setBlindIndexProvider(provider);
+      const mock = createMockExecutor([[]]);
+      AadUniqueEntity.setExecutor(mock.executor);
+
+      await expect(
+        AadUniqueEntity.updateBy(where, { secret: 's1' }),
+      ).rejects.toThrow(
+        /cannot resolve a unique AAD predicate for field "tenant_id"/,
+      );
+
+      // Ошибка до encrypt и до обращения к БД.
+      expect(provider.encrypts).toHaveLength(0);
+      expect(mock.queries).toHaveLength(0);
+    });
+  }
+
+  it('отсутствующее AAD-поле — прежняя ошибка "not fixed by the where predicate"', async () => {
+    const provider = new RecordingEncryptionProvider();
+    AadUniqueEntity.setEncryptionProvider(provider);
+    AadUniqueEntity.setBlindIndexProvider(provider);
+    const mock = createMockExecutor([[]]);
+    AadUniqueEntity.setExecutor(mock.executor);
+
+    await expect(
+      AadUniqueEntity.updateBy({ tenant_id: 't1' }, { secret: 's1' }),
+    ).rejects.toThrow(
+      /AAD field\(s\) "org_id" are not fixed by the where predicate/,
+    );
+    expect(provider.encrypts).toHaveLength(0);
+    expect(mock.queries).toHaveLength(0);
+  });
+
+  it('aadOverride по-прежнему обходит проверку уникальности — где остаётся произвольным', async () => {
+    const provider = new RecordingEncryptionProvider();
+    AadUniqueEntity.setEncryptionProvider(provider);
+    AadUniqueEntity.setBlindIndexProvider(provider);
+    const mock = createMockExecutor([[]]);
+    AadUniqueEntity.setExecutor(mock.executor);
+
+    await AadUniqueEntity.updateBy(
+      { tenant_id: { $in: ['t1', 't2'] }, org_id: 'o1' },
+      { pinned_secret: 's1' },
+    );
+
+    expect(mock.queries).toHaveLength(1);
+    expect(provider.encrypts).toHaveLength(1);
+    expect(provider.encrypts[0].aad).toBe('fixed-aad');
+  });
+});


### PR DESCRIPTION
Closes #166

- updateBy() больше не собирает AAD через String(where[field]) для произвольного предиката: добавлен extractUniqueAadValue — принимается только прямое скалярное равенство или одиночный { $eq: scalar }; $in, $between, диапазоны, $ne, $like, логические группы, массивы, $eq: null и мульти-операторные объекты отклоняются ДО encrypt и ДО запроса.
- Составные AAD-поля: проверка уникальности на каждое поле из meta.aadFields; отсутствие/явный null — прежняя ошибка not fixed by the where predicate.
- aadOverride по-прежнему обходит проверку (осознанное переопределение AAD).
- Тесты: новый регресс-spec test/aad-predicates.spec.ts (13 тестов: равенство, $eq, $in, $between, диапазоны, $ne, логические группы, массивы, null, составной AAD, отсутствие поля, aadOverride). На старом коде падают 10 из 13.
- Полный прогон: 1200 passed; lint — 0 errors.