### PR TITLE
fix(migrations): make legacy bookkeeping upgrade resumable via DescribeTable (#176)

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -295,9 +295,9 @@ async function runCommand(args: CliArgs): Promise<void> {
           '(schema changes were rolled back manually).',
       );
     }
-    const { executor, close } = await connectCli(config);
+    const { driver, executor, close } = await connectCli(config);
     try {
-      const runner = new YdbMigrationRunner(executor);
+      const runner = new YdbMigrationRunner(executor, driver);
       const target = args.positional as string;
       if (args.asApplied) {
         await runner.markMigrationApplied(target);
@@ -313,9 +313,9 @@ async function runCommand(args: CliArgs): Promise<void> {
   }
 
   if (command === 'migration:run' || command === 'migration:revert') {
-    const { executor, close } = await connectCli(config);
+    const { driver, executor, close } = await connectCli(config);
     try {
-      const runner = new YdbMigrationRunner(executor);
+      const runner = new YdbMigrationRunner(executor, driver);
       const migrations = await loadMigrationsFromDir(migrationsDir);
 
       if (command === 'migration:run') {

--- a/src/migrations/migration-runner.spec.ts
+++ b/src/migrations/migration-runner.spec.ts
@@ -206,6 +206,198 @@ describe('YdbMigrationRunner (#101)', () => {
       expect(alters[1].sql).toContain('ADD COLUMN `state` Utf8');
     });
 
+    /** Колонки таблицы учёта для DescribeTable-шва (#176). */
+    const bookkeepingColumns = (hasHash: boolean, hasState: boolean) =>
+      new Map<string, unknown>([
+        ['id', 3],
+        ['timestamp', 3],
+        ['name', 4],
+        ...(hasHash ? ([['hash', 4]] as const) : []),
+        ...(hasState ? ([['state', 4]] as const) : []),
+      ]);
+
+    it('#176 adds both missing columns by DescribeTable metadata', async () => {
+      const mock = createStatefulExecutor();
+      const describeTable = jest.fn((_t: string): Promise<any> =>
+        Promise.resolve({
+          columns: bookkeepingColumns(false, false),
+          primaryKey: ['id'],
+          indexes: [],
+        }),
+      );
+      const runner = new YdbMigrationRunner(
+        mock.executor,
+        undefined,
+        describeTable,
+      );
+
+      await runner.getAppliedMigrations();
+
+      const alters = mock.queries.filter((q) =>
+        q.sql.startsWith('ALTER TABLE'),
+      );
+      expect(alters).toHaveLength(2);
+      expect(alters[0].sql).toContain('ADD COLUMN `hash` Utf8');
+      expect(alters[1].sql).toContain('ADD COLUMN `state` Utf8');
+    });
+
+    it('#176 adding columns is resumable after a failure between ALTERs', async () => {
+      const store = new Map<string, StoreRow>();
+      const failOnState = (sql: string) =>
+        sql.includes('ADD COLUMN `state`')
+          ? new Error('boom on state')
+          : undefined;
+      const mock1 = createStatefulExecutor({ store, failOn: failOnState });
+
+      let hasHash = false;
+      const hasState = false;
+      const describeTable = jest.fn((_t: string): Promise<any> =>
+        Promise.resolve({
+          columns: bookkeepingColumns(hasHash, hasState),
+          primaryKey: ['id'],
+          indexes: [],
+        }),
+      );
+
+      const first = new YdbMigrationRunner(
+        mock1.executor,
+        undefined,
+        describeTable,
+      );
+      await expect(first.getAppliedMigrations()).rejects.toThrow(
+        'boom on state',
+      );
+      expect(
+        mock1.queries.filter((q) => q.sql.startsWith('ALTER TABLE')),
+      ).toHaveLength(1);
+
+      // Первый ALTER (`hash`) прошёл; повторный запуск добавляет только `state`.
+      hasHash = true;
+      const mock2 = createStatefulExecutor({ store });
+      const second = new YdbMigrationRunner(
+        mock2.executor,
+        undefined,
+        describeTable,
+      );
+      await second.getAppliedMigrations();
+
+      const alters = [
+        ...mock1.queries.filter((q) => q.sql.startsWith('ALTER TABLE')),
+        ...mock2.queries.filter((q) => q.sql.startsWith('ALTER TABLE')),
+      ];
+      expect(alters).toHaveLength(2);
+      expect(alters[0].sql).toContain('ADD COLUMN `hash` Utf8');
+      expect(alters[1].sql).toContain('ADD COLUMN `state` Utf8');
+    });
+
+    it('#176 adds only the missing `hash` column', async () => {
+      const mock = createStatefulExecutor();
+      const describeTable = jest.fn((_t: string): Promise<any> =>
+        Promise.resolve({
+          columns: bookkeepingColumns(false, true),
+          primaryKey: ['id'],
+          indexes: [],
+        }),
+      );
+      const runner = new YdbMigrationRunner(
+        mock.executor,
+        undefined,
+        describeTable,
+      );
+
+      await runner.getAppliedMigrations();
+
+      const alters = mock.queries.filter((q) =>
+        q.sql.startsWith('ALTER TABLE'),
+      );
+      expect(alters).toHaveLength(1);
+      expect(alters[0].sql).toContain('ADD COLUMN `hash` Utf8');
+    });
+
+    it('#176 adds only the missing `state` column', async () => {
+      const mock = createStatefulExecutor();
+      const describeTable = jest.fn((_t: string): Promise<any> =>
+        Promise.resolve({
+          columns: bookkeepingColumns(true, false),
+          primaryKey: ['id'],
+          indexes: [],
+        }),
+      );
+      const runner = new YdbMigrationRunner(
+        mock.executor,
+        undefined,
+        describeTable,
+      );
+
+      await runner.getAppliedMigrations();
+
+      const alters = mock.queries.filter((q) =>
+        q.sql.startsWith('ALTER TABLE'),
+      );
+      expect(alters).toHaveLength(1);
+      expect(alters[0].sql).toContain('ADD COLUMN `state` Utf8');
+    });
+
+    it('#176 fully upgraded table performs no ALTER statements', async () => {
+      const mock = createStatefulExecutor();
+      const describeTable = jest.fn((_t: string): Promise<any> =>
+        Promise.resolve({
+          columns: bookkeepingColumns(true, true),
+          primaryKey: ['id'],
+          indexes: [],
+        }),
+      );
+      const runner = new YdbMigrationRunner(
+        mock.executor,
+        undefined,
+        describeTable,
+      );
+
+      await runner.getAppliedMigrations();
+
+      expect(
+        mock.queries.filter((q) => q.sql.startsWith('ALTER TABLE')),
+      ).toHaveLength(0);
+    });
+
+    it('#176 transient DescribeTable error propagates without any ALTER', async () => {
+      const mock = createStatefulExecutor();
+      const describeTable = jest.fn((_t: string): Promise<any> =>
+        Promise.reject(new Error('table is unavailable')),
+      );
+      const runner = new YdbMigrationRunner(
+        mock.executor,
+        undefined,
+        describeTable,
+      );
+
+      await expect(runner.getAppliedMigrations()).rejects.toThrow(
+        'table is unavailable',
+      );
+      expect(
+        mock.queries.filter((q) => q.sql.startsWith('ALTER TABLE')),
+      ).toHaveLength(0);
+    });
+
+    it('#176 permission DescribeTable error propagates without any ALTER', async () => {
+      const mock = createStatefulExecutor();
+      const describeTable = jest.fn((_t: string): Promise<any> =>
+        Promise.reject(new Error('SCHEME_ERROR: access denied')),
+      );
+      const runner = new YdbMigrationRunner(
+        mock.executor,
+        undefined,
+        describeTable,
+      );
+
+      await expect(runner.getAppliedMigrations()).rejects.toThrow(
+        'access denied',
+      );
+      expect(
+        mock.queries.filter((q) => q.sql.startsWith('ALTER TABLE')),
+      ).toHaveLength(0);
+    });
+
     it('ensures the table only once per runner instance (#101)', async () => {
       // Раньше ensureMigrationsTable выполнялся перед каждым чтением
       const mock = createStatefulExecutor({

--- a/src/migrations/migration-runner.ts
+++ b/src/migrations/migration-runner.ts
@@ -1,7 +1,12 @@
 import { createHash } from 'node:crypto';
+import type { Driver } from '@ydbjs/core';
 import { YdbExecutor } from '../core/interfaces.js';
 import { mapToYdb } from '../core/mapper.js';
 import { quoteIdentifier } from '../core/sql-utils.js';
+import {
+  YdbSchemaSyncer,
+  type YdbTableDescription,
+} from '../schema/schema-sync.js';
 import { YdbMigration, executeSql } from './migration.interface.js';
 
 /** Таблица учёта применённых миграций. */
@@ -271,7 +276,22 @@ export class YdbMigrationRunner {
   /** Кеш ensure: один round-trip на инстанс вместо каждого чтения (#101). */
   private ensurePromise?: Promise<void>;
 
-  constructor(private readonly executor: YdbExecutor) {}
+  constructor(
+    private readonly executor: YdbExecutor,
+    /**
+     * Драйвер нужен для гарантированного апгрейда легаси-таблицы учёта
+     * (#176): DescribeTable через Table service отличает «колонки нет»
+     * от транзиентной ошибки, SELECT-проба этого не умела.
+     */
+    private readonly driver?: Driver,
+    /**
+     * Шов для тестов поверх пути DescribeTable.
+     * Возвращает null, если таблицы не существует (или схему читать нельзя).
+     */
+    private readonly describeTable?: (
+      tableName: string,
+    ) => Promise<YdbTableDescription | null>,
+  ) {}
 
   /** Создаёт таблицу учёта миграций, если её ещё нет (один раз на инстанс). */
   async ensureMigrationsTable(): Promise<void> {
@@ -290,10 +310,36 @@ export class YdbMigrationRunner {
         'PRIMARY KEY (`id`)' +
         ')',
     );
-    // Апгрейд таблицы старого формата (созданной до #101): колонок `hash`
-    // и `state` может не быть — SELECT несуществующей колонки падает,
-    // добавляем колонки. На уже обновлённых таблицах это лишний дешёвый
-    // SELECT один раз на инстанс раннера.
+
+    // Апгрейд таблицы старого формата (созданной до #101): колонок
+    // `hash`/`state` может не быть. Колонки добавляются ТОЛЬКО по реальным
+    // метаданным DescribeTable (#176): Select-проба не отличала отсутствие
+    // колонки от транзиентной/авторизационной ошибки, а безусловная пара
+    // ALTER не переживала частичного апгрейда (сбой между ALTER оставлял
+    // таблицу в состоянии, при котором повторный запуск падал на
+    // дубликате колонки и никогда не доходил до второй).
+    let description: YdbTableDescription | null = null;
+    if (this.driver || this.describeTable) {
+      description = await this.describeMigrationsTable();
+    }
+    if (description) {
+      const missing = (['hash', 'state'] as const).filter(
+        (column) => !description.columns.has(column),
+      );
+      for (const column of missing) {
+        await executeSql(
+          this.executor,
+          `ALTER TABLE ${quoteIdentifier(MIGRATIONS_TABLE)} ` +
+            `ADD COLUMN \`${column}\` Utf8`,
+        );
+      }
+      return;
+    }
+
+    // Легаси-путь для раннеров, созданных без driver (программный вызов):
+    // DescribeTable недоступен — SELECT-проба с безусловным ремонтом. В CLI
+    // и NestJS-путях всегда передаётся driver, поэтому сюда попадают только
+    // явно сконструированные без драйвера раннеры.
     try {
       await executeSql(
         this.executor,
@@ -309,6 +355,23 @@ export class YdbMigrationRunner {
         `ALTER TABLE ${quoteIdentifier(MIGRATIONS_TABLE)} ADD COLUMN \`state\` Utf8`,
       );
     }
+  }
+
+  /**
+   * Метаданные таблицы учёта через существующий путь DescribeTable.
+   * Ошибки DescribeTable (нет прав, транзиентные) пробрасываются наверх
+   * без ALTER — только явное отсутствие колонки ведёт к ALTER (#176).
+   */
+  private async describeMigrationsTable(): Promise<YdbTableDescription | null> {
+    if (this.describeTable) {
+      return this.describeTable(MIGRATIONS_TABLE);
+    }
+    if (this.driver) {
+      return new YdbSchemaSyncer(this.driver, this.executor).describeTable(
+        MIGRATIONS_TABLE,
+      );
+    }
+    return null;
   }
 
   /** Список применённых миграций в порядке применения. */


### PR DESCRIPTION
Closes #176

Проблема: `doEnsureMigrationsTable()` апгрейдил легаси-таблицу учёта через SELECT-пробу + безусловную пару ALTER. Сбой между ALTER (добавлен `hash`, упало на `state`) блокировал повторный запуск — ALTER `hash` падал на дубликате колонки; транзиентные/авторизационные ошибки классифицировались как «нет колонки» и запускали DDL.

Изменения (`YdbMigrationRunner`):
- Конструктор получает опциональный `driver` (и тестовый шов `describeTable`) — апгрейд идёт через существующий DescribeTable (Table service, `YdbSchemaSyncer`).
- Добавляются ТОЛЬКО реально отсутствующие колонки (`hash`/`state` проверяются по метаданным независимо).
- Ошибки DescribeTable (транзиентные, нет прав) пробрасываются без единого ALTER.
- Легаси-путь SELECT-пробы сохранён только для раннеров, созданных без driver (обратная совместимость программного вызова); CLI передаёт driver.
- `src/cli/cli.ts`: `migration:run/revert/repair` передают `driver`.

Тесты: +7 в `src/migrations/migration-runner.spec.ts` (обновление обеих колонок; возобновление после сбоя между ALTER; недостаёт только `hash`; только `state`; полностью обновлённая — без ALTER; транзиентная и авторизационная ошибки без ALTER). Подтверждено: 1194 passed, lint — 0 errors.