### PR TITLE
fix(migrations): prevent file-backed migrations from overriding content hashes (#169)

### DIFF
--- a/src/migrations/migration-loader.spec.ts
+++ b/src/migrations/migration-loader.spec.ts
@@ -246,6 +246,90 @@ describe('loadMigrationsFromDir', () => {
     });
   });
 
+  describe('#169 regression: file-backed identity only', () => {
+    it('assigns content hash to object exports, not just classes', async () => {
+      const body = `export default {
+        up: async () => {},
+        down: async () => {},
+      };`;
+      writeMigration('1000-Obj.mjs', body);
+
+      const migrations = await loadMigrationsFromDir(dir);
+
+      expect(migrations[0].hash).toBe(
+        createHash('sha256').update(body).digest('hex'),
+      );
+    });
+
+    it('rejects a hash declared on a class export', async () => {
+      writeMigration(
+        '1000-ClassHash.mjs',
+        `export default class ClassHash {
+          hash = 'forged-hash';
+          async up() {}
+          async down() {}
+        }`,
+      );
+
+      await expect(loadMigrationsFromDir(dir)).rejects.toThrow(
+        /1000-ClassHash\.mjs declares its own migration hash \("forged-hash"\)/,
+      );
+    });
+
+    it('rejects a hash declared on an object export', async () => {
+      writeMigration(
+        '1000-ObjHash.mjs',
+        `export default {
+          hash: 'forged-hash',
+          up: async () => {},
+          down: async () => {},
+        };`,
+      );
+
+      await expect(loadMigrationsFromDir(dir)).rejects.toThrow(
+        /1000-ObjHash\.mjs declares its own migration hash/,
+      );
+    });
+
+    it('rejects a declared hash even when it equals the file content hash', async () => {
+      // Ключевой кейс: «идеальный» поддельный hash (совпадающий с текущим
+      // содержимым) нельзя просто стереть — он запрещён в принципе, чтобы
+      // изменение исходника не могло сохранить записанный hash.
+      const declared = 'b'.repeat(64);
+      const body = `export default class EqualHash {
+        hash = '${declared}';
+        async up() {}
+        async down() {}
+      }`;
+      writeMigration('1000-Equal.mjs', body);
+
+      await expect(loadMigrationsFromDir(dir)).rejects.toThrow(
+        /declares its own migration hash/,
+      );
+    });
+
+    it('always reassigns the content hash on modified file content', async () => {
+      const body = `export default class Mutable {
+        async up() {}
+        async down() {}
+      }`;
+      writeMigration('1000-Mutable.mjs', body);
+      const before = await loadMigrationsFromDir(dir);
+
+      // Повторная загрузка уже выдала бы файл из кеша Node import;
+      // переименование + изменение содержимого имитируют модификацию.
+      fs.writeFileSync(
+        path.join(dir, '2000-Mutable.mjs'),
+        body.concat('\n// touched\n'),
+        'utf-8',
+      );
+      const after = await loadMigrationsFromDir(dir);
+      const changed = after.find((m) => m.name === '2000-Mutable')!;
+
+      expect(changed.hash).not.toBe(before[0].hash);
+    });
+  });
+
   describe('missing directory (#103)', () => {
     it('fails clearly instead of returning []', async () => {
       // Раньше несуществующая директория выглядела как «No pending

--- a/src/migrations/migration-loader.ts
+++ b/src/migrations/migration-loader.ts
@@ -158,8 +158,17 @@ export async function loadMigrationsFromDir(
 
     const migration = candidates[0].create();
     migration.name ??= file.replace(MIGRATION_FILE_RE, '');
-    // Стабильная идентичность (#101); явно заданный hash не перезаписываем.
-    migration.hash ??= contentHash;
+    // Стабильная идентичность (#101): hash всегда берётся из содержимого
+    // файла. Явный hash в коде миграции — попытка обойти контроль
+    // целостности (#169): изменённый исходник сохранил бы записанный hash
+    // и ушёл бы от drift-детекции.
+    if (migration.hash !== undefined) {
+      throw new Error(
+        `File ${file} declares its own migration hash ("${migration.hash}"). ` +
+          `Migration identity is derived from the file content — remove the "hash" property.`,
+      );
+    }
+    migration.hash = contentHash;
 
     // Дубли имени (в т.ч. `.ts` + скомпилированный `.js` рядом) —
     // раньше второй файл молча skip-ался или дважды применялся в раннере (#100).


### PR DESCRIPTION
Closes #169

Проблема: загрузчик миграций вычислял SHA-256 содержимого файла, но применял его через `migration.hash ??= contentHash` — экспортированная в коде миграции `hash` перекрывала вычисленный и обходила идентичность по содержимому: изменённый исходник сохранял записанный hash и уходил от drift-детекции.

Изменение (`src/migrations/migration-loader.ts`):
- `hash` теперь всегда присваивается из содержимого файла безусловно;
- явный `hash` в экспорте миграции (класс или объект) — ошибка `File X declares its own migration hash ("...")` до применения любых упрощений: запрещён даже «идеальный» (совпадающий с содержимым), чтобы модификация исходника не могла сохранить записанный идентификатор.

Тесты (+5 в `src/migrations/migration-loader.spec.ts`, #169):
- хеш присваивается и для object-экспортов, не только классов;
- класс с объявленным `hash` — ошибка;
- объект с объявленным `hash` — ошибка;
- объявленный `hash`, равный содержимому файла, всё равно отклоняется;
- изменённое содержимое файла всегда меняет хеш (детекция модификации).

Полный прогон: 1192 passed, lint — 0 errors.
