### PR TITLE
fix(logging): do not log parameter values by default (#168)

### DIFF
--- a/src/core/driver.ts
+++ b/src/core/driver.ts
@@ -184,7 +184,9 @@ export function createExecutor(
       typeof opts.logQueries === 'object' && opts.logQueries !== null
         ? opts.logQueries
         : new ConsoleQueryLogger();
-    executor = wrapExecutorWithLogging(executor, logger);
+    executor = wrapExecutorWithLogging(executor, logger, {
+      values: opts.logParamValues,
+    });
   }
 
   return executor;

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -6,7 +6,7 @@ import {
   YdbEncryptionProvider,
 } from '../encryption/ydb-encryption-provider.interface.js';
 import type { YdbValidationProvider } from '../validation/ydb-validate.interface.js';
-import type { QueryLogger } from './query-logger.js';
+import type { QueryLogger, YdbLogParamValues } from './query-logger.js';
 import type { YdbRetryPolicyInput } from './retry.js';
 
 export type { QueryOptions } from './query-options.js';
@@ -76,9 +76,19 @@ export interface YdbModuleOptions {
   sync?: boolean;
   /**
    * Логирование запросов: true (консоль по умолчанию) или экземпляр QueryLogger.
-   * Логирует SQL, замаскированные параметры и длительность.
+   * Логирует SQL, имена параметров, безопасную метаинформацию значений
+   * (тип и длину) и длительность.
    */
   logQueries?: boolean | QueryLogger;
+  /**
+   * Раскрытие raw-значений параметров в логах (#168). По умолчанию
+   * (undefined/false) значения не логируются вовсе — только безопасная
+   * метаинформация (`<string:8>`, `<bytes:24>`), поэтому чувствительные
+   * данные с произвольными именами не попадают в журналы. Раскрытие —
+   * явный opt-in: true (все значения), string[] / RegExp / предикат
+   * (только подходящие имена параметров).
+   */
+  logParamValues?: YdbLogParamValues;
   /**
    * Настройки транзакций (#98):
    * - ambient — включить ambient-контекст транзакций (AsyncLocalStorage):

--- a/src/core/query-logger.ts
+++ b/src/core/query-logger.ts
@@ -24,93 +24,103 @@ export interface QueryLogger {
   log(entry: QueryLogEntry): void;
 }
 
-/** Максимальная длина замаскированного значения параметра. */
+/**
+ * Опции обёртки логирования (#168): управление раскрытием raw-значений
+ * параметров. По умолчанию значения не логируются вовсе.
+ */
+export interface YdbLoggingOptions {
+  values?: YdbLogParamValues;
+}
+
+/** Максимальная длина raw-значения параметра в логах (opt-in раскрытие). */
 const MAX_PARAM_LENGTH = 64;
 
-/** Плейсхолдер вместо значения секретного/PII параметра в логах. */
-const REDACTED = '<redacted>';
-
 /**
- * Токены, по которым имя параметра признаётся чувствительным (секреты/PII).
- * Матчинг по токенам имени (password, token, secret, email, authorization и
- * т.п.) — короткие значения не должны попадать в лог открыто только потому,
- * что не длиннее MAX_PARAM_LENGTH.
- */
-const SENSITIVE_TOKENS = new Set([
-  'password',
-  'passwd',
-  'passphrase',
-  'pwd',
-  'token',
-  'tokens',
-  'secret',
-  'secrets',
-  'authorization',
-  'credential',
-  'credentials',
-  'apikey',
-  'accesskey',
-  'secretkey',
-  'privatekey',
-  'clientsecret',
-  'email',
-  'emails',
-  'phone',
-  'phone_number',
-  'telephone',
-  'mobile',
-  'cellphone',
-  'ssn',
-  'passport',
-  'cvv',
-  'cvc',
-  'card',
-  'cardnumber',
-  'pin',
-  'first_name',
-  'last_name',
-  'full_name',
-  'username',
-  'login',
-  'cookie',
-  'session',
-  'bearer',
-]);
-
-/**
- * Чувствителен ли параметр по имени.
+ * Разрешение на раскрытие raw-значений параметров в логах (#168).
  *
- * Кроме явных токенов секретов/PII маскируются synthetic-колонки blind index
- * (`{field}_bi`): их хеш детерминирован по plaintext, и по логам можно
- * коррелировать значения/подбирать их частотным анализом.
+ * По умолчанию (undefined/false) логгер выводит для каждого параметра только
+ * безопасную метаинформацию — тип и длину (`<string:8>`), никогда не раскрывая
+ * сами значения (байты и blind index маскируются всегда). Историческая
+ * денylist-маскировка по токенам имени непокрыто утекала чувствительные
+ * значения с произвольными именами (`salary`, `medical_record` и т.п.).
+ *
+ * Раскрытие raw-значений — явный opt-in приложения:
+ * - `true` — раскрывать все значения (заведомо unsafe-логгер);
+ * - `string[]` — раскрывать только перечисленные имена параметров;
+ * - `RegExp` — раскрывать по маске имени параметра;
+ * - `(name: string) => boolean` — произвольный предикат приложения.
  */
-function isSensitiveParam(name: string): boolean {
-  const lower = name.toLowerCase();
-  // {field}_bi — корневой параметр, {field}_bi_N — нумерованный
-  // (non-root WHERE, см. buildFieldCondition в entity-persistence).
-  if (/[-_]bi(_\d+)?$/.test(lower)) return true;
-  const tokens = lower.split(/[^a-z0-9]+/).filter((t) => t.length > 0);
-  return tokens.some((t) => SENSITIVE_TOKENS.has(t));
+export type YdbLogParamValues =
+  boolean | string[] | RegExp | ((name: string) => boolean);
+
+/** Допущенное приложением имя — выбор источника raw-значений (#168). */
+function allowRawValue(
+  values: YdbLogParamValues | undefined,
+  name: string,
+): boolean {
+  if (values === undefined || values === false) return false;
+  if (values === true) return true;
+  if (typeof values === 'function') return values(name);
+  if (Array.isArray(values)) return values.includes(name);
+  values.lastIndex = 0;
+  return values.test(name);
 }
 
 /**
- * Маскирование скалярного значения: ciphertext/бинарные данные — только длиной,
- * чувствительные параметры — целиком, длинные строки обрезаются.
+ * Безопасная метаинформация о значении параметра (#168): raw не логируется,
+ * только тип и длина. Строки/числа/JSON/булевы не раскрываются, чтобы по
+ * журналам нельзя было восстановить sensitive-значения с именами, которых
+ * нет ни в каком денylist'е.
  */
-function maskScalarValue(name: string, value: unknown): unknown {
+function safeMetaValue(value: unknown): unknown {
+  if (value instanceof Uint8Array) return `<bytes:${value.length}>`;
+  switch (typeof value) {
+    case 'string':
+      return `<string:${value.length}>`;
+    case 'number':
+      return '<number>';
+    case 'bigint':
+      return '<bigint>';
+    case 'boolean':
+      return '<boolean>';
+    case 'object': {
+      if (value === null) return null;
+      if (value instanceof Date) return '<date>';
+      return `<json:${JSON.stringify(value).length}>`;
+    }
+    default:
+      return `<${typeof value}>`;
+  }
+}
+
+/**
+ * Маскирование скалярного значения. Байты никогда не раскрываются (только
+ * длина). Raw-значение допустимо только для имён из явного allowlist'а
+ * приложения (#168); длинные строки в таком случае обрезаются.
+ */
+function maskScalarValue(
+  name: string,
+  value: unknown,
+  allowRaw: boolean,
+): unknown {
   if (value instanceof Uint8Array) {
-    // Бинарные/зашифрованные данные никогда не логируем дословно.
     return `<bytes:${value.length}>`;
   }
-  if (isSensitiveParam(name)) return REDACTED;
-  if (typeof value === 'string' && value.length > MAX_PARAM_LENGTH) {
-    return value.slice(0, MAX_PARAM_LENGTH) + '...';
+  if (allowRaw) {
+    if (typeof value === 'string' && value.length > MAX_PARAM_LENGTH) {
+      return value.slice(0, MAX_PARAM_LENGTH) + '...';
+    }
+    return value;
   }
-  return value;
+  return safeMetaValue(value);
 }
 
 /** Маскирование значения параметра по имени параметра. */
-function maskValue(name: string, value: unknown): unknown {
+function maskValue(
+  name: string,
+  value: unknown,
+  values?: YdbLogParamValues,
+): unknown {
   if (value === null || value === undefined) return value;
   if (
     typeof value === 'object' &&
@@ -120,9 +130,9 @@ function maskValue(name: string, value: unknown): unknown {
     // YDB typed value { type: ..., value: ... }
     const inner = (value as any).value;
     if (inner === null || inner === undefined) return inner;
-    return maskScalarValue(name, inner);
+    return maskScalarValue(name, inner, allowRawValue(values, name));
   }
-  return maskScalarValue(name, value);
+  return maskScalarValue(name, value, allowRawValue(values, name));
 }
 
 /**
@@ -152,11 +162,16 @@ export class ConsoleQueryLogger implements QueryLogger {
 /**
  * Оборачивает executor логированием: замеряет длительность,
  * маскирует параметры, логирует SQL + ошибки.
+ *
+ * @param options Настройки раскрытия raw-значений параметров (#168):
+ *   по умолчанию в лог попадают только имена и метаинформация (тип+длина).
  */
 export function wrapExecutorWithLogging(
   executor: YdbExecutor,
   logger: QueryLogger,
+  options?: YdbLoggingOptions,
 ): YdbExecutor {
+  const values = options?.values;
   const wrapped: any = (strings: TemplateStringsArray, ...args: any[]) => {
     const sql = strings[0];
     const startTime = performance.now();
@@ -169,7 +184,7 @@ export function wrapExecutorWithLogging(
     const proxied: any = {
       parameter(name: string, value: unknown) {
         paramNames.push(name);
-        maskedParams[name] = maskValue(name, value);
+        maskedParams[name] = maskValue(name, value, values);
         originalParameter(name, value);
         // Возвращаем прокси, иначе цепочка parameter().parameter() сбегает
         // из прокси и последующие вызовы теряют логирование
@@ -220,11 +235,11 @@ export function wrapExecutorWithLogging(
   };
 
   wrapped.transaction = (
-    options?: Parameters<YdbExecutor['transaction']>[0],
+    txOptions?: Parameters<YdbExecutor['transaction']>[0],
   ) => {
     // Опции транзакции (#98) пробрасываются как есть — логируется только
     // executor, семантика исполнения не меняется.
-    const tx = executor.transaction(options);
+    const tx = executor.transaction(txOptions);
     return {
       execute: (
         fn: (trx: YdbExecutor, signal?: AbortSignal) => Promise<unknown>,
@@ -233,7 +248,7 @@ export function wrapExecutorWithLogging(
           // Транзакционный executor оборачивается тем же логгером: каждый
           // запрос внутри runInTransaction (и вложенных транзакций) логируется
           // с той же семантикой, что и обычные запросы.
-          return fn(wrapExecutorWithLogging(trx, logger), signal);
+          return fn(wrapExecutorWithLogging(trx, logger, options), signal);
         }),
     };
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,10 @@ export {
   ConsoleQueryLogger,
   wrapExecutorWithLogging,
 } from './core/query-logger.js';
+export type {
+  YdbLogParamValues,
+  YdbLoggingOptions,
+} from './core/query-logger.js';
 
 // Декораторы
 export { YdbEntity } from './decorators/entity.decorator.js';

--- a/test/query-logger.spec.ts
+++ b/test/query-logger.spec.ts
@@ -96,7 +96,8 @@ describe('wrapExecutorWithLogging', () => {
     expect(logEntries).toHaveLength(1);
     expect(logEntries[0].sql).toBe('SELECT * FROM users');
     expect(logEntries[0].paramNames).toEqual(['id']);
-    expect(logEntries[0].maskedParams).toEqual({ id: 'test' });
+    // #168: по умолчанию значения не раскрываются — только метаинформация
+    expect(logEntries[0].maskedParams).toEqual({ id: '<string:4>' });
     expect(logEntries[0].durationMs).toBeGreaterThanOrEqual(0);
     expect(logEntries[0].error).toBeUndefined();
   });
@@ -116,7 +117,7 @@ describe('wrapExecutorWithLogging', () => {
     expect(logEntries[0].error?.message).toBe('connection refused');
   });
 
-  it('masks long string parameters', async () => {
+  it('masks long string parameters to metadata', async () => {
     const mock = createMockExecutor([[]]);
     const logging = wrapExecutorWithLogging(mock.executor, mockLogger);
 
@@ -124,40 +125,33 @@ describe('wrapExecutorWithLogging', () => {
     q.parameter('description', 'a'.repeat(200));
     await q;
 
-    expect(logEntries[0].maskedParams.description).toBe('a'.repeat(64) + '...');
+    expect(logEntries[0].maskedParams.description).toBe('<string:200>');
   });
 
-  it('redacts short sensitive parameter values', async () => {
+  it('masks every scalar by default, including non-denylisted names (#168)', async () => {
+    // Раньше значения с произвольными именами (salary, medical_record и т.п.)
+    // утекали в лог открыто — денylist не мог их покрыть.
     const mock = createMockExecutor([[]]);
     const logging = wrapExecutorWithLogging(mock.executor, mockLogger);
 
     const q = logging(['INSERT INTO t'] as unknown as TemplateStringsArray);
     q.parameter('password', 'hunter2');
     q.parameter('api_token', 'abc123');
-    q.parameter('authorization', 'Bearer x');
-    q.parameter('email_encrypted', 'ivan@example.com');
+    q.parameter('salary', 150000);
+    q.parameter('medical_record', 'MI-3712-X');
+    q.parameter('home_address', 'Baker St');
+    q.parameter('birth_date', '1990-01-02');
     await q;
 
-    expect(logEntries[0].maskedParams.password).toBe('<redacted>');
-    expect(logEntries[0].maskedParams.api_token).toBe('<redacted>');
-    expect(logEntries[0].maskedParams.authorization).toBe('<redacted>');
-    expect(logEntries[0].maskedParams.email_encrypted).toBe('<redacted>');
+    expect(logEntries[0].maskedParams.password).toBe('<string:7>');
+    expect(logEntries[0].maskedParams.api_token).toBe('<string:6>');
+    expect(logEntries[0].maskedParams.salary).toBe('<number>');
+    expect(logEntries[0].maskedParams.medical_record).toBe('<string:9>');
+    expect(logEntries[0].maskedParams.home_address).toBe('<string:8>');
+    expect(logEntries[0].maskedParams.birth_date).toBe('<string:10>');
   });
 
-  it('redacts long sensitive parameter values', async () => {
-    const mock = createMockExecutor([[]]);
-    const logging = wrapExecutorWithLogging(mock.executor, mockLogger);
-
-    const q = logging(['INSERT INTO t'] as unknown as TemplateStringsArray);
-    q.parameter('secret', 'k'.repeat(500));
-    q.parameter('access_token', 't'.repeat(500));
-    await q;
-
-    expect(logEntries[0].maskedParams.secret).toBe('<redacted>');
-    expect(logEntries[0].maskedParams.access_token).toBe('<redacted>');
-  });
-
-  it('redacts blind index columns by suffix', async () => {
+  it('masks blind index columns to metadata without revealing hashes', async () => {
     const mock = createMockExecutor([[]]);
     const logging = wrapExecutorWithLogging(mock.executor, mockLogger);
 
@@ -169,9 +163,9 @@ describe('wrapExecutorWithLogging', () => {
     q.parameter('email_bi_0', 'numbered-hash');
     await q;
 
-    expect(logEntries[0].maskedParams.email_encrypted_bi).toBe('<redacted>');
-    expect(logEntries[0].maskedParams.author_email_bi).toBe('<redacted>');
-    expect(logEntries[0].maskedParams.email_bi_0).toBe('<redacted>');
+    expect(logEntries[0].maskedParams.email_encrypted_bi).toBe('<string:17>');
+    expect(logEntries[0].maskedParams.author_email_bi).toBe('<string:12>');
+    expect(logEntries[0].maskedParams.email_bi_0).toBe('<string:13>');
   });
 
   it('passes idempotent() through to the wrapped query (#27)', async () => {
@@ -189,20 +183,24 @@ describe('wrapExecutorWithLogging', () => {
     db.assertComplete();
   });
 
-  it('redacts non-string sensitive values', async () => {
+  it('masks non-string sensitive values by default', async () => {
     const mock = createMockExecutor([[]]);
     const logging = wrapExecutorWithLogging(mock.executor, mockLogger);
 
     const q = logging(['INSERT INTO t'] as unknown as TemplateStringsArray);
     q.parameter('pin', 1234);
+    q.parameter('is_admin', true);
     await q;
 
-    expect(logEntries[0].maskedParams.pin).toBe('<redacted>');
+    expect(logEntries[0].maskedParams.pin).toBe('<number>');
+    expect(logEntries[0].maskedParams.is_admin).toBe('<boolean>');
   });
 
-  it('keeps non-sensitive short and long values unmasked/truncated', async () => {
+  it('option true reveals all raw values (#168)', async () => {
     const mock = createMockExecutor([[]]);
-    const logging = wrapExecutorWithLogging(mock.executor, mockLogger);
+    const logging = wrapExecutorWithLogging(mock.executor, mockLogger, {
+      values: true,
+    });
 
     const q = logging(['INSERT INTO t'] as unknown as TemplateStringsArray);
     q.parameter('title', 'Hello');
@@ -213,6 +211,66 @@ describe('wrapExecutorWithLogging', () => {
     expect(logEntries[0].maskedParams.title).toBe('Hello');
     expect(logEntries[0].maskedParams.table_name).toBe('t'.repeat(64) + '...');
     expect(logEntries[0].maskedParams.hash).toBe('sha256hash');
+  });
+
+  it('allowlist by name reveals only listed parameters (#168)', async () => {
+    const mock = createMockExecutor([[]]);
+    const logging = wrapExecutorWithLogging(mock.executor, mockLogger, {
+      values: ['title'],
+    });
+
+    const q = logging(['INSERT INTO t'] as unknown as TemplateStringsArray);
+    q.parameter('title', 'Hello');
+    q.parameter('salary', 150000);
+    await q;
+
+    expect(logEntries[0].maskedParams.title).toBe('Hello');
+    expect(logEntries[0].maskedParams.salary).toBe('<number>');
+  });
+
+  it('allowlist by regex matches parameter names (#168)', async () => {
+    const mock = createMockExecutor([[]]);
+    const logging = wrapExecutorWithLogging(mock.executor, mockLogger, {
+      values: /^email/,
+    });
+
+    const q = logging(['INSERT INTO t'] as unknown as TemplateStringsArray);
+    q.parameter('email', 'ivan@example.com');
+    q.parameter('name', 'Ivan');
+    await q;
+
+    expect(logEntries[0].maskedParams.email).toBe('ivan@example.com');
+    expect(logEntries[0].maskedParams.name).toBe('<string:4>');
+  });
+
+  it('allowlist predicate decides per parameter name (#168)', async () => {
+    const mock = createMockExecutor([[]]);
+    const logging = wrapExecutorWithLogging(mock.executor, mockLogger, {
+      values: (name) => name.startsWith('debug_'),
+    });
+
+    const q = logging(['INSERT INTO t'] as unknown as TemplateStringsArray);
+    q.parameter('debug_trace_id', 'abc-123');
+    q.parameter('user_id', 'u-42');
+    await q;
+
+    expect(logEntries[0].maskedParams.debug_trace_id).toBe('abc-123');
+    expect(logEntries[0].maskedParams.user_id).toBe('<string:4>');
+  });
+
+  it('bytes and blind index stay masked even when values are revealed (#168)', async () => {
+    const mock = createMockExecutor([[]]);
+    const logging = wrapExecutorWithLogging(mock.executor, mockLogger, {
+      values: true,
+    });
+
+    const q = logging(['INSERT INTO t'] as unknown as TemplateStringsArray);
+    q.parameter('data', new Uint8Array([1, 2, 3]));
+    q.parameter('email_bi', 'hash');
+    await q;
+
+    expect(logEntries[0].maskedParams.data).toBe('<bytes:3>');
+    expect(logEntries[0].maskedParams.email_bi).toBe('hash');
   });
 
   it('masks Uint8Array parameters', async () => {
@@ -226,6 +284,17 @@ describe('wrapExecutorWithLogging', () => {
     expect(logEntries[0].maskedParams.data).toBe('<bytes:3>');
   });
 
+  it('masks YDB typed-parameter inner values by default (#168)', async () => {
+    const mock = createMockExecutor([[]]);
+    const logging = wrapExecutorWithLogging(mock.executor, mockLogger);
+
+    const q = logging(['INSERT INTO t'] as unknown as TemplateStringsArray);
+    q.parameter('typed', { type: 'Utf8', value: 'raw-secret' });
+    await q;
+
+    expect(logEntries[0].maskedParams.typed).toBe('<string:10>');
+  });
+
   it('keeps logging through parameter() chaining', async () => {
     const mock = createMockExecutor([[]]);
     const logging = wrapExecutorWithLogging(mock.executor, mockLogger);
@@ -237,7 +306,10 @@ describe('wrapExecutorWithLogging', () => {
 
     expect(logEntries).toHaveLength(1);
     expect(logEntries[0].paramNames).toEqual(['a', 'b']);
-    expect(logEntries[0].maskedParams).toEqual({ a: 1, b: 2 });
+    expect(logEntries[0].maskedParams).toEqual({
+      a: '<number>',
+      b: '<number>',
+    });
   });
 
   it('passes through transaction method', () => {
@@ -260,7 +332,7 @@ describe('wrapExecutorWithLogging', () => {
     expect(logEntries).toHaveLength(1);
     expect(logEntries[0].sql).toBe('SELECT COUNT(*) FROM t');
     expect(logEntries[0].paramNames).toEqual(['flag']);
-    expect(logEntries[0].maskedParams).toEqual({ flag: 1 });
+    expect(logEntries[0].maskedParams).toEqual({ flag: '<number>' });
     expect(logEntries[0].error).toBeUndefined();
   });
 
@@ -318,7 +390,7 @@ describe('wrapExecutorWithLogging', () => {
     // последующий откат транзакции.
     expect(logEntries).toHaveLength(1);
     expect(logEntries[0].sql).toBe('UPDATE t SET x = 1');
-    expect(logEntries[0].maskedParams).toEqual({ v: 2 });
+    expect(logEntries[0].maskedParams).toEqual({ v: '<number>' });
     expect(logEntries[0].error).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #168

Проблема: логгер маскировал параметры по конечному денylist'у токенов имён (`password`, `email`, ...). Короткие значения с произвольными именами (`salary`, `medical_record`, `home_address`, `birth_date` и любые application-specific id) логировались дословно и попадали в персистентные журналы.

Изменения (`src/core/query-logger.ts`):
- По умолчанию значения параметров НЕ логируются: только имя и безопасная метаинформация — тип и длина (`<string:8>`, `<bytes:24>`, `<number>`, `<json:N>`, `<date>`, `<boolean>`). Утечки «произвольное имя — сырое значение» больше нет в принципе.
- Raw-логирование — явный opt-in через `YdbLogParamValues` (`wrapExecutorWithLogging(executor, logger, { values })`, прокинута как `YdbModuleOptions.logParamValues`):
  - `true` — все значения (заведомо unsafe-логгер);
  - `string[]` — по именам параметров;
  - `RegExp` — по маске имени;
  - `(name) => boolean` — предикат приложения.
- Действующие правила поверх opt-in: бинарные данные (в т.ч. ciphertext) маскируются всегда (`<bytes:N>`), длинные строки обрезаются до 64 символов. Денylist-маскировка упразднена — при opt-in выбранные имена раскрываются приложением осознанно.

Тесты (`test/query-logger.spec.ts`, переписаны под новые дефолты + новые):
- по умолчанию маскируются и «секретные» имена, и произвольные (`salary`, `medical_record` и т.п.), и blind index;
- typed-параметры YDB (`{ type, value }`) маскируются по внутреннему значению;
- `values: true` — полное раскрытие (с обрезкой длинных); `['title']` / `/^email/` / предикат — точечное раскрытие, остальные маскируются;
- даже при `values: true` байты остаются `<bytes:N>`.

Полный прогон: 1191 passed, lint — 0 errors.
