### PR TITLE
security(ci): pin actions and reduce privileged workflow permissions (#167)

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -9,6 +9,7 @@ on:
       - labeled
 
 permissions:
+  contents: read
   pull-requests: write
 
 concurrency:
@@ -36,7 +37,8 @@ jobs:
 
     steps:
       - name: DeepSeek Code Review
-        uses: hustcer/deepseek-review@v1
+        # Пин по полному SHA коммита (#167): 'v1' — mutable тег.
+        uses: hustcer/deepseek-review@eccde2e9781008d795e366b951e313e37af88dd5
         with:
           chat-token: ${{ secrets.DEEPSEEK_CHAT_TOKEN }}
           base-url: ${{ secrets.DEEPSEEK_BASE_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,9 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      # Пин по полному SHA коммита (#167): mutable 'v4' здесь и ниже.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: yarn
@@ -30,8 +31,8 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: yarn
@@ -42,14 +43,14 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: yarn
       - run: yarn install --frozen-lockfile
       - run: yarn build
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: dist
           path: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,17 +6,15 @@ on:
       - "v*"
 
 permissions:
-  contents: write
-  packages: write
-  id-token: write
+  contents: read
 
 jobs:
   ci:
     name: CI gate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: yarn
@@ -29,9 +27,17 @@ jobs:
     name: Publish to npm
     needs: ci
     runs-on: ubuntu-latest
+    # Публикация изолирована в отдельный job (#167): write-права (GitHub
+    # Release) и id-token (npm provenance) действуют только здесь, а не на
+    # CI-gate. Секреты публикации привязываются к окружению 'release'
+    # (автоматически создаётся при первом запуске).
+    environment: release
+    permissions:
+      contents: write
+      id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: yarn


### PR DESCRIPTION
Closes #167

Проблема: mutable major-version теги (`@v4`, `@v1`) в `uses:` — уязвимы для supply-chain дрейфа; `pull_request_target`-воркфлоу получал write-права и прокидывал секреты в уязвимый mutable-тег; release-воркфлоу раздавал write/OIDC-права всем джобам, включая CI-gate.

Изменения (все три воркфлоу):

**`ai-review.yml`**
- `hustcer/deepseek-review@v1` → пин по полному 40-символьному SHA `eccde2e...`.
- `permissions` минимальны: `contents: read` + `pull-requests: write` (комментарий ревью). Секреты DeepSeek используются только в этом джобе.

**`ci.yml`**
- `checkout`, `setup-node`, `upload-artifact` — все три зафиксированы на commit SHA.
- `permissions: contents: read` (уже было) — без изменений.

**`release.yml`**
- write-права и OIDC изолированы в джоб `publish`: top-level только `contents: read`; `publish` получает `contents: write` (GitHub Release) + `id-token: write` (npm provenance) + `environment: release` (секреты публикации привязаны к окружению, а не глобальны). Неиспользуемые `packages: write` убраны. CI-gate наследует только `contents: read`.
- Все экшены зафиксированы на commit SHA.

Пины SHA (текущие head'ы тегов на момент фикса):
- `actions/checkout@v4` → `11d5960a326750d5838078e36cf38b85af677262`
- `actions/setup-node@v4` → `49933ea5288caeca8642d1e84afbd3f7d6820020`
- `actions/upload-artifact@v4` → `ea165f8d65b6e75b540449e92b4886f43607fa02`
- `hustcer/deepseek-review@v1` → `eccde2e9781008d795e366b951e313e37af88dd5`

YAML-валидность всех трёх файлов проверена. Кода и тестов не затронуто.
