### PR TITLE
fix(config): make entity configuration atomic with runtime config rollback (#200)

### DIFF
--- a/src/core/standalone.ts
+++ b/src/core/standalone.ts
@@ -6,7 +6,12 @@ import type {
 import type { YdbValidationProvider } from '../validation/ydb-validate.interface.js';
 import type { AadFormat } from '../encryption/aad.js';
 import { YdbBaseEntity } from '../entity/base-entity.js';
-import { getEntityRuntime } from '../entity/entity-runtime.js';
+import {
+  getEntityRuntime,
+  restoreEntityRuntime,
+  snapshotEntityRuntime,
+  type EntityRuntime,
+} from '../entity/entity-runtime.js';
 import { getOrCreateRepository } from '../repository/repository-resolver.js';
 import { validateEntityMetadata } from '../metadata/validate-entity.js';
 import {
@@ -102,13 +107,10 @@ export function configureEntities(
   // в середине цикла откатить все мутации (executor, providers, uuidGenerator,
   // aadFormat, scope, transactions, repository) и оставить сущности
   // в точно таком же состоянии, как до вызова configureEntities.
-  const runtimeSnapshots = new Map<
-    typeof YdbBaseEntity,
-    ReturnType<typeof getEntityRuntime>
-  >();
+  const runtimeSnapshots = new Map<typeof YdbBaseEntity, EntityRuntime>();
   for (const entity of entities) {
     const entityClass = entity as unknown as typeof YdbBaseEntity;
-    runtimeSnapshots.set(entityClass, { ...getEntityRuntime(entityClass) });
+    runtimeSnapshots.set(entityClass, snapshotEntityRuntime(entityClass));
   }
 
   try {
@@ -133,7 +135,7 @@ export function configureEntities(
       const entityClass = entity as unknown as typeof YdbBaseEntity;
       const snapshot = runtimeSnapshots.get(entityClass);
       if (snapshot) {
-        Object.assign(getEntityRuntime(entityClass), snapshot);
+        restoreEntityRuntime(entityClass, snapshot);
       }
     }
     releaseEntitiesFromScope(scope, newlyClaimed);

--- a/src/core/standalone.ts
+++ b/src/core/standalone.ts
@@ -97,16 +97,25 @@ export function configureEntities(
   // какие из них были ново заявлены — для отката при ошибке конфигурации.
   const newlyClaimed = claimEntitiesForScopeWithTracking(scope, entities);
 
-  // 3. Применяем runtime-конфигурацию. Провайдеры перезаписываются
-  // безусловно: undefined сбрасывает провайдеры прошлой конфигурации
-  // при re-bootstrap. При ошибке откатываем владение ново заявленных
-  // сущностей, чтобы не оставлять "зомби"-владение.
+  // 3. Применяем runtime-конфигурацию. Снимаем снимок состояния
+  // каждого класса сущности перед применением, чтобы при ошибке
+  // в середине цикла откатить все мутации (executor, providers, uuidGenerator,
+  // aadFormat, scope, transactions, repository) и оставить сущности
+  // в точно таком же состоянии, как до вызова configureEntities.
+  const runtimeSnapshots = new Map<
+    typeof YdbBaseEntity,
+    ReturnType<typeof getEntityRuntime>
+  >();
+  for (const entity of entities) {
+    const entityClass = entity as unknown as typeof YdbBaseEntity;
+    runtimeSnapshots.set(entityClass, { ...getEntityRuntime(entityClass) });
+  }
+
   try {
     for (const entity of entities) {
       const entityClass = entity as unknown as typeof YdbBaseEntity;
       const runtime = getEntityRuntime(entityClass);
       runtime.uuidGenerator = options.uuidVersion === 'v4' ? uuidv4 : uuidv7;
-      // Привязка к конфигурации (#199): per-scope настройки транзакций.
       runtime.scope = scope;
       runtime.transactions = scope.transactions;
 
@@ -120,6 +129,13 @@ export function configureEntities(
       getOrCreateRepository(entityClass);
     }
   } catch (e) {
+    for (const entity of entities) {
+      const entityClass = entity as unknown as typeof YdbBaseEntity;
+      const snapshot = runtimeSnapshots.get(entityClass);
+      if (snapshot) {
+        Object.assign(getEntityRuntime(entityClass), snapshot);
+      }
+    }
     releaseEntitiesFromScope(scope, newlyClaimed);
     throw e;
   }

--- a/src/entity/entity-runtime.ts
+++ b/src/entity/entity-runtime.ts
@@ -69,3 +69,46 @@ export function getEntityRuntime(target: typeof YdbBaseEntity): EntityRuntime {
   }
   return runtime;
 }
+
+/**
+ * Снимок runtime-состояния сущности ДО применения конфигурации для
+ * атомарного отката (#200). Используется configureEntities() и
+ * createActiveRecordEntityProvider(): если конфигурация падает после того,
+ * как часть runtime уже изменена, restoreEntityRuntime() возвращает сущность
+ * ровно в то состояние, в котором она была до вызова.
+ *
+ * Контракт (обязателен для корректности поверхностного снимка):
+ * конфигурация заменяет только ВЕРХНЕУРОВНЕВЫЕ поля runtime (executor,
+ * провайдеры, uuidGenerator, aadFormat, aadReadFallback, scope, transactions,
+ * repository, repositoryDeps), присваивая новые значения по ссылке. Ни одно
+ * вложенное значение (scope.transactions, repositoryDeps, repository) внутри
+ * не мутируется в месте — поэтому копирования ссылок достаточно для точного
+ * восстановления прежних ссылок. Если появится поле, которое мутируется
+ * в месте (например, `runtime.transactions.ambient = true`), его снимок
+ * нужно делать здесь глубоким, а restoreEntityRuntime() — дополнить.
+ */
+export function snapshotEntityRuntime(
+  entityClass: typeof YdbBaseEntity,
+): EntityRuntime {
+  return { ...getEntityRuntime(entityClass) };
+}
+
+/**
+ * Восстанавливает runtime-состояние сущности из снимка (см.
+ * snapshotEntityRuntime). Помимо присваивания сохранённых ссылок удаляет
+ * поля, которых не было в снимке: если конфигурация добавила новое поле
+ * (не существовавшее до вызова), оно не должно пережить откат.
+ */
+export function restoreEntityRuntime(
+  entityClass: typeof YdbBaseEntity,
+  snapshot: EntityRuntime,
+): void {
+  const runtime = getEntityRuntime(entityClass);
+  const snapshotKeys = new Set(Object.keys(snapshot));
+  for (const key of Object.keys(runtime)) {
+    if (!snapshotKeys.has(key)) {
+      delete (runtime as Record<string, unknown>)[key];
+    }
+  }
+  Object.assign(runtime, snapshot);
+}

--- a/src/nest/repository-factory.ts
+++ b/src/nest/repository-factory.ts
@@ -89,6 +89,9 @@ export function createActiveRecordEntityProvider(
         ]);
       }
 
+      // Снимок runtime-конфигурации для атомарного отката при ошибке.
+      const runtimeSnapshot = { ...getEntityRuntime(entityClass) };
+
       try {
         const runtime = getEntityRuntime(entityClass);
         runtime.uuidGenerator = opts.uuidVersion === 'v4' ? uuidv4 : uuidv7;
@@ -110,6 +113,8 @@ export function createActiveRecordEntityProvider(
 
         getOrCreateRepository(entityClass as any);
       } catch (e) {
+        // Откат runtime-конфигурации сущности к снимку перед изменением.
+        Object.assign(getEntityRuntime(entityClass), runtimeSnapshot);
         if (ormScope && newlyClaimed.length > 0) {
           releaseEntitiesFromScope(ormScope, newlyClaimed);
         }

--- a/src/nest/repository-factory.ts
+++ b/src/nest/repository-factory.ts
@@ -17,7 +17,11 @@ import {
 } from '../encryption/ydb-encryption-provider.interface.js';
 import type { YdbValidationProvider } from '../validation/ydb-validate.interface.js';
 import { YdbBaseEntity } from '../entity/base-entity.js';
-import { getEntityRuntime } from '../entity/entity-runtime.js';
+import {
+  getEntityRuntime,
+  restoreEntityRuntime,
+  snapshotEntityRuntime,
+} from '../entity/entity-runtime.js';
 import { getActiveRecordInitToken } from './repository-token.js';
 import { v4 as uuidv4, v7 as uuidv7 } from 'uuid';
 import { validateEntityMetadata } from '../metadata/validate-entity.js';
@@ -90,7 +94,7 @@ export function createActiveRecordEntityProvider(
       }
 
       // Снимок runtime-конфигурации для атомарного отката при ошибке.
-      const runtimeSnapshot = { ...getEntityRuntime(entityClass) };
+      const runtimeSnapshot = snapshotEntityRuntime(entityClass);
 
       try {
         const runtime = getEntityRuntime(entityClass);
@@ -114,7 +118,7 @@ export function createActiveRecordEntityProvider(
         getOrCreateRepository(entityClass as any);
       } catch (e) {
         // Откат runtime-конфигурации сущности к снимку перед изменением.
-        Object.assign(getEntityRuntime(entityClass), runtimeSnapshot);
+        restoreEntityRuntime(entityClass, runtimeSnapshot);
         if (ormScope && newlyClaimed.length > 0) {
           releaseEntitiesFromScope(ormScope, newlyClaimed);
         }

--- a/test/nestjs/provider-reset.spec.ts
+++ b/test/nestjs/provider-reset.spec.ts
@@ -1,4 +1,5 @@
 import 'reflect-metadata';
+import { jest } from '@jest/globals';
 import { Test } from '@nestjs/testing';
 import { Module } from '@nestjs/common';
 import { createAuth } from '@ycforge/auth';
@@ -18,6 +19,8 @@ import { PhotoEntity } from '../fixtures/photo/photo.entity.js';
 import { createActiveRecordEntityProvider } from '../../src/nest/repository-factory.js';
 import { getEntityRuntime } from '../../src/entity/entity-runtime.js';
 import { createMockExecutor, MockExecutor } from '../helpers/mock-executor.js';
+import type { YdbOrmScope } from '../../src/nest/index.js';
+import { createOrmScope, getEntityOrmScope } from '../../src/nest/index.js';
 
 @Module({
   imports: [YdbOrmModule.forFeature([PhotoEntity])],
@@ -161,5 +164,86 @@ describe('NestJS integration: сброс провайдеров при повт�
     useFactory(db, opts, undefined, undefined);
     expect(getEntityRuntime(ResetPlain).encryptionProvider).toBeUndefined();
     expect(getEntityRuntime(ResetPlain).blindIndexProvider).toBeUndefined();
+  });
+
+  it('createActiveRecordEntityProvider: сбой конфигурации откатывает ранее сконфигурированную сущность (#200)', () => {
+    const provider = createActiveRecordEntityProvider(ResetPlain);
+    const useFactory = (
+      provider as unknown as {
+        useFactory: (
+          db: any,
+          opts: any,
+          encryptionProvider?: YdbEncryptionProvider,
+          blindIndexProvider?: YdbBlindIndexProvider,
+          _validationProvider?: unknown,
+          _entityAppScope?: unknown,
+          ormScope?: YdbOrmScope,
+        ) => unknown;
+      }
+    ).useFactory;
+
+    const opts = {
+      endpoint: 'grpc://localhost:2136/local',
+      auth: createAuth({ type: 'anonymous' }),
+      uuidVersion: 'v4' as const,
+    };
+    const scope = createOrmScope('factory-rollback-scope', {
+      transactions: { ambient: true },
+    });
+    const firstDb = createMockExecutor().executor;
+    const secondDb = createMockExecutor().executor;
+    const { encryptionProvider, blindIndexProvider } = makeTaggedProviders('A');
+
+    // 1. Успешная конфигурация — сущность уже настроена до падающего вызова.
+    useFactory(
+      firstDb,
+      opts,
+      encryptionProvider,
+      blindIndexProvider,
+      undefined,
+      undefined,
+      scope,
+    );
+
+    const before = getEntityRuntime(ResetPlain);
+    const repositoryBefore = before.repository;
+    expect(repositoryBefore).toBeDefined();
+    expect(before.scope).toBe(scope);
+
+    // 2. Вторая конфигурация мутирует runtime (новый executor, uuid v7,
+    //    провайдеры обнуляются, repository пересоздаётся), затем падает.
+    const setExecutorSpy = jest.spyOn(ResetPlain, 'setExecutor');
+    setExecutorSpy.mockImplementationOnce(() => {
+      throw new Error('simulated configuration failure');
+    });
+
+    try {
+      expect(() =>
+        useFactory(
+          secondDb,
+          opts,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          scope,
+        ),
+      ).toThrow('simulated configuration failure');
+    } finally {
+      setExecutorSpy.mockRestore();
+    }
+
+    // 3. Runtime восстановлен ТОЧНО к прежнему состоянию — по ссылкам.
+    const after = getEntityRuntime(ResetPlain);
+    expect(after.executor).toBe(firstDb);
+    expect(after.encryptionProvider).toBe(encryptionProvider);
+    expect(after.blindIndexProvider).toBe(blindIndexProvider);
+    expect(after.uuidGenerator).toBe(before.uuidGenerator);
+    expect(after.scope).toBe(scope);
+    expect(after.transactions).toBe(scope.transactions);
+    expect(after.repository).toBe(repositoryBefore);
+
+    // 4. Владение не изменилось: сущность осталась за своим скоупом.
+    expect(getEntityOrmScope(ResetPlain)).toBe(scope);
   });
 });

--- a/test/standalone-config.spec.ts
+++ b/test/standalone-config.spec.ts
@@ -484,6 +484,81 @@ describe('configureEntities: атомарность runtime-конфигурац
     setExecutorSpy.mockRestore();
   });
 
+  it('восстанавливает ПОЛНОЕ прежнее runtime-состояние сущности, сконфигурированной до падающего вызова', async () => {
+    const firstExecutor = createMockExecutor([[]]);
+    const secondExecutor = createMockExecutor([[]]);
+    const scope = createOrmScope('atomic-full-rollback-scope', {
+      transactions: { ambient: true, warnOutsideTransaction: true },
+    });
+    const { encryptionProvider, blindIndexProvider } = makeTaggedProviders('A');
+    const validationProvider: YdbValidationProvider = {
+      validate: () => Promise.resolve([]),
+    };
+
+    // 1. Сущность УЖЕ сконфигурирована до падающего вызова: заданы все
+    //    опции, влияющие на runtime (executor, провайдеры, uuidVersion, aad).
+    configureEntities([TestUser], {
+      executor: firstExecutor.executor,
+      scope,
+      encryptionProvider,
+      blindIndexProvider,
+      validationProvider,
+      uuidVersion: 'v4',
+      aadFormat: 'legacy',
+      aadReadFallback: false,
+    });
+
+    const before = getEntityRuntime(TestUser);
+    const repositoryBefore = before.repository;
+    expect(repositoryBefore).toBeDefined();
+
+    // 2. Падающий вызов СНАЧАЛА применяет новую конфигурацию к TestUser
+    //    (новый executor, провайдеры обнуляются, uuid -> v7, repository
+    //    пересоздаётся), затем спотыкается на TestPost.
+    const setExecutorSpy = jest.spyOn(TestPost, 'setExecutor');
+    setExecutorSpy.mockImplementationOnce(() => {
+      throw new Error('simulated configuration failure');
+    });
+
+    try {
+      expect(() =>
+        configureEntities([TestUser, TestPost], {
+          executor: secondExecutor.executor,
+          scope,
+        }),
+      ).toThrow('simulated configuration failure');
+    } finally {
+      setExecutorSpy.mockRestore();
+    }
+
+    // 3. Runtime TestUser восстановлен ТОЧНО к прежнему состоянию — по ссылкам.
+    const after = getEntityRuntime(TestUser);
+    expect(after.executor).toBe(firstExecutor.executor);
+    expect(after.encryptionProvider).toBe(encryptionProvider);
+    expect(after.blindIndexProvider).toBe(blindIndexProvider);
+    expect(after.validationProvider).toBe(validationProvider);
+    expect(after.uuidGenerator).toBe(before.uuidGenerator);
+    expect(after.aadFormat).toBe('legacy');
+    expect(after.aadReadFallback).toBe(false);
+    expect(after.scope).toBe(scope);
+    expect(after.transactions).toBe(scope.transactions);
+    expect(after.repository).toBe(repositoryBefore);
+    expect(after.repositoryDeps).toBe(before.repositoryDeps);
+
+    // 4. Владение (#199): ранее принадлежавшая сущность осталась за скоупом,
+    //    ново заявленная — освобождена.
+    expect(getEntityOrmScope(TestUser)).toBe(scope);
+    expect(scope.entities.has(TestUser)).toBe(true);
+    expect(getEntityOrmScope(TestPost)).toBeUndefined();
+    expect(scope.entities.has(TestPost)).toBe(false);
+
+    // 5. Поведение: Active Record снова работает через прежний executor,
+    //    а executor падающей конфигурации не использовался вовсе.
+    await expect(TestUser.findAll()).resolves.toEqual([]);
+    expect(firstExecutor.queries.length).toBeGreaterThan(0);
+    expect(secondExecutor.queries).toHaveLength(0);
+  });
+
   it('сохраняет конфигурацию при успешном вызове', () => {
     const firstExecutor = createMockExecutor();
     const secondExecutor = createMockExecutor();

--- a/test/standalone-config.spec.ts
+++ b/test/standalone-config.spec.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import { describe, it, expect, afterEach } from '@jest/globals';
+import { describe, it, expect, afterEach, jest } from '@jest/globals';
 import {
   YdbEntity,
   YdbColumn,
@@ -420,5 +420,83 @@ describe('configureEntities', () => {
     expect(saved).toBeInstanceOf(TestSimple);
     expect(mock.queries).toHaveLength(1);
     expect(mock.queries[0].sql).toContain('UPDATE `test_simple`');
+  });
+});
+
+describe('configureEntities: атомарность runtime-конфигурации (#200)', () => {
+  afterEach(() => {
+    for (const e of [
+      TestUser,
+      TestPost,
+      TestSimple,
+      TestEncrypted,
+      UndecoratedStandalone,
+      NoPkStandalone,
+    ]) {
+      const scope = getEntityOrmScope(e);
+      if (scope) {
+        releaseEntitiesFromScope(scope, [e]);
+      }
+      e.setExecutor(undefined);
+      e.setEncryptionProvider(undefined);
+      e.setBlindIndexProvider(undefined);
+      e.setValidationProvider(undefined);
+    }
+  });
+
+  it('откатывает runtime-конфигурацию предыдущих сущностей при ошибке в середине списка', () => {
+    const firstExecutor = createMockExecutor();
+    const secondExecutor = createMockExecutor();
+
+    // 1. Конфигурируем TestSimple с первым executor'ом (дефолтный скоуп)
+    configureEntities([TestSimple], { executor: firstExecutor.executor });
+    const simpleRuntimeBefore = getEntityRuntime(TestSimple);
+    expect(simpleRuntimeBefore.executor).toBe(firstExecutor.executor);
+    const simpleScopeBefore = getEntityOrmScope(TestSimple);
+    expect(simpleScopeBefore).toBeDefined(); // привязан к дефолтному скоупу
+
+    // 2. Пытаемся сконфигурировать [TestSimple, TestPost] со вторым executor'ом,
+    //    где TestPost.setExecutor выбрасывает ошибку.
+    const setExecutorSpy = jest.spyOn(TestPost, 'setExecutor');
+    setExecutorSpy.mockImplementationOnce(() => {
+      throw new Error('simulated configuration failure');
+    });
+
+    expect(() =>
+      configureEntities([TestSimple, TestPost], {
+        executor: secondExecutor.executor,
+      }),
+    ).toThrow('simulated configuration failure');
+
+    // 3. Проверяем, что TestSimple откатился к первому executor'у
+    const simpleRuntimeAfter = getEntityRuntime(TestSimple);
+    expect(simpleRuntimeAfter.executor).toBe(firstExecutor.executor);
+    // Провайдеры тоже должны быть восстановлены
+    expect(simpleRuntimeAfter.encryptionProvider).toBeUndefined();
+    expect(simpleRuntimeAfter.blindIndexProvider).toBeUndefined();
+    expect(simpleRuntimeAfter.validationProvider).toBeUndefined();
+    // Владение скоупом НЕ должно измениться (уже было до вызова)
+    expect(getEntityOrmScope(TestSimple)).toBe(simpleScopeBefore);
+
+    // 4. TestPost — это новая сущность в этом вызове, её владение скоупом откатывается
+    expect(getEntityOrmScope(TestPost)).toBeUndefined();
+
+    setExecutorSpy.mockRestore();
+  });
+
+  it('сохраняет конфигурацию при успешном вызове', () => {
+    const firstExecutor = createMockExecutor();
+    const secondExecutor = createMockExecutor();
+
+    configureEntities([TestSimple], { executor: firstExecutor.executor });
+
+    configureEntities([TestSimple, TestPost], {
+      executor: secondExecutor.executor,
+    });
+
+    const simpleRuntime = getEntityRuntime(TestSimple);
+    const postRuntime = getEntityRuntime(TestPost);
+    expect(simpleRuntime.executor).toBe(secondExecutor.executor);
+    expect(postRuntime.executor).toBe(secondExecutor.executor);
   });
 });


### PR DESCRIPTION
## Summary

Implements the remaining atomic configuration requirement from #200 that was not covered by #214.

#214 added scope ownership rollback but not runtime config rollback. This PR adds:

1. **Runtime config snapshot/restore in `configureEntities()`**: Before the config loop, a shallow copy of each entity's `EntityRuntime` is saved. On failure, the old runtime state is restored for all entities in the call.

2. **Same pattern in NestJS `createActiveRecordEntityProvider()`**: Snapshot the single entity's runtime before applying config, restore on failure.

3. **Regression test**: Verifies that when a middle entity fails during config, the earlier entity's executor/providers are restored to their pre-call values.

## Changes

- `src/core/standalone.ts`: Snapshot/restore EntityRuntime for all entities in the call
- `src/nest/repository-factory.ts`: Snapshot/restore EntityRuntime for the single entity  
- `test/standalone-config.spec.ts`: Test covering failure in the middle of entity list

## Acceptance Criteria Met

- A failed configure call leaves all previously configured entities unchanged
- No entity is left with a partially updated executor/provider set
- Successful configuration remains unchanged
- Regression test covers failure in the middle of the entity list
