### PR TITLE
fix(retry): reject builder mutations after query execution starts (#205)

### DIFF
--- a/src/core/retry-executor.ts
+++ b/src/core/retry-executor.ts
@@ -106,6 +106,9 @@ function createPolicyQuery(
   // Единственное исполнение операции на весь прокси-запрос (#172):
   // два .then()/await на одном запросе НЕ дублируют обращение к БД.
   let settled: Promise<unknown> | undefined;
+  // Флаг: исполнение начато (первый .then()/await).
+  // После этого мутирующие методы билдера запрещены.
+  let started = false;
 
   const runOnce = async (policySignal?: AbortSignal): Promise<unknown> => {
     // Отмена до старта (cancel() до первого await) — ни одного обращения
@@ -147,18 +150,42 @@ function createPolicyQuery(
 
   const proxy: YdbQuery = {
     parameter(name: string, value: unknown): YdbQuery {
+      if (started) {
+        throw new Error(
+          'Cannot call .parameter() after query execution has started. ' +
+            'All query parameters must be set before the first await/.then().',
+        );
+      }
       params.push([name, value]);
       return proxy;
     },
     timeout(timeout: number): YdbQuery {
+      if (started) {
+        throw new Error(
+          'Cannot call .timeout() after query execution has started. ' +
+            'Query timeout must be set before the first await/.then().',
+        );
+      }
       timeoutMs = timeout;
       return proxy;
     },
     signal(signal: AbortSignal): YdbQuery {
+      if (started) {
+        throw new Error(
+          'Cannot call .signal() after query execution has started. ' +
+            'AbortSignal must be set before the first await/.then().',
+        );
+      }
       userSignal = signal;
       return proxy;
     },
     idempotent(flag?: boolean): YdbQuery {
+      if (started) {
+        throw new Error(
+          'Cannot call .idempotent() after query execution has started. ' +
+            'Idempotency flag must be set before the first await/.then().',
+        );
+      }
       markedIdempotent = flag !== false;
       return proxy;
     },
@@ -173,6 +200,7 @@ function createPolicyQuery(
       // (#172); последующие подписки цепляются за тот же промис и не
       // трогают БД повторно.
       if (settled === undefined) {
+        started = true;
         const operationSignal = combineSignals([
           userSignal,
           policy.signal,

--- a/test/retry-proxy.spec.ts
+++ b/test/retry-proxy.spec.ts
@@ -178,3 +178,79 @@ describe('retry-прокси: отмена на backoff (#172)', () => {
     expect(db.calls).toHaveLength(1);
   });
 });
+
+describe('retry-прокси: защита от мутаций после старта исполнения (#205)', () => {
+  it('parameter() после await бросает ошибку', async () => {
+    const db = createScriptedExecutor({ label: 'mutate' });
+    db.expect('SELECT 1').returnsRows({ id: 1 });
+    const wrapped = withRetryPolicy(db.executor, {});
+    const query = wrapped`SELECT 1`.idempotent(true);
+
+    await query;
+    expect(() => query.parameter('x', 1)).toThrow(
+      /Cannot call \.parameter\(\) after query execution has started/,
+    );
+  });
+
+  it('timeout() после await бросает ошибку', async () => {
+    const db = createScriptedExecutor({ label: 'mutate' });
+    db.expect('SELECT 1').returnsRows({ id: 1 });
+    const wrapped = withRetryPolicy(db.executor, {});
+    const query = wrapped`SELECT 1`.idempotent(true);
+
+    await query;
+    expect(() => query.timeout(1000)).toThrow(
+      /Cannot call \.timeout\(\) after query execution has started/,
+    );
+  });
+
+  it('signal() после await бросает ошибку', async () => {
+    const db = createScriptedExecutor({ label: 'mutate' });
+    db.expect('SELECT 1').returnsRows({ id: 1 });
+    const wrapped = withRetryPolicy(db.executor, {});
+    const query = wrapped`SELECT 1`.idempotent(true);
+
+    await query;
+    expect(() => query.signal(AbortSignal.timeout(1000))).toThrow(
+      /Cannot call \.signal\(\) after query execution has started/,
+    );
+  });
+
+  it('idempotent() после await бросает ошибку', async () => {
+    const db = createScriptedExecutor({ label: 'mutate' });
+    db.expect('SELECT 1').returnsRows({ id: 1 });
+    const wrapped = withRetryPolicy(db.executor, {});
+    const query = wrapped`SELECT 1`.idempotent(true);
+
+    await query;
+    expect(() => query.idempotent(false)).toThrow(
+      /Cannot call \.idempotent\(\) after query execution has started/,
+    );
+  });
+
+  it('cancel() после await продолжает работать', async () => {
+    const db = createScriptedExecutor({ label: 'mutate' });
+    db.expect('SELECT 1').returnsRows({ id: 1 });
+    const wrapped = withRetryPolicy(db.executor, {});
+    const query = wrapped`SELECT 1`.idempotent(true);
+
+    await query;
+    // cancel() должен не бросать, а просто возвращать proxy
+    expect(query.cancel()).toBe(query);
+  });
+
+  it('mutation до await разрешена', async () => {
+    const db = createScriptedExecutor({ label: 'mutate' });
+    db.expect('SELECT 1').returnsRows({ id: 1 });
+    const wrapped = withRetryPolicy(db.executor, {});
+    const query = wrapped`SELECT 1`;
+
+    query.parameter('x', 1);
+    query.timeout(1000);
+    query.signal(AbortSignal.timeout(1000));
+    query.idempotent(true);
+
+    await query;
+    db.assertComplete();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #205: Reject builder mutations after query execution starts.

The retry proxy caches the overall execution promise on the first `.then()`. Builder methods (`parameter()`, `timeout()`, `signal()`, `idempotent()`) remained mutable afterwards, so they could change proxy state without affecting the already started operation.

## Changes

- `src/core/retry-executor.ts`: Added `started` flag that's set when the first `.then()`/`await` is called. All mutating builder methods now check this flag and throw descriptive errors if called after execution starts. `cancel()` remains available.

- `test/retry-proxy.spec.ts`: Added 6 regression tests covering:
  - `parameter()` after await throws
  - `timeout()` after await throws
  - `signal()` after await throws
  - `idempotent()` after await throws
  - `cancel()` after await continues working
  - Mutations before await are still allowed

## Acceptance Criteria Met

- ✅ Mutating methods after first execution fail deterministically
- ✅ The executed query parameters/options cannot silently diverge from proxy state
- ✅ Existing retry and cancellation behavior remains unchanged
