### PR TITLE
refactor(transaction): decouple transaction identity from executor object identity (#207)

### DIFF
--- a/src/core/query-logger.ts
+++ b/src/core/query-logger.ts
@@ -1,4 +1,8 @@
 import { YdbExecutor } from './interfaces.js';
+import {
+  ensureExecutorIdentity,
+  inheritExecutorIdentity,
+} from '../transaction/transaction-context.js';
 
 /**
  * Информация о запросе для логирования.
@@ -309,6 +313,14 @@ export function wrapExecutorWithLogging(
         }),
     };
   };
+
+  // Identity (#207): обёртка и её исходник представляют один логический
+  // executor, поэтому обёртка наследует identity-токен исходника, а исходник
+  // при необходимости получает собственный токен. Разные обёртки одного
+  // логического executor'а разделяют токен — детекция вложенных транзакций
+  // сравнивает DB-контексты по значению, а не по ссылке на объект.
+  ensureExecutorIdentity(executor);
+  inheritExecutorIdentity(executor, wrapped);
 
   return wrapped as YdbExecutor;
 }

--- a/src/core/retry-executor.ts
+++ b/src/core/retry-executor.ts
@@ -13,6 +13,10 @@ import type {
   YdbRetryPolicyInput,
   YdbRetryPolicyOptions,
 } from './retry.js';
+import {
+  ensureExecutorIdentity,
+  inheritExecutorIdentity,
+} from '../transaction/transaction-context.js';
 
 /**
  * Подключение retry-политики к executor'у (#27).
@@ -242,6 +246,12 @@ export function withRetryPolicy(
   (wrapped as unknown as Record<string, unknown>).transaction = (
     options?: YdbTransactionOptions,
   ) => executor.transaction(options);
+
+  // Identity (#207): обёртка наследует identity-токен исходника (см. также
+  // wrapExecutorWithLogging), чтобы разные обёртки одного логического
+  // executor'а распознавались как один DB-контекст.
+  ensureExecutorIdentity(executor);
+  inheritExecutorIdentity(executor, wrapped);
 
   return wrapped;
 }

--- a/src/relations/entity-relations.ts
+++ b/src/relations/entity-relations.ts
@@ -19,6 +19,8 @@ import { quoteIdentifier } from '../core/sql-utils.js';
 import {
   resolveOperationExecutor,
   runWithTransactionContext,
+  getTransactionId,
+  TRANSACTION_ID_KEY,
 } from '../transaction/transaction-context.js';
 import { chunkInValues, dedupeInValues } from '../core/query-limits.js';
 import { getEntityRuntime } from '../entity/entity-runtime.js';
@@ -276,11 +278,25 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
     // Внутренний контекст нужен только для многоуровневых путей с явным
     // { trx }: одноуровневая eager-load и ambient-режим ведут себя как раньше.
     if (options?.trx && segments.length > 1) {
+      // Извлекаем transactionId из явного trx (или генерируем и сохраняем его),
+      // чтобы resolveOperationExecutor не ругался на смешивание транзакций.
+      const extractedId = getTransactionId(options.trx);
+      const transactionId: symbol =
+        typeof extractedId === 'symbol' ? extractedId : Symbol('transaction');
+      if (typeof extractedId !== 'symbol') {
+        if (
+          options.trx &&
+          (typeof options.trx === 'object' || typeof options.trx === 'function')
+        ) {
+          (options.trx as unknown as Record<typeof TRANSACTION_ID_KEY, symbol>)[
+            TRANSACTION_ID_KEY
+          ] = transactionId;
+        }
+      }
       await runWithTransactionContext(
         {
+          transactionId,
           trx: options.trx,
-          // Executor БД, открывший транзакцию: для детекции вложенности по
-          // ссылке (#98). Базовый executor сущности и есть этот db в wiring.
           db: this.executor ?? options.trx,
           ambient: true,
         },

--- a/src/relations/entity-relations.ts
+++ b/src/relations/entity-relations.ts
@@ -20,7 +20,7 @@ import {
   resolveOperationExecutor,
   runWithTransactionContext,
   getTransactionId,
-  TRANSACTION_ID_KEY,
+  setExecutorIdentity,
 } from '../transaction/transaction-context.js';
 import { chunkInValues, dedupeInValues } from '../core/query-limits.js';
 import { getEntityRuntime } from '../entity/entity-runtime.js';
@@ -288,9 +288,7 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
           options.trx &&
           (typeof options.trx === 'object' || typeof options.trx === 'function')
         ) {
-          (options.trx as unknown as Record<typeof TRANSACTION_ID_KEY, symbol>)[
-            TRANSACTION_ID_KEY
-          ] = transactionId;
+          setExecutorIdentity(options.trx, transactionId);
         }
       }
       await runWithTransactionContext(

--- a/src/transaction/transaction-context.ts
+++ b/src/transaction/transaction-context.ts
@@ -142,9 +142,11 @@ export function resolveOperationExecutor(
 }
 
 /**
- * Получает transactionId из executor'а транзакции.
- * Если executor не имеет transactionId (не создан через runInTransaction),
- * возвращает сам executor для обратной совместимости (сравнение по ссылке).
+ * Получает identity-токен из executor'а (#207).
+ * Возвращает символ, если он присвоен executor'у (для live-транзакции это
+ * его transactionId, для логического DB-executor'а — стабильный идентификатор
+ * этого executor'а), иначе сам executor для обратной совместимости
+ * (сравнение по ссылке для executor'ов без identity).
  */
 export function getTransactionId(trx: YdbExecutor): symbol | YdbExecutor {
   const withId = trx as unknown as Record<
@@ -152,4 +154,46 @@ export function getTransactionId(trx: YdbExecutor): symbol | YdbExecutor {
     symbol | undefined
   >;
   return withId[TRANSACTION_ID_KEY] ?? trx;
+}
+
+/**
+ * Присваивает executor'у стабильный identity-токен, если его ещё нет.
+ * Используется для логических DB-executor'ов (#207): разные обёртки одного
+ * и того же логического executor'а разделяют этот токен, поэтому детекция
+ * вложенных транзакций может сравнивать контексты по значению, а не по
+ * ссылке на объект.
+ */
+export function ensureExecutorIdentity(executor: YdbExecutor): symbol {
+  const existing = getTransactionId(executor);
+  if (typeof existing === 'symbol') return existing;
+  const id = Symbol('ydb.executor');
+  if (typeof executor === 'object' || typeof executor === 'function') {
+    (executor as unknown as Record<typeof TRANSACTION_ID_KEY, symbol>)[
+      TRANSACTION_ID_KEY
+    ] = id;
+  }
+  return id;
+}
+
+/**
+ * Наследует identity-токен с внутреннего executor'а на обёртку (#207):
+ * wrapExecutorWithLogging()/withRetryPolicy() создают НОВЫЕ объекты, и чтобы
+ * обёртки того же логического executor'а распознавались как один DB-контекст,
+ * они копируют токен с исходного executor'а.
+ */
+export function inheritExecutorIdentity(
+  source: YdbExecutor,
+  target: YdbExecutor,
+): void {
+  const id = (
+    source as unknown as Record<typeof TRANSACTION_ID_KEY, symbol | undefined>
+  )[TRANSACTION_ID_KEY];
+  if (
+    typeof id === 'symbol' &&
+    (typeof target === 'object' || typeof target === 'function')
+  ) {
+    (target as unknown as Record<typeof TRANSACTION_ID_KEY, symbol>)[
+      TRANSACTION_ID_KEY
+    ] = id;
+  }
 }

--- a/src/transaction/transaction-context.ts
+++ b/src/transaction/transaction-context.ts
@@ -2,9 +2,6 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import type { YdbExecutor } from '../core/interfaces.js';
 import type { YdbTransactionsSettings } from '../core/interfaces.js';
 
-/** Уникальный ключ для хранения transactionId на executor'е. */
-export const TRANSACTION_ID_KEY = Symbol.for('ydb.transaction.id');
-
 /**
  * Активная транзакция в цепочке async-вызовов (#98).
  *
@@ -142,36 +139,50 @@ export function resolveOperationExecutor(
 }
 
 /**
- * Получает identity-токен из executor'а (#207).
- * Возвращает символ, если он присвоен executor'у (для live-транзакции это
- * его transactionId, для логического DB-executor'а — стабильный идентификатор
+ * Приватный реестр identity (#217): executor -> символ.
+ *
+ * Источник правды для transaction/executor identity находится ЗДЕСЬ, а не в
+ * мутируемом свойстве executor'а. Слабые ключи позволяют собирать объекты,
+ * на которые больше нет ссылок (в т.ч. краткоживущие trx-executor'ы каждой
+ * попытки), и НЕ требуют мутации объект executor'а вовсе — frozen/sealed
+ * executor'ы работают без изменений. Потребители не имеют доступа к реестру,
+ * поэтому не могут перезаписать чужой identity и соединить два независимых
+ * контекста в один.
+ */
+const identityRegistry = new WeakMap<YdbExecutor, symbol>();
+
+/**
+ * Получает identity-токен из executor'а (#207/#217).
+ * Возвращает символ из приватного реестра (для live-транзакции это её
+ * transactionId, для логического DB-executor'а — стабильный идентификатор
  * этого executor'а), иначе сам executor для обратной совместимости
  * (сравнение по ссылке для executor'ов без identity).
  */
 export function getTransactionId(trx: YdbExecutor): symbol | YdbExecutor {
-  const withId = trx as unknown as Record<
-    typeof TRANSACTION_ID_KEY,
-    symbol | undefined
-  >;
-  return withId[TRANSACTION_ID_KEY] ?? trx;
+  return identityRegistry.get(trx) ?? trx;
 }
 
 /**
- * Присваивает executor'у стабильный identity-токен, если его ещё нет.
- * Используется для логических DB-executor'ов (#207): разные обёртки одного
- * и того же логического executor'а разделяют этот токен, поэтому детекция
- * вложенных транзакций может сравнивать контексты по значению, а не по
- * ссылке на объект.
+ * Явно запоминает identity-токен для executor'а в приватном реестре (#217).
+ * Используется, чтобы присвоить свежесозданному trx-executor'у данной попытки
+ * её transactionId (см. runAttemptBody, entity-relations). Не мутирует объект.
+ */
+export function setExecutorIdentity(executor: YdbExecutor, id: symbol): void {
+  identityRegistry.set(executor, id);
+}
+
+/**
+ * Присваивает executor'у стабильный identity-токен, если его ещё нет (#207).
+ * Используется для логических DB-executor'ов: разные обёртки одного и того же
+ * логического executor'а разделяют этот токен, поэтому детекция вложенных
+ * транзакций может сравнивать DB-контексты по значению, а не по ссылке на
+ * объект. Токен хранится в приватном реестре и не мутирует executor.
  */
 export function ensureExecutorIdentity(executor: YdbExecutor): symbol {
-  const existing = getTransactionId(executor);
-  if (typeof existing === 'symbol') return existing;
+  const existing = identityRegistry.get(executor);
+  if (existing) return existing;
   const id = Symbol('ydb.executor');
-  if (typeof executor === 'object' || typeof executor === 'function') {
-    (executor as unknown as Record<typeof TRANSACTION_ID_KEY, symbol>)[
-      TRANSACTION_ID_KEY
-    ] = id;
-  }
+  identityRegistry.set(executor, id);
   return id;
 }
 
@@ -179,21 +190,14 @@ export function ensureExecutorIdentity(executor: YdbExecutor): symbol {
  * Наследует identity-токен с внутреннего executor'а на обёртку (#207):
  * wrapExecutorWithLogging()/withRetryPolicy() создают НОВЫЕ объекты, и чтобы
  * обёртки того же логического executor'а распознавались как один DB-контекст,
- * они копируют токен с исходного executor'а.
+ * они копируют токен с исходного executor'а в приватный реестр обёртки.
  */
 export function inheritExecutorIdentity(
   source: YdbExecutor,
   target: YdbExecutor,
 ): void {
-  const id = (
-    source as unknown as Record<typeof TRANSACTION_ID_KEY, symbol | undefined>
-  )[TRANSACTION_ID_KEY];
-  if (
-    typeof id === 'symbol' &&
-    (typeof target === 'object' || typeof target === 'function')
-  ) {
-    (target as unknown as Record<typeof TRANSACTION_ID_KEY, symbol>)[
-      TRANSACTION_ID_KEY
-    ] = id;
+  const id = identityRegistry.get(source);
+  if (id !== undefined) {
+    identityRegistry.set(target, id);
   }
 }

--- a/src/transaction/transaction-context.ts
+++ b/src/transaction/transaction-context.ts
@@ -2,6 +2,9 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import type { YdbExecutor } from '../core/interfaces.js';
 import type { YdbTransactionsSettings } from '../core/interfaces.js';
 
+/** Уникальный ключ для хранения transactionId на executor'е. */
+export const TRANSACTION_ID_KEY = Symbol.for('ydb.transaction.id');
+
 /**
  * Активная транзакция в цепочке async-вызовов (#98).
  *
@@ -12,11 +15,17 @@ import type { YdbTransactionsSettings } from '../core/interfaces.js';
  * 2. Ambient auto-join: если включён (глобально через настройки модуля или
  *    локально через опцию `ambient` вызова), операции репозиториев без
  *    явного { trx } выполняются в активной транзакции.
+ *
+ * Идентичность транзакции определяется `transactionId`, а не ссылкой на
+ * executor, так как разные обёртки могут представлять одну и ту же
+ * логическую транзакцию (например, при оборачивании executor'а для логирования).
  */
 export interface ActiveTransactionContext {
+  /** Уникальный идентификатор транзакции (символ) — для сравнения по значению. */
+  transactionId: symbol;
   /** Executor транзакции — передаётся в операции вместо executor'а сущности. */
   trx: YdbExecutor;
-  /** Executor БД, открывший транзакцию: детекция вложенности по ссылке. */
+  /** Executor БД, открывший транзакцию: детекция вложенности по transactionId. */
   db: YdbExecutor;
   /** Сигнал отмены конкретной попытки транзакции (при retry — новый). */
   signal?: AbortSignal;
@@ -98,7 +107,10 @@ export function resolveOperationExecutor(
   const effectiveSettings = resolveTransactionSettings(scopeSettings);
 
   if (explicitTrx) {
-    if (active?.ambient && active.trx !== explicitTrx) {
+    if (
+      active?.ambient &&
+      active.transactionId !== getTransactionId(explicitTrx)
+    ) {
       throw new Error(
         `Transaction mixing detected in ${entityName}: an explicit { trx } was passed, ` +
           'but a different transaction is active in the current async context. ' +
@@ -127,4 +139,17 @@ export function resolveOperationExecutor(
   }
 
   return fallback;
+}
+
+/**
+ * Получает transactionId из executor'а транзакции.
+ * Если executor не имеет transactionId (не создан через runInTransaction),
+ * возвращает сам executor для обратной совместимости (сравнение по ссылке).
+ */
+export function getTransactionId(trx: YdbExecutor): symbol | YdbExecutor {
+  const withId = trx as unknown as Record<
+    typeof TRANSACTION_ID_KEY,
+    symbol | undefined
+  >;
+  return withId[TRANSACTION_ID_KEY] ?? trx;
 }

--- a/src/transaction/transaction.manager.spec.ts
+++ b/src/transaction/transaction.manager.spec.ts
@@ -13,7 +13,9 @@ import {
 } from './transaction.manager.js';
 import {
   configureTransactionContext,
+  ensureExecutorIdentity,
   getActiveTransaction,
+  getTransactionId,
   resolveOperationExecutor,
 } from './transaction-context.js';
 import { wrapExecutorWithLogging } from '../core/query-logger.js';
@@ -539,6 +541,89 @@ describe('nested detection and mixing with executor wrappers (#207)', () => {
         // смешивание, ошибка сохраняется.
         expect(() =>
           resolveOperationExecutor(other, db.executor, 'UserEntity'),
+        ).toThrow(/mixing detected.*different transaction is active/s);
+        return Promise.resolve();
+      },
+      { ambient: true },
+    );
+  });
+});
+
+describe('identity registry (#217): private, non-mutable source of truth', () => {
+  const noopLogger = { log() {} };
+
+  it('overwriting a symbol/property on the executor cannot forge its identity', async () => {
+    const db = makeFakeDb();
+    const executor = db.executor;
+    const manager = new YdbTransactionManager(executor);
+
+    // Пытаемся «подделать» identity, записав произвольный символ в свойства
+    // executor'а, в т.ч. по прежнему глобальному ключу Symbol.for(...).
+    const forged = Symbol('forged');
+    (executor as unknown as Record<PropertyKey, unknown>)[
+      Symbol.for('ydb.transaction.id')
+    ] = forged;
+    (executor as unknown as Record<string, unknown>).anyOtherProp = forged;
+
+    // Реестр identity не читает свойства объекта — identity не изменился.
+    expect(getTransactionId(executor)).not.toBe(forged);
+
+    // Вложенная детекция по-прежнему работает по registry-identity.
+    await expect(
+      manager.runInTransaction(() =>
+        manager.runInTransaction(() => Promise.resolve()),
+      ),
+    ).rejects.toThrow(/Nested runInTransaction\(\) detected/);
+  });
+
+  it('two wrappers of the same logical executor resolve to one identity', () => {
+    const anExecutor = makeFakeDb().executor;
+    ensureExecutorIdentity(anExecutor);
+    const wrapped = wrapExecutorWithLogging(anExecutor, noopLogger);
+    expect(getTransactionId(wrapped)).toBe(ensureExecutorIdentity(anExecutor));
+  });
+
+  it('different executors get different identities', () => {
+    const a = makeFakeDb().executor;
+    const b = makeFakeDb().executor;
+    const idA = ensureExecutorIdentity(a);
+    const idB = ensureExecutorIdentity(b);
+    expect(idA).not.toBe(idB);
+    expect(getTransactionId(a)).toBe(idA);
+    expect(getTransactionId(b)).toBe(idB);
+  });
+
+  it('works for a frozen executor without requiring mutation', async () => {
+    const db = makeFakeDb();
+    Object.freeze(db.executor);
+    const manager = new YdbTransactionManager(db.executor);
+
+    const id = ensureExecutorIdentity(db.executor);
+    expect(getTransactionId(db.executor)).toBe(id);
+
+    // Вложенная детекция на frozen-executor'е работает (никаких записей в объект).
+    await expect(
+      manager.runInTransaction(() =>
+        manager.runInTransaction(() => Promise.resolve()),
+      ),
+    ).rejects.toThrow(/Nested runInTransaction\(\) detected/);
+  });
+
+  it('same-vs-distinct transaction detection keeps working', async () => {
+    const db = makeFakeDb();
+    const manager = new YdbTransactionManager(db.executor);
+
+    await manager.runInTransaction(
+      (trx) => {
+        // Обёртка ТОЙ ЖЕ транзакции — не смешивание.
+        const wrapped = wrapExecutorWithLogging(trx, noopLogger);
+        expect(() =>
+          resolveOperationExecutor(wrapped, db.executor, 'UserEntity'),
+        ).not.toThrow();
+        // Чужой executor — смешивание при активной ambient-транзакции.
+        const stranger = makeFakeDb().executor;
+        expect(() =>
+          resolveOperationExecutor(stranger, db.executor, 'UserEntity'),
         ).toThrow(/mixing detected.*different transaction is active/s);
         return Promise.resolve();
       },

--- a/src/transaction/transaction.manager.spec.ts
+++ b/src/transaction/transaction.manager.spec.ts
@@ -16,6 +16,7 @@ import {
   getActiveTransaction,
   resolveOperationExecutor,
 } from './transaction-context.js';
+import { wrapExecutorWithLogging } from '../core/query-logger.js';
 import type {
   YdbExecutor,
   YdbTransactionHandle,
@@ -456,6 +457,93 @@ describe('runInTransaction(): nested call detection (#98)', () => {
 
     await manager.runInTransaction(() => Promise.resolve());
     expect(db.count()).toBe(2);
+  });
+});
+
+describe('nested detection and mixing with executor wrappers (#207)', () => {
+  const noopLogger = { log() {} };
+
+  it('recognizes nested runInTransaction across different wrappers of the same logical DB', async () => {
+    const db = makeFakeDb();
+    const managerA = new YdbTransactionManager(db.executor);
+    // Вторая обёртка того же логического executor'а (логирование).
+    const managerB = new YdbTransactionManager(
+      wrapExecutorWithLogging(db.executor, noopLogger),
+    );
+
+    await expect(
+      managerA.runInTransaction(() =>
+        managerB.runInTransaction(() => Promise.resolve('inner')),
+      ),
+    ).rejects.toThrow(/Nested runInTransaction\(\) detected/);
+
+    // Вторая независимая транзакция не открылась — вложенность распознана.
+    expect(db.count()).toBe(1);
+  });
+
+  it('reuses the active transaction across different wrappers of the same logical DB', async () => {
+    const db = makeFakeDb();
+    const managerA = new YdbTransactionManager(db.executor);
+    const managerB = new YdbTransactionManager(
+      wrapExecutorWithLogging(db.executor, noopLogger),
+    );
+
+    const result = await managerA.runInTransaction((outerTrx) =>
+      managerB.runInTransaction(
+        (innerTrx) => {
+          // reuse присоединяется к активной транзакции внешнего вызова —
+          // тот же trx, новая БД-транзакция не открывается.
+          expect(innerTrx).toBe(outerTrx);
+          return Promise.resolve('joined');
+        },
+        { reuse: true },
+      ),
+    );
+
+    expect(result).toBe('joined');
+    // Открыта ровно одна транзакция — внешняя.
+    expect(db.count()).toBe(1);
+  });
+
+  it('does not treat a wrapped executor of the SAME transaction as mixing (ambient)', async () => {
+    const db = makeFakeDb();
+    const manager = new YdbTransactionManager(db.executor);
+
+    await manager.runInTransaction(
+      (trx) => {
+        const wrappedTrx = wrapExecutorWithLogging(trx, noopLogger);
+        // Обёртка активной транзакции как явный { trx } при ambient —
+        // это та же логическая транзакция, ошибки смешивания быть не должно.
+        expect(() =>
+          resolveOperationExecutor(wrappedTrx, db.executor, 'UserEntity'),
+        ).not.toThrow();
+        return Promise.resolve();
+      },
+      { ambient: true },
+    );
+  });
+
+  it('still rejects a wrapped executor of a DISTINCT transaction as mixing (ambient)', async () => {
+    const db = makeFakeDb();
+    const manager = new YdbTransactionManager(db.executor);
+
+    await manager.runInTransaction(
+      async () => {
+        const stranger = makeFakeDb().executor;
+        const other = await new YdbTransactionManager(
+          stranger,
+        ).runInTransaction((otherTrx) =>
+          Promise.resolve(wrapExecutorWithLogging(otherTrx, noopLogger)),
+        );
+        // Посторонняя транзакция (хоть и обёрнутая) при активной ambient —
+        // смешивание, ошибка сохраняется.
+        expect(() =>
+          resolveOperationExecutor(other, db.executor, 'UserEntity'),
+        ).toThrow(/mixing detected.*different transaction is active/s);
+        return Promise.resolve();
+      },
+      { ambient: true },
+    );
   });
 });
 

--- a/src/transaction/transaction.manager.ts
+++ b/src/transaction/transaction.manager.ts
@@ -12,7 +12,7 @@ import {
   getTransactionId,
   resolveTransactionSettings,
   runWithTransactionContext,
-  TRANSACTION_ID_KEY,
+  setExecutorIdentity,
 } from './transaction-context.js';
 
 /** Генерирует уникальный идентификатор транзакции. */
@@ -339,14 +339,12 @@ export class YdbTransactionManager {
       sdkSignal: AbortSignal | undefined,
     ) => {
       const attemptSignal = composeAttemptSignal(sdkSignal);
-      // Генерируем уникальный ID для этой транзакции и сохраняем на executor'е.
+      // Генерируем уникальный ID для этой транзакции и запоминаем его для
+      // trx-executor'а данной попытки в приватном реестре identity (#217).
       const transactionId = generateTransactionId();
-      // Защита для моков и нестандартных executor'ов: trx может быть
-      // функцией (jest mock), объектом или примитивом.
+      // trx всегда объект/функция (WeakMap-ключ); защита для примитивных моков.
       if (trx && (typeof trx === 'object' || typeof trx === 'function')) {
-        (trx as unknown as Record<typeof TRANSACTION_ID_KEY, symbol>)[
-          TRANSACTION_ID_KEY
-        ] = transactionId;
+        setExecutorIdentity(trx, transactionId);
       }
       return runWithTransactionContext(
         { transactionId, trx, db: this.db, signal: attemptSignal, ambient },

--- a/src/transaction/transaction.manager.ts
+++ b/src/transaction/transaction.manager.ts
@@ -10,7 +10,13 @@ import {
   getActiveTransaction,
   resolveTransactionSettings,
   runWithTransactionContext,
+  TRANSACTION_ID_KEY,
 } from './transaction-context.js';
+
+/** Генерирует уникальный идентификатор транзакции. */
+function generateTransactionId(): symbol {
+  return Symbol('transaction');
+}
 
 /**
  * Опции runInTransaction() (#98).
@@ -246,6 +252,8 @@ export class YdbTransactionManager {
 
     // Детекция вложенности работает всегда (ambient включён или нет).
     const active = getActiveTransaction();
+    // Сравниваем по transactionId, а не по ссылке на executor (#207).
+    // active.db === this.db проверяет, что это тот же executor БД.
     if (active && active.db === this.db) {
       if (options?.reuse) {
         // Переиспользуем активную транзакцию: коммит/откат остаются у
@@ -257,6 +265,7 @@ export class YdbTransactionManager {
         if (options.ambient === true) {
           return runWithTransactionContext(
             {
+              transactionId: active.transactionId,
               trx: active.trx,
               db: this.db,
               signal: active.signal,
@@ -321,8 +330,17 @@ export class YdbTransactionManager {
       sdkSignal: AbortSignal | undefined,
     ) => {
       const attemptSignal = composeAttemptSignal(sdkSignal);
+      // Генерируем уникальный ID для этой транзакции и сохраняем на executor'е.
+      const transactionId = generateTransactionId();
+      // Защита для моков и нестандартных executor'ов: trx может быть
+      // функцией (jest mock), объектом или примитивом.
+      if (trx && (typeof trx === 'object' || typeof trx === 'function')) {
+        (trx as unknown as Record<typeof TRANSACTION_ID_KEY, symbol>)[
+          TRANSACTION_ID_KEY
+        ] = transactionId;
+      }
       return runWithTransactionContext(
-        { trx, db: this.db, signal: attemptSignal, ambient },
+        { transactionId, trx, db: this.db, signal: attemptSignal, ambient },
         () => fn(trx, attemptSignal),
       );
     };

--- a/src/transaction/transaction.manager.ts
+++ b/src/transaction/transaction.manager.ts
@@ -7,7 +7,9 @@ import type {
   YdbTransactionsSettings,
 } from '../core/interfaces.js';
 import {
+  ensureExecutorIdentity,
   getActiveTransaction,
+  getTransactionId,
   resolveTransactionSettings,
   runWithTransactionContext,
   TRANSACTION_ID_KEY,
@@ -224,7 +226,12 @@ export class YdbTransactionManager {
   constructor(
     private readonly db: YdbExecutor,
     private readonly settings?: YdbTransactionsSettings,
-  ) {}
+  ) {
+    // Стабильный identity для логического DB-executor'а (#207): разные обёртки
+    // одного и того же executor'а разделяют его, поэтому детекция вложенных
+    // транзакций сравнивает контексты по значению, а не по ссылке на объект.
+    ensureExecutorIdentity(db);
+  }
 
   /**
    * Выполняет fn внутри транзакции YDB.
@@ -252,9 +259,11 @@ export class YdbTransactionManager {
 
     // Детекция вложенности работает всегда (ambient включён или нет).
     const active = getActiveTransaction();
-    // Сравниваем по transactionId, а не по ссылке на executor (#207).
-    // active.db === this.db проверяет, что это тот же executor БД.
-    if (active && active.db === this.db) {
+    // Сравниваем по identity-токену, а не по ссылке на executor (#207).
+    // active.db === this.db — ссылочное сравнение; разные обёртки одного
+    // логического DB-executor'а (логирование/retry) разделяют токен, поэтому
+    // проверка по значению распознаёт вложенную транзакцию того же DB.
+    if (active && getTransactionId(active.db) === getTransactionId(this.db)) {
       if (options?.reuse) {
         // Переиспользуем активную транзакцию: коммит/откат остаются у
         // внешнего вызова, новая БД-транзакция не открывается. Если на


### PR DESCRIPTION
## Summary

Fixes #207: Decouple transaction identity from executor object identity.

Two commits:

1. **8506e2c** — Nested detection compared DB executors by reference (`active.db === this.db`), so two managers using different wrappers of the same logical DB opened a second transaction instead of applying nested/reuse semantics. Assigned a stable logical-executor identity and propagated it through the ORM's wrappers (`wrapExecutorWithLogging`, `withRetryPolicy`).

2. **96c7fa4** — Identity no longer stored as a writable property under an exported global `Symbol.for` key. Replaced with a private module-local `WeakMap<YdbExecutor, symbol>` as the single source of truth.

## Changes

- `transaction-context.ts`: private `WeakMap` identity registry (`getTransactionId` / `ensureExecutorIdentity` / `inheritExecutorIdentity` / `setExecutorIdentity`). Removed the public `TRANSACTION_ID_KEY` symbol (not in the export surface).
- `transaction.manager.ts`: nested detection by registry identity; per-attempt transaction ids recorded via the registry (no executor mutation).
- `relations/entity-relations.ts`: uses the registry setter instead of writing a property.
- `core/query-logger.ts` + `core/retry-executor.ts`: wrappers inherit the logical executor identity token.
- Regression tests: overwrite/forgery resistance, wrapper sharing, distinct executors, same-vs-distinct detection, frozen executors, wrapped cross-manager nesting/reuse.

## Acceptance Criteria Met

- ✅ Identity source of truth not directly mutable by consumers
- ✅ Wrappers of the same logical executor share identity
- ✅ Distinct executors / distinct transactions remain distinct
- ✅ Different DB/configuration contexts remain independent; mixing still rejected
- ✅ Nested detection works across executor wrappers
- ✅ Frozen/sealed executors work (no object mutation required)
- ✅ Existing ambient/nested behavior unchanged