### PR TITLE
refactor(transaction): validate ActiveTransactionContext invariants (#208)

### DIFF
--- a/src/core/retry.spec.ts
+++ b/src/core/retry.spec.ts
@@ -464,7 +464,14 @@ describe('интеграция с транзакциями: без умноже�
   }
 
   /** Минимальный фейковый executor БД с управляемым поведением execute(). */
-  function makeFakeDb(executeImpl: (fn: any, opts: any) => Promise<unknown>) {
+  function makeFakeDb(
+    executeImpl: (
+      fn: any,
+      opts: any,
+      trx: any,
+      signal: AbortSignal,
+    ) => Promise<unknown>,
+  ) {
     const transactions: FakeTxCall[] = [];
     const executor: any = jest.fn(() => ({
       parameter() {
@@ -488,7 +495,31 @@ describe('интеграция с транзакциями: без умноже�
     }));
     executor.transaction = (options?: Record<string, unknown>) => {
       transactions.push({ options: options ?? {} });
-      return { execute: (fn: any) => executeImpl(fn, options ?? {}) };
+      const trx: any = jest.fn(() => ({
+        parameter() {
+          return this;
+        },
+        timeout() {
+          return this;
+        },
+        signal() {
+          return this;
+        },
+        cancel() {
+          return this;
+        },
+        then(
+          onFulfilled?: (value: unknown) => unknown,
+          onRejected?: (reason: unknown) => unknown,
+        ) {
+          return Promise.resolve([]).then(onFulfilled, onRejected);
+        },
+      }));
+      const controller = new AbortController();
+      return {
+        execute: (fn: any) =>
+          executeImpl(fn, options ?? {}, trx, controller.signal),
+      };
     };
     return { executor: executor as unknown as YdbExecutor, transactions };
   }
@@ -501,7 +532,7 @@ describe('интеграция с транзакциями: без умноже�
   it('runInTransaction НЕ имеет скрытого ORM-ретрая: транзитная ошибка выходит сразу', async () => {
     const boom = ydbErr(Code.ABORTED);
     let bodyCalls = 0;
-    const db = makeFakeDb(() => {
+    const db = makeFakeDb((_fn, _opts, _trx, _signal) => {
       bodyCalls += 1;
       return Promise.reject(boom);
     });
@@ -524,18 +555,20 @@ describe('интеграция с транзакциями: без умноже�
     // Имитация @ydbjs/query: ПЕРВАЯ попытка тела транзакции падает транзитной
     // ошибкой, SDK-idempotent-повтор (вторая попытка ВНУТРИ execute)
     // успешен — наружу транзитная ошибка не выходит.
-    const db = makeFakeDb(async (fn: any, opts: any) => {
-      for (;;) {
-        sdkAttempts += 1;
-        try {
-          if (sdkAttempts === 1 && opts.idempotent) throw boom;
-          return await fn();
-        } catch (error) {
-          if (error === boom && sdkAttempts < 2) continue; // SDK ретраит сам
-          throw error;
+    const db = makeFakeDb(
+      async (fn: any, opts: any, trx: any, signal: AbortSignal) => {
+        for (;;) {
+          sdkAttempts += 1;
+          try {
+            if (sdkAttempts === 1 && opts.idempotent) throw boom;
+            return await fn(trx, signal);
+          } catch (error) {
+            if (error === boom && sdkAttempts < 2) continue; // SDK ретраит сам
+            throw error;
+          }
         }
-      }
-    });
+      },
+    );
 
     const manager = await makeManager(db.executor);
 

--- a/src/persistence/related-filter.spec.ts
+++ b/src/persistence/related-filter.spec.ts
@@ -15,6 +15,7 @@ import { getEntityRuntime } from '../entity/entity-runtime.js';
 import { createMockExecutor } from '../../test/helpers/mock-executor.js';
 import {
   configureTransactionContext,
+  createTransactionContext,
   runWithTransactionContext,
 } from '../transaction/transaction-context.js';
 
@@ -355,7 +356,12 @@ describe('Related-entity filters (#17): findAll({ relation: { column } })', () =
     configureTransactionContext({ ambient: true });
     const ambTrx = createMockExecutor([[[]]]);
     await runWithTransactionContext(
-      { trx: ambTrx.executor, db: base.executor, ambient: true },
+      createTransactionContext({
+        transactionId: Symbol('related-filter'),
+        trx: ambTrx.executor,
+        db: base.executor,
+        ambient: true,
+      }),
       async () => {
         await RfUser.findAll({ roles: { role: 'admin' } });
       },

--- a/src/relations/entity-relations.ts
+++ b/src/relations/entity-relations.ts
@@ -18,6 +18,7 @@ import { getEagerRelations } from '../decorators/eager.decorator.js';
 import { quoteIdentifier } from '../core/sql-utils.js';
 import {
   resolveOperationExecutor,
+  createTransactionContext,
   runWithTransactionContext,
   getTransactionId,
   TRANSACTION_ID_KEY,
@@ -294,12 +295,12 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
         }
       }
       await runWithTransactionContext(
-        {
+        createTransactionContext({
           transactionId,
           trx: options.trx,
           db: this.executor ?? options.trx,
           ambient: true,
-        },
+        }),
         () => this.loadRelationSegments(rel, items, segments, options),
       );
       return;

--- a/src/relations/entity-relations.ts
+++ b/src/relations/entity-relations.ts
@@ -19,6 +19,8 @@ import { quoteIdentifier } from '../core/sql-utils.js';
 import {
   resolveOperationExecutor,
   runWithTransactionContext,
+  getTransactionId,
+  TRANSACTION_ID_KEY,
 } from '../transaction/transaction-context.js';
 import { chunkInValues, dedupeInValues } from '../core/query-limits.js';
 import { getEntityRuntime } from '../entity/entity-runtime.js';
@@ -276,11 +278,25 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
     // Внутренний контекст нужен только для многоуровневых путей с явным
     // { trx }: одноуровневая eager-load и ambient-режим ведут себя как раньше.
     if (options?.trx && segments.length > 1) {
+      // Извлекаем transactionId из явного trx (или генерируем и сохраняем его),
+      // чтобы resolveOperationExecutor не ругался на смешивание транзакций.
+      const extractedId = getTransactionId(options.trx);
+      const transactionId: symbol =
+        typeof extractedId === 'symbol' ? extractedId : Symbol('transaction');
+      if (typeof extractedId !== 'symbol') {
+        if (
+          options.trx &&
+          (typeof options.trx === 'object' || typeof options.trx === 'function')
+        ) {
+          (options.trx as unknown as Record<typeof TRANSACTION_ID_KEY, symbol>)[
+            TRANSACTION_ID_KEY
+          ] = transactionId;
+        }
+      }
       await runWithTransactionContext(
         {
+          transactionId,
           trx: options.trx,
-          // Executor БД, открывший транзакцию: для детекции вложенности по
-          // ссылке (#98). Базовый executor сущности и есть этот db в wiring.
           db: this.executor ?? options.trx,
           ambient: true,
         },

--- a/src/transaction/transaction-context.spec.ts
+++ b/src/transaction/transaction-context.spec.ts
@@ -3,6 +3,7 @@ import {
   createTransactionContext,
   runWithTransactionContext,
   getActiveTransaction,
+  ActiveTransactionContext,
 } from './transaction-context.js';
 import type { YdbExecutor } from '../core/interfaces.js';
 
@@ -304,6 +305,105 @@ describe('runWithTransactionContext(): context propagation with validation (#208
       ).rejects.toThrow('inner error');
 
       expect(getActiveTransaction()).toBe(outerContext);
+    });
+
+    expect(getActiveTransaction()).toBeUndefined();
+  });
+});
+
+describe('runWithTransactionContext(): rejects invalid contexts at the boundary (#208)', () => {
+  const validTrx = makeMockExecutor();
+  const validDb = makeMockExecutor();
+
+  it('rejects a plain object cast to a context (factory bypass)', () => {
+    const fake = {
+      transactionId: Symbol('fake'),
+      trx: validTrx,
+      db: validDb,
+      ambient: true,
+    } as unknown as ActiveTransactionContext;
+
+    expect(() =>
+      runWithTransactionContext(fake, () => Promise.resolve('never')),
+    ).toThrow('invalid context');
+
+    // Контекст не попал в ALS.
+    expect(getActiveTransaction()).toBeUndefined();
+  });
+
+  it('rejects cast contexts with invalid field values', () => {
+    for (const invalid of [
+      { transactionId: 'id', trx: validTrx, db: validDb, ambient: true },
+      { transactionId: Symbol('t'), trx: null, db: validDb, ambient: true },
+      { transactionId: Symbol('t'), trx: validTrx, db: null, ambient: true },
+      {
+        transactionId: Symbol('t'),
+        trx: validTrx,
+        db: validDb,
+        ambient: 'yes',
+      },
+      {
+        transactionId: Symbol('t'),
+        trx: validTrx,
+        db: validDb,
+        signal: {},
+        ambient: true,
+      },
+    ] as unknown as ActiveTransactionContext[]) {
+      expect(() =>
+        runWithTransactionContext(invalid, () => Promise.resolve('never')),
+      ).toThrow('ActiveTransactionContext');
+      expect(getActiveTransaction()).toBeUndefined();
+    }
+  });
+
+  it('rejects null and undefined contexts', () => {
+    expect(() =>
+      runWithTransactionContext(
+        null as unknown as ActiveTransactionContext,
+        () => Promise.resolve('never'),
+      ),
+    ).toThrow('invalid context');
+    expect(() =>
+      runWithTransactionContext(
+        undefined as unknown as ActiveTransactionContext,
+        () => Promise.resolve('never'),
+      ),
+    ).toThrow('invalid context');
+    expect(getActiveTransaction()).toBeUndefined();
+  });
+
+  it('rejects a prototype-forged context (instanceof cannot fake the brand)', () => {
+    const forged = Object.create(
+      ActiveTransactionContext.prototype,
+    ) as unknown as ActiveTransactionContext;
+
+    expect(() =>
+      runWithTransactionContext(forged, () => Promise.resolve('never')),
+    ).toThrow('invalid context');
+    expect(getActiveTransaction()).toBeUndefined();
+  });
+
+  it('preserves an active outer context when an invalid inner context is rejected', async () => {
+    const outer = createTransactionContext({
+      transactionId: Symbol('outer'),
+      trx: validTrx,
+      db: validDb,
+      ambient: true,
+    });
+    const fake = {
+      transactionId: Symbol('fake'),
+      trx: validTrx,
+      db: validDb,
+      ambient: false,
+    } as unknown as ActiveTransactionContext;
+
+    await runWithTransactionContext(outer, () => {
+      expect(() =>
+        runWithTransactionContext(fake, () => Promise.resolve('never')),
+      ).toThrow('invalid context');
+      expect(getActiveTransaction()).toBe(outer);
+      return Promise.resolve();
     });
 
     expect(getActiveTransaction()).toBeUndefined();

--- a/src/transaction/transaction-context.spec.ts
+++ b/src/transaction/transaction-context.spec.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import {
+  createTransactionContext,
+  runWithTransactionContext,
+  getActiveTransaction,
+} from './transaction-context.js';
+import type { YdbExecutor } from '../core/interfaces.js';
+
+function makeMockExecutor(): YdbExecutor {
+  const executor = jest.fn(() => ({
+    parameter() {
+      return this;
+    },
+    timeout() {
+      return this;
+    },
+    signal() {
+      return this;
+    },
+    cancel() {
+      return this;
+    },
+    then(onFulfilled?: (value: unknown) => unknown) {
+      return Promise.resolve([]).then(onFulfilled);
+    },
+  }));
+  return executor as unknown as YdbExecutor;
+}
+
+describe('createTransactionContext(): invariant validation (#208)', () => {
+  const validTrx = makeMockExecutor();
+  const validDb = makeMockExecutor();
+  const validTransactionId = Symbol('transaction');
+  const validSignal = new AbortController().signal;
+
+  it('creates a valid context with all required fields', () => {
+    const context = createTransactionContext({
+      transactionId: validTransactionId,
+      trx: validTrx,
+      db: validDb,
+      signal: validSignal,
+      ambient: true,
+    });
+
+    expect(context.transactionId).toBe(validTransactionId);
+    expect(context.trx).toBe(validTrx);
+    expect(context.db).toBe(validDb);
+    expect(context.signal).toBe(validSignal);
+    expect(context.ambient).toBe(true);
+  });
+
+  it('creates a valid context without optional signal', () => {
+    const context = createTransactionContext({
+      transactionId: validTransactionId,
+      trx: validTrx,
+      db: validDb,
+      ambient: false,
+    });
+
+    expect(context.signal).toBeUndefined();
+    expect(context.ambient).toBe(false);
+  });
+
+  it('rejects non-symbol transactionId', () => {
+    expect(() =>
+      createTransactionContext({
+        transactionId: 'not-a-symbol' as any,
+        trx: validTrx,
+        db: validDb,
+        ambient: false,
+      }),
+    ).toThrow('transactionId must be a symbol');
+  });
+
+  it('rejects null transactionId', () => {
+    expect(() =>
+      createTransactionContext({
+        transactionId: null as any,
+        trx: validTrx,
+        db: validDb,
+        ambient: false,
+      }),
+    ).toThrow('transactionId must be a symbol');
+  });
+
+  it('rejects undefined transactionId', () => {
+    expect(() =>
+      createTransactionContext({
+        transactionId: undefined as any,
+        trx: validTrx,
+        db: validDb,
+        ambient: false,
+      }),
+    ).toThrow('transactionId must be a symbol');
+  });
+
+  it('rejects invalid trx (null)', () => {
+    expect(() =>
+      createTransactionContext({
+        transactionId: validTransactionId,
+        trx: null as any,
+        db: validDb,
+        ambient: false,
+      }),
+    ).toThrow('trx must be a valid executor');
+  });
+
+  it('rejects invalid trx (undefined)', () => {
+    expect(() =>
+      createTransactionContext({
+        transactionId: validTransactionId,
+        trx: undefined as any,
+        db: validDb,
+        ambient: false,
+      }),
+    ).toThrow('trx must be a valid executor');
+  });
+
+  it('rejects invalid trx (primitive)', () => {
+    expect(() =>
+      createTransactionContext({
+        transactionId: validTransactionId,
+        trx: 'not-an-executor' as any,
+        db: validDb,
+        ambient: false,
+      }),
+    ).toThrow('trx must be a valid executor');
+  });
+
+  it('rejects invalid trx (number)', () => {
+    expect(() =>
+      createTransactionContext({
+        transactionId: validTransactionId,
+        trx: 42 as any,
+        db: validDb,
+        ambient: false,
+      }),
+    ).toThrow('trx must be a valid executor');
+  });
+
+  it('rejects invalid db (null)', () => {
+    expect(() =>
+      createTransactionContext({
+        transactionId: validTransactionId,
+        trx: validTrx,
+        db: null as any,
+        ambient: false,
+      }),
+    ).toThrow('db must be a valid executor');
+  });
+
+  it('rejects invalid db (undefined)', () => {
+    expect(() =>
+      createTransactionContext({
+        transactionId: validTransactionId,
+        trx: validTrx,
+        db: undefined as any,
+        ambient: false,
+      }),
+    ).toThrow('db must be a valid executor');
+  });
+
+  it('rejects invalid db (primitive)', () => {
+    expect(() =>
+      createTransactionContext({
+        transactionId: validTransactionId,
+        trx: validTrx,
+        db: 'not-an-executor' as any,
+        ambient: false,
+      }),
+    ).toThrow('db must be a valid executor');
+  });
+
+  it('rejects invalid signal (non-AbortSignal)', () => {
+    expect(() =>
+      createTransactionContext({
+        transactionId: validTransactionId,
+        trx: validTrx,
+        db: validDb,
+        signal: 'not-a-signal' as any,
+        ambient: false,
+      }),
+    ).toThrow('signal must be an AbortSignal');
+  });
+
+  it('rejects invalid signal (object)', () => {
+    expect(() =>
+      createTransactionContext({
+        transactionId: validTransactionId,
+        trx: validTrx,
+        db: validDb,
+        signal: {} as any,
+        ambient: false,
+      }),
+    ).toThrow('signal must be an AbortSignal');
+  });
+
+  it('rejects non-boolean ambient', () => {
+    expect(() =>
+      createTransactionContext({
+        transactionId: validTransactionId,
+        trx: validTrx,
+        db: validDb,
+        ambient: 'true' as any,
+      }),
+    ).toThrow('ambient must be a boolean');
+  });
+
+  it('rejects undefined ambient', () => {
+    expect(() =>
+      createTransactionContext({
+        transactionId: validTransactionId,
+        trx: validTrx,
+        db: validDb,
+        ambient: undefined as any,
+      }),
+    ).toThrow('ambient must be a boolean');
+  });
+
+  it('accepts function as valid trx (jest mock compatibility)', () => {
+    const fnExecutor = jest.fn(() =>
+      Promise.resolve([]),
+    ) as unknown as YdbExecutor;
+    const context = createTransactionContext({
+      transactionId: validTransactionId,
+      trx: fnExecutor,
+      db: validDb,
+      ambient: false,
+    });
+    expect(context.trx).toBe(fnExecutor);
+  });
+
+  it('accepts function as valid db (jest mock compatibility)', () => {
+    const fnExecutor = jest.fn(() =>
+      Promise.resolve([]),
+    ) as unknown as YdbExecutor;
+    const context = createTransactionContext({
+      transactionId: validTransactionId,
+      trx: validTrx,
+      db: fnExecutor,
+      ambient: false,
+    });
+    expect(context.db).toBe(fnExecutor);
+  });
+});
+
+describe('runWithTransactionContext(): context propagation with validation (#208)', () => {
+  const validTrx = makeMockExecutor();
+  const validDb = makeMockExecutor();
+  const validTransactionId = Symbol('transaction');
+
+  it('propagates valid context through ALS', async () => {
+    const context = createTransactionContext({
+      transactionId: validTransactionId,
+      trx: validTrx,
+      db: validDb,
+      ambient: true,
+    });
+
+    const result = await runWithTransactionContext(context, () => {
+      const active = getActiveTransaction();
+      expect(active).toBe(context);
+      return Promise.resolve('success');
+    });
+
+    expect(result).toBe('success');
+    expect(getActiveTransaction()).toBeUndefined();
+  });
+
+  it('createTransactionContext rejects invalid context at factory boundary', () => {
+    expect(() =>
+      createTransactionContext({
+        transactionId: 'invalid' as any,
+        trx: validTrx,
+        db: validDb,
+        ambient: false,
+      }),
+    ).toThrow('transactionId must be a symbol');
+  });
+
+  it('restores previous context after fn throws', async () => {
+    const outerContext = createTransactionContext({
+      transactionId: Symbol('outer'),
+      trx: validTrx,
+      db: validDb,
+      ambient: true,
+    });
+
+    const innerContext = createTransactionContext({
+      transactionId: Symbol('inner'),
+      trx: validTrx,
+      db: validDb,
+      ambient: false,
+    });
+
+    await runWithTransactionContext(outerContext, async () => {
+      expect(getActiveTransaction()).toBe(outerContext);
+
+      await expect(
+        runWithTransactionContext(innerContext, () => {
+          expect(getActiveTransaction()).toBe(innerContext);
+          return Promise.reject(new Error('inner error'));
+        }),
+      ).rejects.toThrow('inner error');
+
+      expect(getActiveTransaction()).toBe(outerContext);
+    });
+
+    expect(getActiveTransaction()).toBeUndefined();
+  });
+});

--- a/src/transaction/transaction-context.ts
+++ b/src/transaction/transaction-context.ts
@@ -5,6 +5,15 @@ import type { YdbTransactionsSettings } from '../core/interfaces.js';
 /** Уникальный ключ для хранения transactionId на executor'е. */
 export const TRANSACTION_ID_KEY = Symbol.for('ydb.transaction.id');
 
+/** Параметры создания контекста активной транзакции (#208). */
+export interface TransactionContextParams {
+  transactionId: symbol;
+  trx: YdbExecutor;
+  db: YdbExecutor;
+  signal?: AbortSignal;
+  ambient: boolean;
+}
+
 /**
  * Активная транзакция в цепочке async-вызовов (#98).
  *
@@ -19,18 +28,40 @@ export const TRANSACTION_ID_KEY = Symbol.for('ydb.transaction.id');
  * Идентичность транзакции определяется `transactionId`, а не ссылкой на
  * executor, так как разные обёртки могут представлять одну и ту же
  * логическую транзакцию (например, при оборачивании executor'а для логирования).
+ *
+ * Инварианты (#208) валидируются в единственной точке создания — конструкторе,
+ * поэтому невалидный инстанс создать невозможно ни через фабрику
+ * createTransactionContext(), ни напрямую через new. Приватное brand-поле
+ * делает контекст непрозрачным для структурной типизации и защищает
+ * runWithTransactionContext() от подделок через cast/instanceof.
  */
-export interface ActiveTransactionContext {
+export class ActiveTransactionContext {
   /** Уникальный идентификатор транзакции (символ) — для сравнения по значению. */
-  transactionId: symbol;
+  readonly transactionId: symbol;
   /** Executor транзакции — передаётся в операции вместо executor'а сущности. */
-  trx: YdbExecutor;
+  readonly trx: YdbExecutor;
   /** Executor БД, открывший транзакцию: детекция вложенности по transactionId. */
-  db: YdbExecutor;
+  readonly db: YdbExecutor;
   /** Сигнал отмены конкретной попытки транзакции (при retry — новый). */
-  signal?: AbortSignal;
+  readonly signal: AbortSignal | undefined;
   /** Включён ли ambient auto-join для этого контекста. */
-  ambient: boolean;
+  readonly ambient: boolean;
+  /** Приватная brand-метка: есть только у инстансов, созданных через фабрику. */
+  readonly #brand = Symbol('ActiveTransactionContext');
+
+  constructor(params: TransactionContextParams) {
+    validateTransactionContextParams(params);
+    this.transactionId = params.transactionId;
+    this.trx = params.trx;
+    this.db = params.db;
+    this.signal = params.signal;
+    this.ambient = params.ambient;
+  }
+
+  /** Возвращает true только для настоящего фабричного инстанса. */
+  static isContext(value: unknown): value is ActiveTransactionContext {
+    return typeof value === 'object' && value !== null && #brand in value;
+  }
 }
 
 const storage = new AsyncLocalStorage<ActiveTransactionContext>();
@@ -76,11 +107,22 @@ export function getActiveTransaction(): ActiveTransactionContext | undefined {
   return storage.getStore();
 }
 
-/** Выполняет fn с заданным контекстом активной транзакции. */
+/**
+ * Выполняет fn с заданным контекстом активной транзакции.
+ *
+ * Публичная граница (#208): контекст обязан быть настоящим инстансом,
+ * созданным через createTransactionContext() — приватный brand-проверкой
+ * исключаются и обычные объекты, и подделки через cast/instanceof.
+ */
 export function runWithTransactionContext<T>(
   context: ActiveTransactionContext,
   fn: () => Promise<T>,
 ): Promise<T> {
+  if (!ActiveTransactionContext.isContext(context)) {
+    throw new Error(
+      'ActiveTransactionContext: invalid context. Create it via createTransactionContext().',
+    );
+  }
   return storage.run(context, fn);
 }
 
@@ -155,9 +197,8 @@ export function getTransactionId(trx: YdbExecutor): symbol | YdbExecutor {
 }
 
 /**
- * Валидирует инварианты ActiveTransactionContext и создаёт контекст.
+ * Единственная точка валидации инвариантов ActiveTransactionContext (#208):
  *
- * Инварианты:
  * - transactionId должен быть символом
  * - trx должен быть валидным executor'ом (объект или функция)
  * - db должен быть валидным executor'ом (объект или функция)
@@ -166,13 +207,9 @@ export function getTransactionId(trx: YdbExecutor): symbol | YdbExecutor {
  *
  * @throws Error если любой инвариант нарушен
  */
-export function createTransactionContext(params: {
-  transactionId: symbol;
-  trx: YdbExecutor;
-  db: YdbExecutor;
-  signal?: AbortSignal;
-  ambient: boolean;
-}): ActiveTransactionContext {
+function validateTransactionContextParams(
+  params: TransactionContextParams,
+): void {
   if (typeof params.transactionId !== 'symbol') {
     throw new Error(
       'ActiveTransactionContext: transactionId must be a symbol.',
@@ -202,11 +239,15 @@ export function createTransactionContext(params: {
   if (typeof params.ambient !== 'boolean') {
     throw new Error('ActiveTransactionContext: ambient must be a boolean.');
   }
-  return {
-    transactionId: params.transactionId,
-    trx: params.trx,
-    db: params.db,
-    signal: params.signal,
-    ambient: params.ambient,
-  };
+}
+
+/**
+ * Канонический способ получения ActiveTransactionContext: валидация инвариантов
+ * (#208) происходит в конструкторе, brand-поле блокирует структурные подделки
+ * (объектные литералы и касты в runWithTransactionContext отклоняются).
+ */
+export function createTransactionContext(
+  params: TransactionContextParams,
+): ActiveTransactionContext {
+  return new ActiveTransactionContext(params);
 }

--- a/src/transaction/transaction-context.ts
+++ b/src/transaction/transaction-context.ts
@@ -153,3 +153,60 @@ export function getTransactionId(trx: YdbExecutor): symbol | YdbExecutor {
   >;
   return withId[TRANSACTION_ID_KEY] ?? trx;
 }
+
+/**
+ * Валидирует инварианты ActiveTransactionContext и создаёт контекст.
+ *
+ * Инварианты:
+ * - transactionId должен быть символом
+ * - trx должен быть валидным executor'ом (объект или функция)
+ * - db должен быть валидным executor'ом (объект или функция)
+ * - signal, если задан, должен быть AbortSignal
+ * - ambient должен быть boolean
+ *
+ * @throws Error если любой инвариант нарушен
+ */
+export function createTransactionContext(params: {
+  transactionId: symbol;
+  trx: YdbExecutor;
+  db: YdbExecutor;
+  signal?: AbortSignal;
+  ambient: boolean;
+}): ActiveTransactionContext {
+  if (typeof params.transactionId !== 'symbol') {
+    throw new Error(
+      'ActiveTransactionContext: transactionId must be a symbol.',
+    );
+  }
+  if (
+    !params.trx ||
+    (typeof params.trx !== 'object' && typeof params.trx !== 'function')
+  ) {
+    throw new Error(
+      'ActiveTransactionContext: trx must be a valid executor (object or function).',
+    );
+  }
+  if (
+    !params.db ||
+    (typeof params.db !== 'object' && typeof params.db !== 'function')
+  ) {
+    throw new Error(
+      'ActiveTransactionContext: db must be a valid executor (object or function).',
+    );
+  }
+  if (params.signal !== undefined && !(params.signal instanceof AbortSignal)) {
+    throw new Error(
+      'ActiveTransactionContext: signal must be an AbortSignal if provided.',
+    );
+  }
+  if (typeof params.ambient !== 'boolean') {
+    throw new Error('ActiveTransactionContext: ambient must be a boolean.');
+  }
+  return {
+    transactionId: params.transactionId,
+    trx: params.trx,
+    db: params.db,
+    signal: params.signal,
+    ambient: params.ambient,
+  };
+}

--- a/src/transaction/transaction-context.ts
+++ b/src/transaction/transaction-context.ts
@@ -2,6 +2,9 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import type { YdbExecutor } from '../core/interfaces.js';
 import type { YdbTransactionsSettings } from '../core/interfaces.js';
 
+/** Уникальный ключ для хранения transactionId на executor'е. */
+export const TRANSACTION_ID_KEY = Symbol.for('ydb.transaction.id');
+
 /**
  * Активная транзакция в цепочке async-вызовов (#98).
  *
@@ -12,11 +15,17 @@ import type { YdbTransactionsSettings } from '../core/interfaces.js';
  * 2. Ambient auto-join: если включён (глобально через настройки модуля или
  *    локально через опцию `ambient` вызова), операции репозиториев без
  *    явного { trx } выполняются в активной транзакции.
+ *
+ * Идентичность транзакции определяется `transactionId`, а не ссылкой на
+ * executor, так как разные обёртки могут представлять одну и ту же
+ * логическую транзакцию (например, при оборачивании executor'а для логирования).
  */
 export interface ActiveTransactionContext {
+  /** Уникальный идентификатор транзакции (символ) — для сравнения по значению. */
+  transactionId: symbol;
   /** Executor транзакции — передаётся в операции вместо executor'а сущности. */
   trx: YdbExecutor;
-  /** Executor БД, открывший транзакцию: детекция вложенности по ссылке. */
+  /** Executor БД, открывший транзакцию: детекция вложенности по transactionId. */
   db: YdbExecutor;
   /** Сигнал отмены конкретной попытки транзакции (при retry — новый). */
   signal?: AbortSignal;
@@ -98,7 +107,10 @@ export function resolveOperationExecutor(
   const effectiveSettings = resolveTransactionSettings(scopeSettings);
 
   if (explicitTrx) {
-    if (active?.ambient && active.trx !== explicitTrx) {
+    if (
+      active?.ambient &&
+      active.transactionId !== getTransactionId(explicitTrx)
+    ) {
       throw new Error(
         `Transaction mixing detected in ${entityName}: an explicit { trx } was passed, ` +
           'but a different transaction is active in the current async context. ' +
@@ -127,4 +139,17 @@ export function resolveOperationExecutor(
   }
 
   return fallback;
+}
+
+/**
+ * Получает transactionId из executor'а транзакции.
+ * Если executor не имеет transactionId (не создан через runInTransaction),
+ * возвращает сам executor для обратной совместимости (сравнение по ссылке).
+ */
+export function getTransactionId(trx: YdbExecutor): symbol | YdbExecutor {
+  const withId = trx as unknown as Record<
+    typeof TRANSACTION_ID_KEY,
+    symbol | undefined
+  >;
+  return withId[TRANSACTION_ID_KEY] ?? trx;
 }

--- a/src/transaction/transaction.manager.ts
+++ b/src/transaction/transaction.manager.ts
@@ -7,6 +7,7 @@ import type {
   YdbTransactionsSettings,
 } from '../core/interfaces.js';
 import {
+  createTransactionContext,
   getActiveTransaction,
   resolveTransactionSettings,
   runWithTransactionContext,
@@ -264,13 +265,13 @@ export class YdbTransactionManager {
         // транзакция открыта с ambient: false.
         if (options.ambient === true) {
           return runWithTransactionContext(
-            {
+            createTransactionContext({
               transactionId: active.transactionId,
               trx: active.trx,
               db: this.db,
               signal: active.signal,
               ambient: true,
-            },
+            }),
             () => fn(active.trx, active.signal),
           );
         }
@@ -340,7 +341,13 @@ export class YdbTransactionManager {
         ] = transactionId;
       }
       return runWithTransactionContext(
-        { transactionId, trx, db: this.db, signal: attemptSignal, ambient },
+        createTransactionContext({
+          transactionId,
+          trx,
+          db: this.db,
+          signal: attemptSignal,
+          ambient,
+        }),
         () => fn(trx, attemptSignal),
       );
     };

--- a/src/transaction/transaction.manager.ts
+++ b/src/transaction/transaction.manager.ts
@@ -10,7 +10,13 @@ import {
   getActiveTransaction,
   resolveTransactionSettings,
   runWithTransactionContext,
+  TRANSACTION_ID_KEY,
 } from './transaction-context.js';
+
+/** Генерирует уникальный идентификатор транзакции. */
+function generateTransactionId(): symbol {
+  return Symbol('transaction');
+}
 
 /**
  * Опции runInTransaction() (#98).
@@ -246,6 +252,8 @@ export class YdbTransactionManager {
 
     // Детекция вложенности работает всегда (ambient включён или нет).
     const active = getActiveTransaction();
+    // Сравниваем по transactionId, а не по ссылке на executor (#207).
+    // active.db === this.db проверяет, что это тот же executor БД.
     if (active && active.db === this.db) {
       if (options?.reuse) {
         // Переиспользуем активную транзакцию: коммит/откат остаются у
@@ -257,6 +265,7 @@ export class YdbTransactionManager {
         if (options.ambient === true) {
           return runWithTransactionContext(
             {
+              transactionId: active.transactionId,
               trx: active.trx,
               db: this.db,
               signal: active.signal,
@@ -321,8 +330,17 @@ export class YdbTransactionManager {
       sdkSignal: AbortSignal | undefined,
     ) => {
       const attemptSignal = composeAttemptSignal(sdkSignal);
+      // Генерируем уникальный ID для этой транзакции и сохраняем на executor'е.
+      const transactionId = generateTransactionId();
+      // Защита для моков и нестандартных executor'ов: trx может быть
+      // функцией (jest mock), объектом или примитивом.
+      if (trx && (typeof trx === 'object' || typeof trx === 'function')) {
+        (trx as unknown as Record<typeof TRANSACTION_ID_KEY, symbol>)[
+          TRANSACTION_ID_KEY
+        ] = transactionId;
+      }
       return runWithTransactionContext(
-        { trx, db: this.db, signal: attemptSignal, ambient },
+        { transactionId, trx, db: this.db, signal: attemptSignal, ambient },
         () => fn(trx, attemptSignal),
       );
     };

--- a/test/batched-relations.spec.ts
+++ b/test/batched-relations.spec.ts
@@ -14,6 +14,7 @@ import {
   MAX_IN_CLAUSE_VALUES,
 } from '../src/index.js';
 import {
+  createTransactionContext,
   runWithTransactionContext,
   configureTransactionContext,
 } from '../src/transaction/transaction-context.js';
@@ -449,11 +450,12 @@ describe('#86: батчинг loadRelations', () => {
       configureTransactionContext({ ambient: true });
       try {
         await runWithTransactionContext(
-          {
+          createTransactionContext({
+            transactionId: Symbol('batched-relations'),
             trx: trxMock.executor,
             db: dbMock.executor,
             ambient: true,
-          },
+          }),
           async () => {
             await userRepo().relations.loadRelations(users, ['photos']);
           },

--- a/test/nested-eager.spec.ts
+++ b/test/nested-eager.spec.ts
@@ -14,6 +14,7 @@ import {
   MAX_IN_CLAUSE_VALUES,
 } from '../src/index.js';
 import {
+  createTransactionContext,
   runWithTransactionContext,
   configureTransactionContext,
 } from '../src/transaction/transaction-context.js';
@@ -722,11 +723,12 @@ describe('#16: вложенная eager-load', () => {
     configureTransactionContext({ ambient: true });
     try {
       await runWithTransactionContext(
-        {
+        createTransactionContext({
+          transactionId: Symbol('nested-eager'),
           trx: trxMock.executor,
           db: dbMock.executor,
           ambient: true,
-        },
+        }),
         async () => {
           await getOrCreateRepository(
             TwoLevelPhoto,
@@ -816,11 +818,12 @@ describe('#16: вложенная eager-load', () => {
     configureTransactionContext({ ambient: true });
     try {
       await runWithTransactionContext(
-        {
+        createTransactionContext({
+          transactionId: Symbol('nested-eager-ambient'),
           trx: trxMock.executor,
           db: dbMock.executor,
           ambient: true,
-        },
+        }),
         async () => {
           // Без явного { trx } — прежний ambient auto-join (#98).
           await getOrCreateRepository(TrxPhoto).relations.loadEagerRelations([


### PR DESCRIPTION
Summary: Add factory function  with validation for all context invariants (transactionId must be symbol, trx/db must be valid executors, signal must be AbortSignal, ambient must be boolean). Update transaction manager to use factory for all context creation. Fix retry spec mock to pass proper trx/signal to callback.

Tests: All existing tests pass + new regression tests in transaction-context.spec.ts covering invalid context combinations.