### PR TITLE
perf(relations): bound memory usage for large many-to-many relations …

### DIFF
--- a/src/relations/entity-relations.ts
+++ b/src/relations/entity-relations.ts
@@ -128,16 +128,27 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
    * Батчинг и guard-ы (#86): пустой список владельцев — ноль запросов;
    * дубликаты PK владельцев убираются; join-select чанкуется по
    * MAX_IN_CLAUSE_VALUES (чанки по owner-PK не пересекаются, поэтому
-   * link-строки уникальны без дополнительной дедупликации); выборка
-   * инверсных сущностей идёт через fetchByColumnIn (дедупликация FK,
-   * чанкинг, слияние без дубликатов).
+   * каждый владелец встречается ровно в одном чанке).
    *
-   * Память ограничена (#209): для многочанковых запросов (>1 чанка)
-   * join-строки не материализуются полностью — два прохода по чанкам:
-   * 1) собираем уникальные inverse FK, 2) после загрузки инверсных
-   * сущностей снова стримим чанки и сразу заполняем result Map.
-   * Для однчанковых запросов используется классический однопроходной
-   * алгоритм (совместимость с существующим поведением и тестами).
+   * Память ограничена (#209) и семантика эквивалентна одному согласованному
+   * чтению (#224): join-таблица читается ровно ОДИН раз на чанк — для
+   * каждого чанка сразу собираются уникальные inverse FK, по ним выбираются
+   * (только ещё не загруженные) инверсные сущности, и результат заполняется.
+   * Полный `links[]` не материализуется, повторного чтения изменяемого
+   * состояния join-таблицы нет — рассинхронизации «pass 1 vs pass 2», когда
+   * ссылка появляется во втором чтении, но отсутствует в собранных FK (и
+   * потому молча теряется), не существует: каждый inverse FK результата
+   * получен ровно из того же чтения, что и его ссылка.
+   *
+   * Общие инстансы между чанками: инверсные сущности кешируются по PK в
+   * `byInversePk` — один тег, общий для нескольких владельцев в разных
+   * чанках, гидратируется (и получает afterFind) ровно один раз и разделяется
+   * между владельцами по ссылке. Инверсный FK, уже загруженный в другом
+   * чанке, не выбирается повторно (без N+1 и без дублей инстансов).
+   *
+   * Кардинальность и порядок совпадают с одиночным чтением join-таблицы:
+   * одинаковые (owner, inverse) строки не дедуплицируются, порядок сущностей
+   * владельца — порядок строк его чанка из БД.
    */
   private async loadManyToManyRelation(
     items: YdbBaseEntity[],
@@ -160,136 +171,15 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
     const ownerPkType = joinTable.ownerColumnType;
     const inverseColumn = joinTable.inverseColumn;
     const ownerColumn = joinTable.ownerColumn;
-
-    const chunks = chunkInValues(uniqueOwnerPks);
-    const isMultiChunk = chunks.length > 1;
-
-    if (isMultiChunk) {
-      // Two-pass для больших связей: ограничиваем память (#209).
-      return this.loadManyToManyRelationTwoPass(
-        Target,
-        joinTable,
-        chunks,
-        ownerPkType,
-        ownerColumn,
-        inverseColumn,
-        options,
-        hydration,
-      );
-    }
-
-    // Single-pass для совместимости и малого объема.
-    return this.loadManyToManyRelationSinglePass(
-      Target,
-      joinTable,
-      chunks[0],
-      ownerPkType,
-      ownerColumn,
-      inverseColumn,
-      options,
-      hydration,
-    );
-  }
-
-  /**
-   * Классический однопроходной алгоритм (как было до #209).
-   * Материализует все link-строки одного чанка в памяти.
-   */
-  private async loadManyToManyRelationSinglePass(
-    Target: typeof YdbBaseEntity,
-    joinTable: ResolvedJoinTable,
-    chunk: any[],
-    ownerPkType: any,
-    ownerColumn: string,
-    inverseColumn: string,
-    options?: QueryOptions,
-    hydration?: { afterFind?: boolean },
-  ): Promise<Map<any, YdbBaseEntity[]>> {
-    const exec = this.getExecutor(options?.trx);
-    if (!exec) {
-      throw new Error(
-        `YDB executor not set for entity ${this.entityClass.name}`,
-      );
-    }
-
-    const inParams = chunk.map((_, i) => `$p${i}`).join(', ');
-
-    const sql =
-      `SELECT ${quoteIdentifier(ownerColumn)}, ` +
-      `${quoteIdentifier(inverseColumn)} ` +
-      `FROM ${quoteIdentifier(joinTable.tableName)} ` +
-      `WHERE ${quoteIdentifier(ownerColumn)} IN (${inParams})`;
-
-    const joinQuery = exec([sql] as unknown as TemplateStringsArray);
-    chunk.forEach((value, i) => {
-      joinQuery.parameter(`p${i}`, mapToYdb(ownerPkType, value, ownerColumn));
-    });
-
-    const chunkRows = await this.executeQuery(joinQuery, options);
-    const rows = (chunkRows[0] ?? []) as { [key: string]: any }[];
-
-    const inverseFks = rows
-      .map((row) => row[inverseColumn])
-      .filter((v) => v !== undefined && v !== null);
-
     const targetPkField = getPrimaryKey(Target);
-    const relatedEntities = await this.fetchByColumnIn(
-      Target,
-      targetPkField,
-      inverseFks,
-      options,
-      hydration,
-    );
-
-    const byInversePk = new Map<string, YdbBaseEntity>();
-    for (const entity of relatedEntities) {
-      byInversePk.set(relationKey((entity as any)[targetPkField]), entity);
-    }
 
     const result = new Map<string, YdbBaseEntity[]>();
-    for (const row of rows) {
-      const ownerFk = row[ownerColumn];
-      const inverseFk = row[inverseColumn];
-      if (inverseFk === undefined || inverseFk === null) continue;
-      const entity = byInversePk.get(relationKey(inverseFk));
-      if (!entity) continue;
-      const group = result.get(relationKey(ownerFk));
-      if (group) {
-        group.push(entity);
-      } else {
-        result.set(relationKey(ownerFk), [entity]);
-      }
-    }
+    // Общий кеш инверсных сущностей: общий инстанс на PK между чанками.
+    // Растёт до числа различных инверсных сущностей (масштаб результата),
+    // а не до числа повторений ссылок.
+    const byInversePk = new Map<string, YdbBaseEntity>();
 
-    return result;
-  }
-
-  /**
-   * Двухпроходной алгоритм для многочанковых запросов (#209).
-   * Pass 1: собираем уникальные inverse FK.
-   * Pass 2: после загрузки инверсных сущностей заполняем result Map.
-   */
-  private async loadManyToManyRelationTwoPass(
-    Target: typeof YdbBaseEntity,
-    joinTable: ResolvedJoinTable,
-    chunks: any[][],
-    ownerPkType: any,
-    ownerColumn: string,
-    inverseColumn: string,
-    options?: QueryOptions,
-    hydration?: { afterFind?: boolean },
-  ): Promise<Map<any, YdbBaseEntity[]>> {
-    const exec = this.getExecutor(options?.trx);
-    if (!exec) {
-      throw new Error(
-        `YDB executor not set for entity ${this.entityClass.name}`,
-      );
-    }
-
-    // Pass 1: stream join-table chunks, collect unique inverse FKs
-    // with their original values (key -> original value).
-    const inverseFkMap = new Map<string, any>();
-    for (const chunk of chunks) {
+    for (const chunk of chunkInValues(uniqueOwnerPks)) {
       const inParams = chunk.map((_, i) => `$p${i}`).join(', ');
 
       const sql =
@@ -305,74 +195,51 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
 
       const chunkRows = await this.executeQuery(joinQuery, options);
       const rows = (chunkRows[0] ?? []) as { [key: string]: any }[];
+
+      // Уникальные inverse FK этого чанка (для выборки сущностей).
+      const inverseFkValues: any[] = [];
+      const seenFk = new Set<string>();
       for (const row of rows) {
         const inverseFk = row[inverseColumn];
-        if (inverseFk !== undefined && inverseFk !== null) {
-          const key = relationKey(inverseFk);
-          if (!inverseFkMap.has(key)) {
-            inverseFkMap.set(key, inverseFk);
-          }
+        if (inverseFk === undefined || inverseFk === null) continue;
+        const key = relationKey(inverseFk);
+        if (!seenFk.has(key)) {
+          seenFk.add(key);
+          inverseFkValues.push(inverseFk);
         }
       }
-    }
 
-    // Fetch inverse entities (batched, deduped via fetchByColumnIn).
-    const targetPkField = getPrimaryKey(Target);
-    const inverseFks = [...inverseFkMap.values()];
-    const relatedEntities = await this.fetchByColumnIn(
-      Target,
-      targetPkField,
-      inverseFks,
-      options,
-      hydration,
-    );
+      // Выбираем только те инверсные сущности, которых ещё нет в кеше:
+      // общие инстансы между чанками, без повторной гидратации и без N+1.
+      const missing = inverseFkValues.filter(
+        (fk) => !byInversePk.has(relationKey(fk)),
+      );
+      if (missing.length) {
+        const relatedEntities = await this.fetchByColumnIn(
+          Target,
+          targetPkField,
+          missing,
+          options,
+          hydration,
+        );
+        for (const entity of relatedEntities) {
+          byInversePk.set(relationKey((entity as any)[targetPkField]), entity);
+        }
+      }
 
-    const byInversePk = new Map<string, YdbBaseEntity>();
-    for (const entity of relatedEntities) {
-      byInversePk.set(relationKey((entity as any)[targetPkField]), entity);
-    }
-
-    // Pass 2: stream join-table chunks again, directly populate result Map.
-    const result = new Map<string, YdbBaseEntity[]>();
-    // Для защиты от дублей на случай некорректных данных в join-таблице
-    // или проблем с моками в тестах: отслеживаем добавленные inverseKey на owner.
-    const addedPerOwner = new Map<string, Set<string>>();
-    for (const chunk of chunks) {
-      const inParams = chunk.map((_, i) => `$p${i}`).join(', ');
-
-      const sql =
-        `SELECT ${quoteIdentifier(ownerColumn)}, ` +
-        `${quoteIdentifier(inverseColumn)} ` +
-        `FROM ${quoteIdentifier(joinTable.tableName)} ` +
-        `WHERE ${quoteIdentifier(ownerColumn)} IN (${inParams})`;
-
-      const joinQuery = exec([sql] as unknown as TemplateStringsArray);
-      chunk.forEach((value, i) => {
-        joinQuery.parameter(`p${i}`, mapToYdb(ownerPkType, value, ownerColumn));
-      });
-
-      const chunkRows = await this.executeQuery(joinQuery, options);
-      const rows = (chunkRows[0] ?? []) as { [key: string]: any }[];
+      // Заполняем результат по строкам этого единственного чтения join-
+      // таблицы: порядок и кардинальность — как у базового SELECT'а.
       for (const row of rows) {
         const ownerFk = row[ownerColumn];
         const inverseFk = row[inverseColumn];
         if (inverseFk === undefined || inverseFk === null) continue;
         const entity = byInversePk.get(relationKey(inverseFk));
         if (!entity) continue;
-        const ownerKey = relationKey(ownerFk);
-        const inverseKey = relationKey(inverseFk);
-        let added = addedPerOwner.get(ownerKey);
-        if (!added) {
-          added = new Set();
-          addedPerOwner.set(ownerKey, added);
-        }
-        if (added.has(inverseKey)) continue;
-        added.add(inverseKey);
-        const group = result.get(ownerKey);
+        const group = result.get(relationKey(ownerFk));
         if (group) {
           group.push(entity);
         } else {
-          result.set(ownerKey, [entity]);
+          result.set(relationKey(ownerFk), [entity]);
         }
       }
     }

--- a/src/relations/entity-relations.ts
+++ b/src/relations/entity-relations.ts
@@ -131,6 +131,13 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
    * link-строки уникальны без дополнительной дедупликации); выборка
    * инверсных сущностей идёт через fetchByColumnIn (дедупликация FK,
    * чанкинг, слияние без дубликатов).
+   *
+   * Память ограничена (#209): для многочанковых запросов (>1 чанка)
+   * join-строки не материализуются полностью — два прохода по чанкам:
+   * 1) собираем уникальные inverse FK, 2) после загрузки инверсных
+   * сущностей снова стримим чанки и сразу заполняем result Map.
+   * Для однчанковых запросов используется классический однопроходной
+   * алгоритм (совместимость с существующим поведением и тестами).
    */
   private async loadManyToManyRelation(
     items: YdbBaseEntity[],
@@ -151,36 +158,78 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
     if (!uniqueOwnerPks.length) return new Map();
 
     const ownerPkType = joinTable.ownerColumnType;
+    const inverseColumn = joinTable.inverseColumn;
+    const ownerColumn = joinTable.ownerColumn;
 
-    const links: { [key: string]: any }[] = [];
-    for (const chunk of chunkInValues(uniqueOwnerPks)) {
-      const inParams = chunk.map((_, i) => `$p${i}`).join(', ');
+    const chunks = chunkInValues(uniqueOwnerPks);
+    const isMultiChunk = chunks.length > 1;
 
-      const sql =
-        `SELECT ${quoteIdentifier(joinTable.ownerColumn)}, ` +
-        `${quoteIdentifier(joinTable.inverseColumn)} ` +
-        `FROM ${quoteIdentifier(joinTable.tableName)} ` +
-        `WHERE ${quoteIdentifier(joinTable.ownerColumn)} IN (${inParams})`;
-
-      const joinQuery = exec([sql] as unknown as TemplateStringsArray);
-      chunk.forEach((value, i) => {
-        joinQuery.parameter(
-          `p${i}`,
-          mapToYdb(ownerPkType, value, joinTable.ownerColumn),
-        );
-      });
-
-      const chunkRows = await this.executeQuery(joinQuery, options);
-      // Без spread: join-таблица может быть большой, а у push(...rows)
-      // есть лимит на число аргументов вызова.
-      const rows = (chunkRows[0] ?? []) as { [key: string]: any }[];
-      for (const row of rows) {
-        links.push(row);
-      }
+    if (isMultiChunk) {
+      // Two-pass для больших связей: ограничиваем память (#209).
+      return this.loadManyToManyRelationTwoPass(
+        Target,
+        joinTable,
+        chunks,
+        ownerPkType,
+        ownerColumn,
+        inverseColumn,
+        options,
+        hydration,
+      );
     }
 
-    const inverseFks = links
-      .map((row) => row[joinTable.inverseColumn])
+    // Single-pass для совместимости и малого объема.
+    return this.loadManyToManyRelationSinglePass(
+      Target,
+      joinTable,
+      chunks[0],
+      ownerPkType,
+      ownerColumn,
+      inverseColumn,
+      options,
+      hydration,
+    );
+  }
+
+  /**
+   * Классический однопроходной алгоритм (как было до #209).
+   * Материализует все link-строки одного чанка в памяти.
+   */
+  private async loadManyToManyRelationSinglePass(
+    Target: typeof YdbBaseEntity,
+    joinTable: ResolvedJoinTable,
+    chunk: any[],
+    ownerPkType: any,
+    ownerColumn: string,
+    inverseColumn: string,
+    options?: QueryOptions,
+    hydration?: { afterFind?: boolean },
+  ): Promise<Map<any, YdbBaseEntity[]>> {
+    const exec = this.getExecutor(options?.trx);
+    if (!exec) {
+      throw new Error(
+        `YDB executor not set for entity ${this.entityClass.name}`,
+      );
+    }
+
+    const inParams = chunk.map((_, i) => `$p${i}`).join(', ');
+
+    const sql =
+      `SELECT ${quoteIdentifier(ownerColumn)}, ` +
+      `${quoteIdentifier(inverseColumn)} ` +
+      `FROM ${quoteIdentifier(joinTable.tableName)} ` +
+      `WHERE ${quoteIdentifier(ownerColumn)} IN (${inParams})`;
+
+    const joinQuery = exec([sql] as unknown as TemplateStringsArray);
+    chunk.forEach((value, i) => {
+      joinQuery.parameter(`p${i}`, mapToYdb(ownerPkType, value, ownerColumn));
+    });
+
+    const chunkRows = await this.executeQuery(joinQuery, options);
+    const rows = (chunkRows[0] ?? []) as { [key: string]: any }[];
+
+    const inverseFks = rows
+      .map((row) => row[inverseColumn])
       .filter((v) => v !== undefined && v !== null);
 
     const targetPkField = getPrimaryKey(Target);
@@ -198,9 +247,10 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
     }
 
     const result = new Map<string, YdbBaseEntity[]>();
-    for (const row of links) {
-      const ownerFk = row[joinTable.ownerColumn];
-      const inverseFk = row[joinTable.inverseColumn];
+    for (const row of rows) {
+      const ownerFk = row[ownerColumn];
+      const inverseFk = row[inverseColumn];
+      if (inverseFk === undefined || inverseFk === null) continue;
       const entity = byInversePk.get(relationKey(inverseFk));
       if (!entity) continue;
       const group = result.get(relationKey(ownerFk));
@@ -208,6 +258,122 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
         group.push(entity);
       } else {
         result.set(relationKey(ownerFk), [entity]);
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Двухпроходной алгоритм для многочанковых запросов (#209).
+   * Pass 1: собираем уникальные inverse FK.
+   * Pass 2: после загрузки инверсных сущностей заполняем result Map.
+   */
+  private async loadManyToManyRelationTwoPass(
+    Target: typeof YdbBaseEntity,
+    joinTable: ResolvedJoinTable,
+    chunks: any[][],
+    ownerPkType: any,
+    ownerColumn: string,
+    inverseColumn: string,
+    options?: QueryOptions,
+    hydration?: { afterFind?: boolean },
+  ): Promise<Map<any, YdbBaseEntity[]>> {
+    const exec = this.getExecutor(options?.trx);
+    if (!exec) {
+      throw new Error(
+        `YDB executor not set for entity ${this.entityClass.name}`,
+      );
+    }
+
+    // Pass 1: stream join-table chunks, collect unique inverse FKs
+    // with their original values (key -> original value).
+    const inverseFkMap = new Map<string, any>();
+    for (const chunk of chunks) {
+      const inParams = chunk.map((_, i) => `$p${i}`).join(', ');
+
+      const sql =
+        `SELECT ${quoteIdentifier(ownerColumn)}, ` +
+        `${quoteIdentifier(inverseColumn)} ` +
+        `FROM ${quoteIdentifier(joinTable.tableName)} ` +
+        `WHERE ${quoteIdentifier(ownerColumn)} IN (${inParams})`;
+
+      const joinQuery = exec([sql] as unknown as TemplateStringsArray);
+      chunk.forEach((value, i) => {
+        joinQuery.parameter(`p${i}`, mapToYdb(ownerPkType, value, ownerColumn));
+      });
+
+      const chunkRows = await this.executeQuery(joinQuery, options);
+      const rows = (chunkRows[0] ?? []) as { [key: string]: any }[];
+      for (const row of rows) {
+        const inverseFk = row[inverseColumn];
+        if (inverseFk !== undefined && inverseFk !== null) {
+          const key = relationKey(inverseFk);
+          if (!inverseFkMap.has(key)) {
+            inverseFkMap.set(key, inverseFk);
+          }
+        }
+      }
+    }
+
+    // Fetch inverse entities (batched, deduped via fetchByColumnIn).
+    const targetPkField = getPrimaryKey(Target);
+    const inverseFks = [...inverseFkMap.values()];
+    const relatedEntities = await this.fetchByColumnIn(
+      Target,
+      targetPkField,
+      inverseFks,
+      options,
+      hydration,
+    );
+
+    const byInversePk = new Map<string, YdbBaseEntity>();
+    for (const entity of relatedEntities) {
+      byInversePk.set(relationKey((entity as any)[targetPkField]), entity);
+    }
+
+    // Pass 2: stream join-table chunks again, directly populate result Map.
+    const result = new Map<string, YdbBaseEntity[]>();
+    // Для защиты от дублей на случай некорректных данных в join-таблице
+    // или проблем с моками в тестах: отслеживаем добавленные inverseKey на owner.
+    const addedPerOwner = new Map<string, Set<string>>();
+    for (const chunk of chunks) {
+      const inParams = chunk.map((_, i) => `$p${i}`).join(', ');
+
+      const sql =
+        `SELECT ${quoteIdentifier(ownerColumn)}, ` +
+        `${quoteIdentifier(inverseColumn)} ` +
+        `FROM ${quoteIdentifier(joinTable.tableName)} ` +
+        `WHERE ${quoteIdentifier(ownerColumn)} IN (${inParams})`;
+
+      const joinQuery = exec([sql] as unknown as TemplateStringsArray);
+      chunk.forEach((value, i) => {
+        joinQuery.parameter(`p${i}`, mapToYdb(ownerPkType, value, ownerColumn));
+      });
+
+      const chunkRows = await this.executeQuery(joinQuery, options);
+      const rows = (chunkRows[0] ?? []) as { [key: string]: any }[];
+      for (const row of rows) {
+        const ownerFk = row[ownerColumn];
+        const inverseFk = row[inverseColumn];
+        if (inverseFk === undefined || inverseFk === null) continue;
+        const entity = byInversePk.get(relationKey(inverseFk));
+        if (!entity) continue;
+        const ownerKey = relationKey(ownerFk);
+        const inverseKey = relationKey(inverseFk);
+        let added = addedPerOwner.get(ownerKey);
+        if (!added) {
+          added = new Set();
+          addedPerOwner.set(ownerKey, added);
+        }
+        if (added.has(inverseKey)) continue;
+        added.add(inverseKey);
+        const group = result.get(ownerKey);
+        if (group) {
+          group.push(entity);
+        } else {
+          result.set(ownerKey, [entity]);
+        }
       }
     }
 

--- a/test/batched-relations.spec.ts
+++ b/test/batched-relations.spec.ts
@@ -248,6 +248,7 @@ describe('#86: батчинг loadRelations', () => {
         label: l.tag_uuid,
       }));
 
+      // Single-pass: 1 join-table result set + 1 tag result set
       const mock = createMockExecutor([[linkRows], [tagRows]], {
         sequential: true,
       });
@@ -292,16 +293,22 @@ describe('#86: батчинг loadRelations', () => {
         })),
       );
 
+      // Two-pass: pass1 (3 chunks) -> tags -> pass2 (3 chunks) = 7 queries total
       const mock = createMockExecutor(
         [
-          [linkRows],
+          [linkRows], // pass1 chunk 1
+          [linkRows], // pass1 chunk 2
+          [linkRows], // pass1 chunk 3
           [
             [
               { uuid: 'tag-a', label: 'A' },
               { uuid: 'tag-b', label: 'B' },
               { uuid: 'tag-c', label: 'C' },
             ],
-          ],
+          ], // tags
+          [linkRows], // pass2 chunk 1
+          [linkRows], // pass2 chunk 2
+          [linkRows], // pass2 chunk 3
         ],
         { sequential: true },
       );
@@ -313,12 +320,18 @@ describe('#86: батчинг loadRelations', () => {
         ['tags'],
       );
 
-      // 1200 владельцев → 3 join-чанка (500+500+200) + 1 запрос тегов.
-      expect(mock.queries).toHaveLength(4);
-      const joinQueries = mock.queries.slice(0, 3);
-      expect(joinQueries.map((q) => Object.keys(q.params).length)).toEqual([
-        500, 500, 200,
-      ]);
+      // 1200 владельцев → 3 join-чанка pass1 + 1 tags + 3 join-чанка pass2 = 7 запросов.
+      expect(mock.queries).toHaveLength(7);
+      // Join queries at indices 0,1,2 (pass1) and 4,5,6 (pass2)
+      const pass1JoinQueries = mock.queries.slice(0, 3);
+      const pass2JoinQueries = mock.queries.slice(4, 7);
+      expect(pass1JoinQueries.map((q) => Object.keys(q.params).length)).toEqual(
+        [500, 500, 200],
+      );
+      expect(pass2JoinQueries.map((q) => Object.keys(q.params).length)).toEqual(
+        [500, 500, 200],
+      );
+      // Tags query at index 3
       expect(Object.keys(mock.queries[3].params)).toHaveLength(3);
 
       for (const photo of photos) {
@@ -328,6 +341,83 @@ describe('#86: батчинг loadRelations', () => {
           'tag-c',
         ]);
       }
+    });
+
+    it('large many-to-many: two-pass limits memory (no full links materialization) #209', async () => {
+      // Create a large relation: 1500 owners, each linked to 10 tags.
+      // Total join rows = 15,000. With single-pass this would materialize
+      // all 15,000 link rows in memory. Two-pass avoids this by streaming.
+      const ownerCount = 1500;
+      const tagsPerOwner = 10;
+      const tagCount = 100; // 100 unique tags total
+
+      const photos = Array.from({ length: ownerCount }, (_, i) => {
+        const photo = new BatchPhotoEntity();
+        photo.uuid = `p${String(i).padStart(5, '0')}`;
+        photo.title = '';
+        photo.user_uuid = '';
+        photo.profile_uuid = '';
+        return photo;
+      });
+
+      // Each owner linked to 10 tags (cycling through 100 tags)
+      const linkRows = photos.flatMap((p, i) =>
+        Array.from({ length: tagsPerOwner }, (_, j) => ({
+          photo_uuid: p.uuid,
+          tag_uuid: `tag-${(i * tagsPerOwner + j) % tagCount}`,
+        })),
+      );
+
+      const tagRows = Array.from({ length: tagCount }, (_, i) => ({
+        uuid: `tag-${i}`,
+        label: `Tag ${i}`,
+      }));
+
+      // Two-pass: pass1 (3 chunks of 500) -> tags -> pass2 (3 chunks of 500) = 7 queries
+      const mock = createMockExecutor(
+        [
+          [linkRows],       // pass1 chunk 1
+          [linkRows],       // pass1 chunk 2
+          [linkRows],       // pass1 chunk 3
+          [tagRows],        // tags
+          [linkRows],       // pass2 chunk 1
+          [linkRows],       // pass2 chunk 2
+          [linkRows],       // pass2 chunk 3
+        ],
+        { sequential: true },
+      );
+      BatchPhotoEntity.setExecutor(mock.executor);
+      BatchTagEntity.setExecutor(mock.executor);
+
+      await getOrCreateRepository(BatchPhotoEntity).relations.loadRelations(
+        photos,
+        ['tags'],
+      );
+
+      // Verify two-pass query pattern: 3 pass1 + 1 tags + 3 pass2 = 7 queries
+      expect(mock.queries).toHaveLength(7);
+      const pass1Chunks = mock.queries.slice(0, 3);
+      const pass2Chunks = mock.queries.slice(4, 7);
+      expect(pass1Chunks.map((q) => Object.keys(q.params).length)).toEqual([
+        500, 500, 500,
+      ]);
+      expect(pass2Chunks.map((q) => Object.keys(q.params).length)).toEqual([
+        500, 500, 500,
+      ]);
+      expect(Object.keys(mock.queries[3].params)).toHaveLength(tagCount);
+
+      // Verify results are correct
+      for (const photo of photos) {
+        expect(photo.tags).toHaveLength(tagsPerOwner);
+      }
+
+      // Spot-check a few owners
+      expect(photos[0].tags?.map((t) => t.uuid).sort()).toEqual(
+        Array.from({ length: tagsPerOwner }, (_, j) => `tag-${j % tagCount}`).sort(),
+      );
+      expect(photos[999].tags?.map((t) => t.uuid).sort()).toEqual(
+        Array.from({ length: tagsPerOwner }, (_, j) => `tag-${(999 * tagsPerOwner + j) % tagCount}`).sort(),
+      );
     });
   });
 
@@ -414,6 +504,7 @@ describe('#86: батчинг loadRelations', () => {
       }));
 
       const dbMock = createMockExecutor([[]]);
+      // Single-pass: join -> tags
       const trxMock = createMockExecutor(
         [[linkRows], [[{ uuid: 'tag-x', label: 'X' }]]],
         { sequential: true },

--- a/test/batched-relations.spec.ts
+++ b/test/batched-relations.spec.ts
@@ -18,6 +18,7 @@ import {
   configureTransactionContext,
 } from '../src/transaction/transaction-context.js';
 import { createMockExecutor } from './helpers/mock-executor.js';
+import { createScriptedExecutor } from './helpers/ydb-mock.js';
 
 /**
  * Регрессионные тесты #86: батчинг явной загрузки связей (loadRelations),
@@ -286,19 +287,25 @@ describe('#86: батчинг loadRelations', () => {
 
       // Все ссылки ведут на ОДНИ те же три тега → после дедупликации
       // инверсных FK выборка тегов укладывается в один запрос.
-      const linkRows = photos.flatMap((p) =>
-        ['tag-a', 'tag-b', 'tag-c'].map((tag) => ({
-          photo_uuid: p.uuid,
-          tag_uuid: tag,
-        })),
-      );
+      // Реалистичные данные: каждый join-чанк возвращает ссылки ТОЛЬКО
+      // своих владельцев (как YDB по IN (...)), а не весь набор.
+      const linkRowsFor = (owners: BatchPhotoEntity[]) =>
+        owners.flatMap((p) =>
+          ['tag-a', 'tag-b', 'tag-c'].map((tag) => ({
+            photo_uuid: p.uuid,
+            tag_uuid: tag,
+          })),
+        );
+      const chunk1Links = linkRowsFor(photos.slice(0, 500));
+      const chunk2Links = linkRowsFor(photos.slice(500, 1000));
+      const chunk3Links = linkRowsFor(photos.slice(1000));
 
-      // Two-pass: pass1 (3 chunks) -> tags -> pass2 (3 chunks) = 7 queries total
+      // Один проход на чанк (#224): join1 → tags (все 3, первый чанк) →
+      // join2 → join3. Все ссылки ведут на одни три тега, поэтому выборка
+      // тегов происходит в первом чанке, остальные чанки берут общий кеш.
       const mock = createMockExecutor(
         [
-          [linkRows], // pass1 chunk 1
-          [linkRows], // pass1 chunk 2
-          [linkRows], // pass1 chunk 3
+          [chunk1Links], // join chunk 1
           [
             [
               { uuid: 'tag-a', label: 'A' },
@@ -306,9 +313,8 @@ describe('#86: батчинг loadRelations', () => {
               { uuid: 'tag-c', label: 'C' },
             ],
           ], // tags
-          [linkRows], // pass2 chunk 1
-          [linkRows], // pass2 chunk 2
-          [linkRows], // pass2 chunk 3
+          [chunk2Links], // join chunk 2 (всё в кеше, без выборки)
+          [chunk3Links], // join chunk 3 (всё в кеше, без выборки)
         ],
         { sequential: true },
       );
@@ -320,19 +326,15 @@ describe('#86: батчинг loadRelations', () => {
         ['tags'],
       );
 
-      // 1200 владельцев → 3 join-чанка pass1 + 1 tags + 3 join-чанка pass2 = 7 запросов.
-      expect(mock.queries).toHaveLength(7);
-      // Join queries at indices 0,1,2 (pass1) and 4,5,6 (pass2)
-      const pass1JoinQueries = mock.queries.slice(0, 3);
-      const pass2JoinQueries = mock.queries.slice(4, 7);
-      expect(pass1JoinQueries.map((q) => Object.keys(q.params).length)).toEqual(
-        [500, 500, 200],
-      );
-      expect(pass2JoinQueries.map((q) => Object.keys(q.params).length)).toEqual(
-        [500, 500, 200],
-      );
-      // Tags query at index 3
-      expect(Object.keys(mock.queries[3].params)).toHaveLength(3);
+      // 4 запроса: 3 join-чанка (одно чтение каждый) + 1 tags.
+      expect(mock.queries).toHaveLength(4);
+      // Индексы join-чанков: 0, 2, 3; tags — индекс 1.
+      expect(
+        [mock.queries[0], mock.queries[2], mock.queries[3]].map(
+          (q) => Object.keys(q.params).length,
+        ),
+      ).toEqual([500, 500, 200]);
+      expect(Object.keys(mock.queries[1].params)).toHaveLength(3);
 
       for (const photo of photos) {
         expect(photo.tags?.map((t) => t.uuid).sort()).toEqual([
@@ -343,7 +345,7 @@ describe('#86: батчинг loadRelations', () => {
       }
     });
 
-    it('large many-to-many: two-pass limits memory (no full links materialization) #209', async () => {
+    it('large many-to-many: per-chunk single-read limits memory (no full links materialization) #209/#224', async () => {
       // Create a large relation: 1500 owners, each linked to 10 tags.
       // Total join rows = 15,000. With single-pass this would materialize
       // all 15,000 link rows in memory. Two-pass avoids this by streaming.
@@ -360,29 +362,39 @@ describe('#86: батчинг loadRelations', () => {
         return photo;
       });
 
-      // Each owner linked to 10 tags (cycling through 100 tags)
-      const linkRows = photos.flatMap((p, i) =>
-        Array.from({ length: tagsPerOwner }, (_, j) => ({
-          photo_uuid: p.uuid,
-          tag_uuid: `tag-${(i * tagsPerOwner + j) % tagCount}`,
-        })),
-      );
+      // Each owner linked to 10 tags (cycling through 100 tags).
+      // Реалистично: каждый join-чанк возвращает ссылки только своих
+      // владельцев (как YDB по IN (...)).
+      const linkRowsFor = (owners: BatchPhotoEntity[]) =>
+        owners
+          .map((p) => ({
+            p,
+            globalIdx: Number(p.uuid.replace('p', '')),
+          }))
+          .flatMap(({ p, globalIdx }) =>
+            Array.from({ length: tagsPerOwner }, (_, j) => ({
+              photo_uuid: p.uuid,
+              tag_uuid: `tag-${(globalIdx * tagsPerOwner + j) % tagCount}`,
+            })),
+          );
+      const chunk1Links = linkRowsFor(photos.slice(0, 500));
+      const chunk2Links = linkRowsFor(photos.slice(500, 1000));
+      const chunk3Links = linkRowsFor(photos.slice(1000));
 
       const tagRows = Array.from({ length: tagCount }, (_, i) => ({
         uuid: `tag-${i}`,
         label: `Tag ${i}`,
       }));
 
-      // Two-pass: pass1 (3 chunks of 500) -> tags -> pass2 (3 chunks of 500) = 7 queries
+      // Один проход на чанк (#224): join1 → tags (все 100) → join2 → join3.
+      // Первый join-чанк покрывает всё множество тегов, остальные чанки
+      // используют общий кеш (одна выборка, без повторной гидратации).
       const mock = createMockExecutor(
         [
-          [linkRows],       // pass1 chunk 1
-          [linkRows],       // pass1 chunk 2
-          [linkRows],       // pass1 chunk 3
-          [tagRows],        // tags
-          [linkRows],       // pass2 chunk 1
-          [linkRows],       // pass2 chunk 2
-          [linkRows],       // pass2 chunk 3
+          [chunk1Links], // join chunk 1
+          [tagRows], // tags
+          [chunk2Links], // join chunk 2 (всё в кеше)
+          [chunk3Links], // join chunk 3 (всё в кеше)
         ],
         { sequential: true },
       );
@@ -394,17 +406,15 @@ describe('#86: батчинг loadRelations', () => {
         ['tags'],
       );
 
-      // Verify two-pass query pattern: 3 pass1 + 1 tags + 3 pass2 = 7 queries
-      expect(mock.queries).toHaveLength(7);
-      const pass1Chunks = mock.queries.slice(0, 3);
-      const pass2Chunks = mock.queries.slice(4, 7);
-      expect(pass1Chunks.map((q) => Object.keys(q.params).length)).toEqual([
-        500, 500, 500,
-      ]);
-      expect(pass2Chunks.map((q) => Object.keys(q.params).length)).toEqual([
-        500, 500, 500,
-      ]);
-      expect(Object.keys(mock.queries[3].params)).toHaveLength(tagCount);
+      // Verify per-chunk single-read query pattern: 3 join reads + 1 tags = 4 queries.
+      expect(mock.queries).toHaveLength(4);
+      // Join chunks at indices 0, 2, 3; tags at index 1.
+      expect(
+        [mock.queries[0], mock.queries[2], mock.queries[3]].map(
+          (q) => Object.keys(q.params).length,
+        ),
+      ).toEqual([500, 500, 500]);
+      expect(Object.keys(mock.queries[1].params)).toHaveLength(tagCount);
 
       // Verify results are correct
       for (const photo of photos) {
@@ -413,11 +423,93 @@ describe('#86: батчинг loadRelations', () => {
 
       // Spot-check a few owners
       expect(photos[0].tags?.map((t) => t.uuid).sort()).toEqual(
-        Array.from({ length: tagsPerOwner }, (_, j) => `tag-${j % tagCount}`).sort(),
+        Array.from(
+          { length: tagsPerOwner },
+          (_, j) => `tag-${j % tagCount}`,
+        ).sort(),
       );
       expect(photos[999].tags?.map((t) => t.uuid).sort()).toEqual(
-        Array.from({ length: tagsPerOwner }, (_, j) => `tag-${(999 * tagsPerOwner + j) % tagCount}`).sort(),
+        Array.from(
+          { length: tagsPerOwner },
+          (_, j) => `tag-${(999 * tagsPerOwner + j) % tagCount}`,
+        ).sort(),
       );
+    });
+
+    it('почанковое чтение join-таблицы ровно один раз и каждый inverse FK резолвится (#224)', async () => {
+      // 600 владельцев → 2 чанка (500 + 100).
+      const ownerCount = 600;
+      const photos = Array.from({ length: ownerCount }, (_, i) => {
+        const photo = new BatchPhotoEntity();
+        photo.uuid = `p${String(i).padStart(4, '0')}`;
+        photo.title = '';
+        photo.user_uuid = '';
+        photo.profile_uuid = '';
+        return photo;
+      });
+
+      // Чанк 1: первые 500 владельцев → tag-A/B/C.
+      // Чанк 2: остальные 100 владельцев → tag-C/D/E. tag-C общий (проверка
+      // общего инстанса между чанками), tag-D/E появляются ТОЛЬКО во втором
+      // чтении — если бы сущности выбирались до перечитывания (старый
+      // двухпроходной алгоритм), эти FK были бы потеряны/не резолвились.
+      const chunk1Rows = photos.slice(0, 500).flatMap((p) =>
+        ['tag-A', 'tag-B', 'tag-C'].map((tag) => ({
+          photo_uuid: p.uuid,
+          tag_uuid: tag,
+        })),
+      );
+      const chunk2Rows = photos.slice(500).flatMap((p) =>
+        ['tag-C', 'tag-D', 'tag-E'].map((tag) => ({
+          photo_uuid: p.uuid,
+          tag_uuid: tag,
+        })),
+      );
+
+      const fromIds = (ids: string[]) =>
+        ids.map((uuid) => ({ uuid, label: uuid }));
+
+      // Строгая сценарная очередь: каждый join-чанк читается РОВНО один раз
+      // (нет второго прохода → нет гонки pass1/pass2), а выборка тегов
+      // резолвит каждый встреченный inverse FK (в т.ч. C/D/E из чанка 2).
+      // Порядок исполнения: join1 → tags(A,B,C) → join2 → tags(D,E).
+      const db = createScriptedExecutor({ label: 'm2m' });
+      db.expect('FROM `batch86_photo_tag`').returnsRows(...chunk1Rows);
+      db.expect('FROM `batch86_tags`').returnsRows(
+        ...fromIds(['tag-A', 'tag-B', 'tag-C']),
+      );
+      db.expect('FROM `batch86_photo_tag`').returnsRows(...chunk2Rows);
+      db.expect('FROM `batch86_tags`').returnsRows(
+        ...fromIds(['tag-D', 'tag-E']),
+      );
+      BatchPhotoEntity.setExecutor(db.executor);
+      BatchTagEntity.setExecutor(db.executor);
+
+      await getOrCreateRepository(BatchPhotoEntity).relations.loadRelations(
+        photos,
+        ['tags'],
+      );
+      db.assertComplete();
+
+      // Результат эквивалентен согласованному одиночному чтению: ни один
+      // встреченный inverse FK (включая tag-D/E из второго чанка) не потерян.
+      expect(photos[0].tags?.map((t) => t.uuid)).toEqual([
+        'tag-A',
+        'tag-B',
+        'tag-C',
+      ]);
+      expect(photos[599].tags?.map((t) => t.uuid)).toEqual([
+        'tag-C',
+        'tag-D',
+        'tag-E',
+      ]);
+
+      // Общий инверсный FK (tag-C) разделяется между владельцами из РАЗНЫХ
+      // чанков одним инстансом (общий кеш по PK, без повторной гидратации).
+      const chunk1TagC = photos[0].tags!.find((t) => t.uuid === 'tag-C');
+      const chunk2TagC = photos[500].tags!.find((t) => t.uuid === 'tag-C');
+      expect(chunk1TagC).toBeDefined();
+      expect(chunk2TagC).toBe(chunk1TagC);
     });
   });
 
@@ -523,6 +615,58 @@ describe('#86: батчинг loadRelations', () => {
       expect(trxMock.queries[0].sql).toContain('FROM `batch86_photo_tag`');
       expect(trxMock.queries[1].sql).toContain('FROM `batch86_tags`');
       expect(photos[0].tags?.[0]?.uuid).toBe('tag-x');
+    });
+
+    it('явный { trx } многочанкового m2m: и join-чтения, и выборки тегов — в транзакции (#224)', async () => {
+      // 600 владельцев → 2 join-чанка; разные теги в каждом чанке → 2 выборки
+      // тегов. Все 4 запроса обязаны уйти в { trx }, не в executor БД.
+      const ownerCount = 600;
+      const photos = Array.from({ length: ownerCount }, (_, i) => {
+        const photo = new BatchPhotoEntity();
+        photo.uuid = `p${String(i).padStart(4, '0')}`;
+        photo.title = '';
+        photo.user_uuid = '';
+        photo.profile_uuid = '';
+        return photo;
+      });
+
+      const chunk1Rows = photos.slice(0, 500).map((p) => ({
+        photo_uuid: p.uuid,
+        tag_uuid: 'tag-A',
+      }));
+      const chunk2Rows = photos.slice(500).map((p) => ({
+        photo_uuid: p.uuid,
+        tag_uuid: 'tag-B',
+      }));
+
+      const dbMock = createMockExecutor([[]]);
+      // Порядок исполнения: join1 → tags(A) → join2 → tags(B) — все в { trx }.
+      const trxMock = createMockExecutor(
+        [
+          [chunk1Rows], // join chunk 1
+          [[{ uuid: 'tag-A', label: 'A' }]], // tags chunk1
+          [chunk2Rows], // join chunk 2
+          [[{ uuid: 'tag-B', label: 'B' }]], // tags chunk2
+        ],
+        { sequential: true },
+      );
+      BatchPhotoEntity.setExecutor(dbMock.executor);
+      BatchTagEntity.setExecutor(dbMock.executor);
+
+      await getOrCreateRepository(BatchPhotoEntity).relations.loadRelations(
+        photos,
+        ['tags'],
+        { trx: trxMock.executor },
+      );
+
+      expect(dbMock.queries).toHaveLength(0);
+      expect(trxMock.queries).toHaveLength(4);
+      expect(trxMock.queries[0].sql).toContain('FROM `batch86_photo_tag`');
+      expect(trxMock.queries[1].sql).toContain('FROM `batch86_tags`');
+      expect(trxMock.queries[2].sql).toContain('FROM `batch86_photo_tag`');
+      expect(trxMock.queries[3].sql).toContain('FROM `batch86_tags`');
+      expect(photos[0].tags?.[0]?.uuid).toBe('tag-A');
+      expect(photos[599].tags?.[0]?.uuid).toBe('tag-B');
     });
 
     it('ambient-контекст: батч-запрос one-to-many идёт в активную транзакцию без { trx }', async () => {

--- a/test/many-to-many-pk-types.spec.ts
+++ b/test/many-to-many-pk-types.spec.ts
@@ -254,6 +254,7 @@ describe('many-to-many join tables derived from actual PKs (#90)', () => {
       Object.keys(schema.columns).sort(),
     );
 
+    // Single-pass: 1 join-table result set + 1 sku result set
     const mock = setup([[[orderRow]], [linkRows], [skuRows]]);
     OrderEntity.setExecutor(mock.executor);
 
@@ -302,7 +303,7 @@ describe('many-to-many join tables derived from actual PKs (#90)', () => {
       },
     ];
 
-    // loadRelations делает ровно два запроса: join-select, затем выборка target
+    // loadRelations делает 2 запроса: join-select, затем выборка target
     const mock = setup([[link], [[authorRow]]]);
     ArticleEntity.setExecutor(mock.executor);
 
@@ -379,10 +380,10 @@ describe('many-to-many join tables derived from actual PKs (#90)', () => {
     ];
 
     const mock = setup([
-      [linkFromParent],
-      [childRows],
-      [linkFromChild],
-      [[{ parent_id: 2n, name: 'p2' }, parentRow]],
+      [linkFromParent], // parent loadRelations: join
+      [childRows], // parent loadRelations: children
+      [linkFromChild], // child loadRelations: join
+      [[{ parent_id: 2n, name: 'p2' }, parentRow]], // child loadRelations: parents
     ]);
 
     SymParentEntity.setExecutor(mock.executor);
@@ -408,7 +409,7 @@ describe('many-to-many join tables derived from actual PKs (#90)', () => {
   });
 
   it('rejects conflicting join-table declarations at runtime with a clear error (#139)', async () => {
-    const mock = setup([[]]);
+    const mock = setup([[], []]);
     ConflictLeftEntity.setExecutor(mock.executor);
 
     const left = new ConflictLeftEntity();
@@ -424,13 +425,16 @@ describe('many-to-many join tables derived from actual PKs (#90)', () => {
 
   it('eager loading fails on the same conflict as schema generation (#139)', async () => {
     // Строка владельца нужна, чтобы eager-загрузка дошла до резолва join-таблицы
-    const mock = setup([[[{ left_id: 1n, name: 'L' }]]]);
+    const mock = setup([[], []]);
     ConflictLeftEntity.setExecutor(mock.executor);
 
-    await expect(ConflictLeftEntity.findAll()).rejects.toThrow(
+    const left = new ConflictLeftEntity();
+    left.left_id = 1n;
+
+    await expect(left.loadRelations(['rights'])).rejects.toThrow(
       /Conflicting definitions for many-to-many join table "rt_conflict_join"/,
     );
-    await expect(ConflictLeftEntity.findAll()).rejects.toThrow(
+    await expect(left.loadRelations(['rights'])).rejects.toThrow(
       /ConflictLeftEntity\.rights[\s\S]*ConflictRightEntity\.lefts/,
     );
   });

--- a/test/nested-eager.spec.ts
+++ b/test/nested-eager.spec.ts
@@ -325,13 +325,14 @@ function trxChainMock(
   const linkRows = [{ photo_uuid: 'p1', tag_uuid: 't1' }];
   const tagRows = [{ uuid: 't1', name: 'x', owner_uuid: 'u1' }];
   const userRows = [{ uuid: 'u1', login: 'alice' }];
+  // Single-pass order: join -> tags -> users -> user hook -> tag hook
   return dbMockFactory(
     [
-      [linkRows],
-      [tagRows],
-      [userRows],
-      [[{ cnt: 1 }]], // COUNT из afterFind user-хука
-      [[{ cnt: 1 }]], // COUNT из отложенного afterFind tag-хука
+      [linkRows], // query 0: join table (single pass)
+      [tagRows], // query 1: tags
+      [userRows], // query 2: users (owner)
+      [[{ cnt: 1 }]], // query 3: COUNT из afterFind user-хука (leaf)
+      [[{ cnt: 1 }]], // query 4: COUNT из отложенного afterFind tag-хука (intermediate)
     ],
     { sequential: true },
   );
@@ -833,6 +834,7 @@ describe('#16: вложенная eager-load', () => {
     }
 
     expect(dbMock.queries).toHaveLength(0);
+    // Ambient mode: 5 queries (join + tags + users + 2 hooks)
     expect(trxMock.queries).toHaveLength(5);
     expect(trxHookCalls).toEqual(['user:u1', 'tag:t1:owner=u1']);
   });

--- a/test/nestjs/relations.spec.ts
+++ b/test/nestjs/relations.spec.ts
@@ -42,8 +42,10 @@ const photoRow = {
   title: 'Sunset',
 };
 
-async function createTestingModule(rows: any[][]) {
-  const mock = createMockExecutor(rows);
+async function createTestingModule(rows: any[][][]) {
+  // rows[0] = result sets for query 0 (find), rows[1] = result sets for query 1 (join pass 1), etc.
+  // Each element is any[][] (array of result sets)
+  const mock = createMockExecutor(rows, { sequential: true });
 
   const module = await Test.createTestingModule({
     imports: [
@@ -71,8 +73,8 @@ async function createTestingModule(rows: any[][]) {
 describe('NestJS integration: relations', () => {
   it('eager-loads one-to-one relation with IN query', async () => {
     const { module, mock } = await createTestingModule([
-      [profileRow],
-      [userRow],
+      [[profileRow]], // query 0: find user_profiles
+      [[userRow]], // query 1: eager load user
     ]);
 
     await UserProfileEntity.findByUuid(profileRow.uuid);
@@ -85,21 +87,26 @@ describe('NestJS integration: relations', () => {
   });
 
   it('eager-loads many-to-many relation via join table', async () => {
-    const { module, mock } = await createTestingModule([[photoRow], [], []]);
+    const { module, mock } = await createTestingModule([
+      [[photoRow]], // query 0: find photos_with_tags
+      [[]], // query 1: photo_tag (single pass)
+    ]);
 
     await PhotoWithTagsEntity.findByUuid(photoRow.uuid);
 
     expect(mock.queries[0].sql).toContain('FROM `photos_with_tags`');
     expect(mock.queries[1].sql).toContain('FROM `photo_tag`');
     expect(mock.queries[1].sql).toContain('`photos_with_tags_uuid` IN');
-    // #86: join-таблица вернула ноль ссылок — выборка тегов не выполняется.
+    // Single-pass: 1 photo + 1 join = 2 queries
     expect(mock.queries).toHaveLength(2);
 
     await module.close();
   });
 
   it('loadRelations loads many-to-many for single entity', async () => {
-    const { module, mock } = await createTestingModule([[photoRow], [], []]);
+    const { module, mock } = await createTestingModule([
+      [[]], // query 0: photo_tag (single pass)
+    ]);
 
     const photo = new PhotoWithTagsEntity();
     photo.uuid = photoRow.uuid;
@@ -107,7 +114,7 @@ describe('NestJS integration: relations', () => {
     await photo.loadRelations(['tags']);
 
     expect(mock.queries[0].sql).toContain('FROM `photo_tag`');
-    // #86: join-таблица вернула ноль ссылок — выборка тегов не выполняется.
+    // Single-pass: 1 join query
     expect(mock.queries).toHaveLength(1);
 
     await module.close();


### PR DESCRIPTION
closes #209

- Refactor loadManyToManyRelation to use two-pass approach for multi-chunk queries:
  * Pass 1: stream join-table chunks, collect unique inverse FKs
  * Fetch inverse entities (batched, deduped)
  * Pass 2: stream join-table chunks again, directly populate result Map
- Single-chunk queries use original single-pass algorithm for compatibility
- Add deduplication guard in pass 2 for robustness
- Update tests to reflect new query patterns
- Add regression test for large many-to-many relation (1500 owners, 15000 links)