### PR TITLE
fix(query): compose multiple JSON predicates on the same column (#201)

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,19 @@ await EventEntity.query()
   .getMany();
 ```
 
+Несколько JSON-предикатов для одной колонки не перезаписывают друг друга,
+а объединяются через `AND` (#201):
+
+```ts
+// metadata: $.settings.theme существует И $.role = 'admin'
+await EventEntity.query()
+  .andWhereJsonExists('metadata', '$.settings.theme')
+  .andWhereJsonValue('metadata', '$.role', 'admin')
+  .getMany();
+// WHERE (JSON_EXISTS(`metadata`, $metadata_0_jsonexists)
+//    AND JSON_VALUE(`metadata`, $metadata_1_jsonvalue_path) = $metadata_1_jsonvalue_val)
+```
+
 ## Schema sync
 
 ### Standalone

--- a/src/persistence/entity-persistence.ts
+++ b/src/persistence/entity-persistence.ts
@@ -769,12 +769,13 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
       );
       const subConditions: string[] = [];
       for (const [op, operand] of opEntries) {
-        const condition = this.buildSingleOperatorCondition(
+        const condition = await this.buildSingleOperatorCondition(
           field,
           op,
           operand,
           ctx,
           isRoot,
+          env,
         );
         if (condition) subConditions.push(condition);
       }
@@ -814,15 +815,18 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 
   /**
-   * Строит условие для одного оператора над полем.
+   * Строит условие для одного оператора над полем. Логические `$and`/`$or`
+   * на уровне значения поля (#201) рекурсивно строят вложенные условия той же
+   * колонки — это делает JSON-предикаты (JSON_EXISTS/JSON_VALUE) композируемыми.
    */
-  private buildSingleOperatorCondition(
+  private async buildSingleOperatorCondition(
     field: string,
     op: string,
     operand: any,
     ctx: WhereBuildContext,
     isRoot: boolean,
-  ): string | undefined {
+    env: WhereBuildEnv,
+  ): Promise<string | undefined> {
     const meta = this.getMeta();
     const dbSchema = getEntityDbSchema(meta);
     const fieldType = dbSchema[field];
@@ -836,6 +840,28 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
     };
 
     switch (op) {
+      case '$and':
+      case '$or': {
+        if (!Array.isArray(operand) || operand.length === 0) {
+          throw new Error(
+            `Operator "${op}" on field "${field}" requires a non-empty array of conditions.`,
+          );
+        }
+        const combiner = op === '$and' ? 'AND' : 'OR';
+        const subs: string[] = [];
+        for (const sub of operand) {
+          const subSql = await this.buildFieldCondition(
+            field,
+            sub,
+            ctx,
+            false,
+            env,
+          );
+          if (subSql) subs.push(subSql);
+        }
+        if (!subs.length) return undefined;
+        return subs.length === 1 ? subs[0] : `(${subs.join(` ${combiner} `)})`;
+      }
       case '$eq': {
         if (operand === null) return `${quotedField} IS NULL`;
         if (operand === undefined) return undefined;

--- a/src/query/query-builder.ts
+++ b/src/query/query-builder.ts
@@ -35,7 +35,9 @@ type EntityClass<T extends YdbBaseEntity> = {
 /**
  * Цепочный query builder поверх Active Record сущности.
  * Условия where/andWhere — только равенство, объединяются через AND
- * (повторное поле в andWhere перезаписывает предыдущее).
+ * (повторное поле в andWhere перезаписывает предыдущее). JSON-предикаты
+ * (andWhereJsonExists/andWhereJsonValue) для одной колонки НЕ перезаписывают
+ * друг друга, а компонуются через AND (#201).
  * Зашифрованные поля с blind index поддерживаются так же, как в find/findAll.
  *
  * Билдер переиспользуем: методы-строители (where/orderBy/limit/... ) и методы
@@ -99,27 +101,58 @@ export class YdbQueryBuilder<T extends YdbBaseEntity> {
   }
 
   /**
-   * Добавить условие JSON_EXISTS для JSON-колонки.
+   * Добавить условие JSON_EXISTS для JSON-колонки (#201).
    * Колонка должна быть объявлена как `@YdbColumn('Json')`, `@YdbColumn('JsonDocument')`
    * или `@YdbJson()`.
+   *
+   * Несколько JSON-предикатов для одной колонки сохраняются и объединяются
+   * через AND (композиция через `$and`), а не перезаписывают друг друга.
    */
   andWhereJsonExists(column: string, path: string): this {
-    this.whereValues = {
-      ...this.whereValues,
-      [column]: { $jsonExists: path },
-    };
-    return this;
+    return this.appendJsonCondition(column, { $jsonExists: path });
   }
 
   /**
-   * Добавить условие JSON_VALUE = значение для JSON-колонки.
+   * Добавить условие JSON_VALUE = значение для JSON-колонки (#201).
    * Значение сравнивается как строка (Utf8).
+   *
+   * Несколько JSON-предикатов для одной колонки сохраняются и объединяются
+   * через AND (композиция через `$and`), а не перезаписывают друг друга.
    */
   andWhereJsonValue(column: string, path: string, value: any): this {
-    this.whereValues = {
-      ...this.whereValues,
-      [column]: { $jsonValue: { path, equals: value } },
-    };
+    return this.appendJsonCondition(column, {
+      $jsonValue: { path, equals: value },
+    });
+  }
+
+  /**
+   * Накопить JSON-предикат для колонки (#201). Существующий предикат той же
+   * колонки не перезаписывается: первым задаётся как есть, каждый следующий
+   * присоединяется через `$and` (явная AND-семантика).
+   */
+  private appendJsonCondition(
+    column: string,
+    predicate: Record<string, any>,
+  ): this {
+    const existing: unknown = this.whereValues[column];
+    const isJsonGroup =
+      existing !== null &&
+      typeof existing === 'object' &&
+      !Array.isArray(existing) &&
+      Object.keys(existing).length === 1 &&
+      Array.isArray((existing as { $and: unknown }).$and);
+    let next: unknown;
+    if (existing === undefined) {
+      next = predicate;
+    } else if (isJsonGroup) {
+      // Уже накопленная группа — дополняем плоский список `$and`.
+      const members = (existing as { $and: unknown[] }).$and;
+      next = { $and: [...members, predicate] };
+    } else {
+      // Любое предыдущее значение той же колонки сохраняется в группу.
+      next = { $and: [existing, predicate] };
+    }
+    this.whereValues = { ...this.whereValues, [column]: next };
     return this;
   }
 

--- a/test/json-doc.spec.ts
+++ b/test/json-doc.spec.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata';
 import { JsonDocEntity } from './fixtures/json_doc/json-doc.entity.js';
 import { createMockExecutor } from './helpers/mock-executor.js';
-import { Utf8, Json, JsonDocument } from '@ydbjs/value/primitive';
+import { Utf8, Json, JsonDocument, Uuid } from '@ydbjs/value/primitive';
 
 const uuid = '5ad91505-d4f6-4a81-ab65-9dbc68cf4ed5';
 const metadata = { role: 'admin', settings: { theme: 'dark' } };
@@ -161,6 +161,133 @@ describe('JSON columns', () => {
       );
       expect((q.params.metadata_0_jsonvalue_path as any).value).toBe('$.role');
       expect((q.params.metadata_0_jsonvalue_val as any).value).toBe('admin');
+    });
+
+    it('composes three JSON_EXISTS on the same column with AND (#201)', async () => {
+      const mock = createMockExecutor([[]]);
+      JsonDocEntity.setExecutor(mock.executor);
+
+      await JsonDocEntity.query()
+        .andWhereJsonExists('metadata', '$.settings.theme')
+        .andWhereJsonExists('metadata', '$.security.role')
+        .andWhereJsonExists('metadata', '$.owner.id')
+        .getMany();
+
+      const [q] = mock.queries;
+      expect(q.sql).toContain(
+        'WHERE (JSON_EXISTS(`metadata`, $metadata_0_jsonexists) ' +
+          'AND JSON_EXISTS(`metadata`, $metadata_1_jsonexists) ' +
+          'AND JSON_EXISTS(`metadata`, $metadata_2_jsonexists))',
+      );
+      expect((q.params.metadata_0_jsonexists as any).value).toBe(
+        '$.settings.theme',
+      );
+      expect((q.params.metadata_1_jsonexists as any).value).toBe(
+        '$.security.role',
+      );
+      expect((q.params.metadata_2_jsonexists as any).value).toBe('$.owner.id');
+    });
+
+    it('composes mixed JSON_EXISTS + JSON_VALUE on the same column (#201)', async () => {
+      const mock = createMockExecutor([[]]);
+      JsonDocEntity.setExecutor(mock.executor);
+
+      await JsonDocEntity.query()
+        .andWhereJsonExists('metadata', '$.settings.theme')
+        .andWhereJsonValue('metadata', '$.role', 'admin')
+        .getMany();
+
+      const [q] = mock.queries;
+      expect(q.sql).toContain(
+        'WHERE (JSON_EXISTS(`metadata`, $metadata_0_jsonexists) ' +
+          'AND JSON_VALUE(`metadata`, $metadata_1_jsonvalue_path) ' +
+          '= $metadata_1_jsonvalue_val)',
+      );
+      expect((q.params.metadata_0_jsonexists as any).value).toBe(
+        '$.settings.theme',
+      );
+      expect((q.params.metadata_1_jsonvalue_path as any).value).toBe('$.role');
+      expect((q.params.metadata_1_jsonvalue_val as any).value).toBe('admin');
+    });
+
+    it('composes two JSON_VALUE on the same column with AND (#201)', async () => {
+      const mock = createMockExecutor([[]]);
+      JsonDocEntity.setExecutor(mock.executor);
+
+      await JsonDocEntity.query()
+        .andWhereJsonValue('metadata', '$.role', 'admin')
+        .andWhereJsonValue('metadata', '$.theme', 'dark')
+        .getMany();
+
+      const [q] = mock.queries;
+      expect(q.sql).toContain(
+        'WHERE (JSON_VALUE(`metadata`, $metadata_0_jsonvalue_path) ' +
+          '= $metadata_0_jsonvalue_val ' +
+          'AND JSON_VALUE(`metadata`, $metadata_1_jsonvalue_path) ' +
+          '= $metadata_1_jsonvalue_val)',
+      );
+      expect((q.params.metadata_0_jsonvalue_val as any).value).toBe('admin');
+      expect((q.params.metadata_1_jsonvalue_val as any).value).toBe('dark');
+    });
+
+    it('composes JSON predicates with ordinary where/andWhere criteria (#201)', async () => {
+      const mock = createMockExecutor([[]]);
+      JsonDocEntity.setExecutor(mock.executor);
+
+      await JsonDocEntity.query()
+        .where({ uuid })
+        .andWhereJsonExists('metadata', '$.settings.theme')
+        .andWhereJsonValue('metadata', '$.role', 'admin')
+        .getMany();
+
+      const [q] = mock.queries;
+      expect(q.sql).toContain(
+        'WHERE `uuid` = $uuid AND (JSON_EXISTS(`metadata`, $metadata_0_jsonexists) ' +
+          'AND JSON_VALUE(`metadata`, $metadata_1_jsonvalue_path) ' +
+          '= $metadata_1_jsonvalue_val)',
+      );
+      expect(q.params.uuid).toBeInstanceOf(Uuid);
+      expect(String(q.params.uuid)).toBe(uuid);
+    });
+
+    it('keeps JSON predicates intact inside an $or group (#201)', async () => {
+      const mock = createMockExecutor([[]]);
+      JsonDocEntity.setExecutor(mock.executor);
+
+      await JsonDocEntity.query()
+        .andWhereJsonValue('metadata', '$.role', 'admin')
+        .orWhere({ uuid })
+        .getMany();
+
+      const [q] = mock.queries;
+      expect(q.sql).toContain(
+        'WHERE (JSON_VALUE(`metadata`, $metadata_0_jsonvalue_path) ' +
+          '= $metadata_0_jsonvalue_val OR `uuid` = $uuid_1_eq)',
+      );
+      expect((q.params.metadata_0_jsonvalue_val as any).value).toBe('admin');
+      expect(q.params.uuid_1_eq).toBeInstanceOf(Uuid);
+      expect(String(q.params.uuid_1_eq)).toBe(uuid);
+    });
+
+    it('builds composed JSON predicates from a hand-written $and object (#201)', async () => {
+      const mock = createMockExecutor([[]]);
+      JsonDocEntity.setExecutor(mock.executor);
+
+      await JsonDocEntity.find({
+        metadata: {
+          $and: [
+            { $jsonExists: '$.settings.theme' },
+            { $jsonValue: { path: '$.role', equals: 'admin' } },
+          ],
+        },
+      });
+
+      const [q] = mock.queries;
+      expect(q.sql).toContain(
+        'WHERE (JSON_EXISTS(`metadata`, $metadata_0_jsonexists) ' +
+          'AND JSON_VALUE(`metadata`, $metadata_1_jsonvalue_path) ' +
+          '= $metadata_1_jsonvalue_val)',
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #201: JSON predicates from `andWhereJsonExists()` / `andWhereJsonValue()` were stored directly under the JSON column name, so a later predicate for the same column silently **overwrote** the previous one.

## Changes

- **`src/query/query-builder.ts`** — JSON predicates now accumulate through the existing `$and` AST via a private `appendJsonCondition()` helper: the first predicate for a column is stored as-is; each subsequent one joins a flat `$and` group instead of replacing the value. Explicit AND semantics.
- **`src/persistence/entity-persistence.ts`** — `buildFieldCondition`/`buildSingleOperatorCondition` now understand `$and`/`$or` at field-operator level, recursively building sub-conditions of the same column. This makes composed JSON predicates (and hand-written `{ col: { $and: [...] } }`) build correctly while keeping the existing `JSON_EXISTS`/`JSON_VALUE` generation and parameterization untouched. Also supports `$or` at field level for symmetry.
- **`test/json-doc.spec.ts`** — regression tests: 3× JSON_EXISTS on one column, mixed JSON_EXISTS + JSON_VALUE, 2× JSON_VALUE, interaction with ordinary `where()` criteria, JSON predicates surviving inside an `$or` group, and a hand-written `$and` object via `find()`.
- **`README.md`** — small doc note on AND composition.

## Verification

- Focused tests: `test/json-doc.spec.ts`, `src/query/query-builder.spec.ts`, `test/where-operators.spec.ts` — pass
- Full suite: 87 suites / 1384 tests pass
- `yarn build` — ok
- `yarn lint` — 0 errors (only pre-existing warnings)