### PR TITLE
fix(migrations): make contentChanged status non-applied

### DIFF
--- a/README.md
+++ b/README.md
@@ -1277,6 +1277,8 @@ export default {
 
 `YdbMigrationRunner` (run/revert/status, восстановление после сбоев — `markMigrationApplied`/`removeMigrationRecord`), `loadMigrationsFromDir`, `planMigration`, `executeSql` экспортируются из пакета — можно встроить миграции в свой пайплайн.
 
+В `YdbMigrationStatus` поле `applied` равно `true` **только** для здорово применённой миграции: изменённая после применения (`contentChanged`) и прерванная (`interrupted`) миграции — не `applied` (флаг несёт истинную причину); orphan-записи информационны. Не полагайтесь на `applied` как на «есть запись учёта» — проверяйте готовность через `evaluateMigrationCheck`/`migration:check`.
+
 ---
 
 ## Разработка

--- a/examples/09-migrations/main.ts
+++ b/examples/09-migrations/main.ts
@@ -11,7 +11,8 @@
  *  - выполнение учитывается в таблице `ydb_migrations`;
  *  - повторный run() ничего не делает (миграции уже применены);
  *  - revert() откатывает последнюю применённую;
- *  - статус: pending/applied/interrupted.
+ *  - статус: pending/applied/interrupted/modified (после применения файлы
+ *    менять нельзя — содержимое фиксируется хешем, #101/#212).
  */
 import { fileURLToPath } from 'node:url';
 import {
@@ -20,8 +21,16 @@ import {
   loadMigrationsFromDir,
   mapToYdb,
   YdbMigrationRunner,
+  type YdbMigrationStatus,
 } from '../../src/index.js';
 import { buildYdbOptions } from '../shared/options.js';
+
+/** Человекочитаемое состояние миграции (причины не схлопываются в pending). */
+function renderStatus(status: YdbMigrationStatus): string {
+  if (status.contentChanged) return 'modified after apply';
+  if (status.interrupted) return 'interrupted';
+  return status.applied ? 'applied' : 'pending';
+}
 
 async function main(): Promise<void> {
   const dbOptions = buildYdbOptions();
@@ -44,9 +53,7 @@ async function main(): Promise<void> {
     const statusBefore = await runner.status(migrations);
     console.log(
       'Статус до run:',
-      statusBefore.map(
-        (s) => `${s.name} -> ${s.applied ? 'applied' : 'pending'}`,
-      ),
+      statusBefore.map((s) => `${s.name} -> ${renderStatus(s)}`),
     );
 
     // --- Применяем всё ---
@@ -80,9 +87,7 @@ async function main(): Promise<void> {
     const statusAfter = await runner.status(migrations);
     console.log(
       'Статус после run:',
-      statusAfter.map(
-        (s) => `${s.name} -> ${s.applied ? 'applied' : 'pending'}`,
-      ),
+      statusAfter.map((s) => `${s.name} -> ${renderStatus(s)}`),
     );
 
     // --- Откат последней миграции ---

--- a/src/cli/migration-verify.spec.ts
+++ b/src/cli/migration-verify.spec.ts
@@ -614,6 +614,47 @@ describe('runMigrationVerification (#152)', () => {
       });
     });
 
+    it('#212: content-changed migration is applied=false in JSON, state=modified', async () => {
+      const mock = makeRecordingExecutor();
+      const io = makeIo();
+
+      await runMigrationVerification({
+        command: 'migration:check',
+        migrationsDir: './migrations',
+        json: true,
+        connect: makeConnect(mock.executor),
+        loadMigrations: () =>
+          Promise.resolve(
+            makeMigrations([{ name: '1-Tampered', hash: 'new' }]),
+          ),
+        inspectBookkeeping: makeInspect([
+          { name: '1-Tampered', timestamp: 12345, hash: 'old' },
+        ]),
+        io,
+      });
+
+      const report = JSON.parse(io.stdoutLines.join('\n'));
+      expect(report).toMatchObject({
+        ready: false,
+        state: 'modified',
+        states: ['modified'],
+        exitCode: 4,
+        applied: false,
+        appliedCount: 0,
+        modified: ['1-Tampered'],
+        pending: [],
+      });
+      expect(report.migrations[0]).toEqual({
+        name: '1-Tampered',
+        applied: false,
+        appliedAt: new Date(12345).toISOString(),
+        interrupted: false,
+        orphan: false,
+        contentChanged: true,
+      });
+      mock.expectNoSqlAtAll();
+    });
+
     it('schema drift: structured issues included', async () => {
       const mock = makeRecordingExecutor();
       const io = makeIo();
@@ -765,7 +806,7 @@ describe('renderStatusLine (#152)', () => {
       renderStatusLine({ name: 'a', applied: true, interrupted: true }),
     ).toBe('[~] a — interrupted, resolve via migration:repair');
     expect(
-      renderStatusLine({ name: 'a', applied: true, contentChanged: true }),
+      renderStatusLine({ name: 'a', applied: false, contentChanged: true }),
     ).toContain('[#] a — content changed after apply');
     expect(renderStatusLine({ name: 'a', applied: true, orphan: true })).toBe(
       '[!] a — orphan record (no matching migration file)',
@@ -773,7 +814,7 @@ describe('renderStatusLine (#152)', () => {
     expect(
       renderStatusLine({
         name: 'a',
-        applied: true,
+        applied: false,
         orphan: true,
         interrupted: true,
       }),
@@ -781,7 +822,7 @@ describe('renderStatusLine (#152)', () => {
     expect(
       renderStatusLine({
         name: 'a',
-        applied: true,
+        applied: false,
         interrupted: true,
         contentChanged: true,
       }),

--- a/src/cli/migration-verify.ts
+++ b/src/cli/migration-verify.ts
@@ -273,6 +273,9 @@ export function buildJsonReport(
 ): Record<string, unknown> {
   const migrations: JsonMigrationEntry[] = statuses.map((s) => ({
     name: s.name,
+    // `applied` в отчёте — только здорово применённая (#212): изменённая
+    // после применения и прерванная миграции не считаются applied
+    // независимо от значения поля статуса (producer уже даёт false).
     applied: s.applied && !s.interrupted && !s.contentChanged,
     appliedAt: isoOrNull(s.appliedAt),
     interrupted: s.interrupted === true,

--- a/src/migrations/migration-check.spec.ts
+++ b/src/migrations/migration-check.spec.ts
@@ -71,16 +71,40 @@ describe('evaluateMigrationCheck (#152)', () => {
   });
 
   it('modified after apply (#101) is its own state', () => {
+    // #212: producer даёт applied=false для изменённой миграции.
     const verdict = evaluateMigrationCheck([
-      status({ name: 'a', applied: true, contentChanged: true }),
+      status({ name: 'a', contentChanged: true }),
     ]);
 
     expect(verdict.modified).toEqual(['a']);
     expect(verdict.pending).toEqual([]);
     expect(verdict.interrupted).toEqual([]);
+    expect(verdict.appliedCount).toBe(0);
     expect(verdict.ready).toBe(false);
     expect(verdict.state).toBe('modified');
     expect(migrationStateExitCode(verdict.state)).toBe(4);
+  });
+
+  it('#212: a content-changed migration can never satisfy the healthy-applied condition', () => {
+    // Обе формы входа (новая from producer и legacy/ручная с applied=true)
+    // дают один вердикт: не готово, state=modified, appliedCount=0.
+    const inputs: YdbMigrationStatus[][] = [
+      [status({ name: 'm', contentChanged: true })],
+      [status({ name: 'm', applied: true, contentChanged: true })],
+    ];
+
+    for (const list of inputs) {
+      expect(
+        list[0].applied && !list[0].contentChanged && !list[0].interrupted,
+      ).toBe(false);
+
+      const verdict = evaluateMigrationCheck(list);
+      expect(verdict.ready).toBe(false);
+      expect(verdict.state).toBe('modified');
+      expect(verdict.appliedCount).toBe(0);
+      expect(verdict.modified).toEqual(['m']);
+      expect(verdict.pending).toEqual([]);
+    }
   });
 
   it('schema drift only when issues are passed', () => {
@@ -142,7 +166,7 @@ describe('evaluateMigrationCheck (#152)', () => {
       [
         status({ name: 'p' }),
         status({ name: 'i', applied: true, interrupted: true }),
-        status({ name: 'm', applied: true, contentChanged: true }),
+        status({ name: 'm', contentChanged: true }),
       ],
       { schemaIssues },
     );
@@ -159,7 +183,7 @@ describe('evaluateMigrationCheck (#152)', () => {
     expect(
       evaluateMigrationCheck([
         status({ name: 'p' }),
-        status({ name: 'm', applied: true, contentChanged: true }),
+        status({ name: 'm', contentChanged: true }),
       ]).state,
     ).toBe('modified');
 

--- a/src/migrations/migration-check.ts
+++ b/src/migrations/migration-check.ts
@@ -13,7 +13,8 @@
  *  - `schema-drift` — схема БД расходится с метаданными сущностей
  *    (проверяется только если в конфиге CLI заданы entities).
  *
- * Прерванные и изменённые миграции НЕ считаются успешно применёнными.
+ * Прерванные и изменённые миграции НЕ считаются успешно применёнными —
+ * у таких статусов `applied=false` (флаг «причина» сохранён, #212).
  * Orphan-записи (файл удалён после применения) — информационные: сами по
  * себе готовность не ломают, но всегда выводятся в отчёте.
  */
@@ -75,6 +76,16 @@ export function migrationStateExitCode(state: MigrationCheckState): number {
 }
 
 /**
+ * Здоровая «применённая» миграция (#212): единственная точка истины для
+ * «applied=true не означает проблему». Изменённая после применения и
+ * прерванная миграции сюда не проходят в любой форме входных данных —
+ * и новые (applied=false + флаг), и legacy/ручные (applied=true + флаг).
+ */
+function isHealthilyApplied(status: YdbMigrationStatus): boolean {
+  return status.applied && !status.interrupted && !status.contentChanged;
+}
+
+/**
  * Сводит статусы миграций (+ опциональные issues схемы) к вердикту.
  * Приоритет при нескольких состояниях: interrupted > modified >
  * pending > schema-drift — сначала то, что блокирует повторный запуск
@@ -100,8 +111,8 @@ export function evaluateMigrationCheck(
     }
     if (status.interrupted) interrupted.push(status.name);
     else if (status.contentChanged) modified.push(status.name);
-    else if (!status.applied) pending.push(status.name);
-    else appliedCount++;
+    else if (isHealthilyApplied(status)) appliedCount++;
+    else pending.push(status.name);
   }
 
   const found = new Set<Exclude<MigrationCheckState, 'ok'>>();

--- a/src/migrations/migration-runner.spec.ts
+++ b/src/migrations/migration-runner.spec.ts
@@ -991,7 +991,8 @@ describe('YdbMigrationRunner (#101)', () => {
         },
         {
           name: '2-Interrupted',
-          applied: true,
+          // #212: прерванная миграция не считается применённой.
+          applied: false,
           appliedAt: new Date(2000),
           interrupted: true,
         },
@@ -1042,7 +1043,8 @@ describe('YdbMigrationRunner (#101)', () => {
       expect(statuses).toEqual([
         {
           name: '1-Edited',
-          applied: true,
+          // #212: содержимое изменилось — это не «здорово применённая».
+          applied: false,
           appliedAt: new Date(5000),
           interrupted: false,
           contentChanged: true,
@@ -1070,6 +1072,61 @@ describe('YdbMigrationRunner (#101)', () => {
           contentChanged: undefined,
         },
       ]);
+    });
+
+    it('#212: never reports applied=true together with contentChanged/interrupted', async () => {
+      const cleanHash = sha256('clean');
+      const tampered = sha256('tampered');
+      const halfHash = sha256('halfway');
+      const mock = createStatefulExecutor({
+        rows: [
+          { timestamp: 1000, name: '1-Edited', hash: sha256('original') },
+          {
+            timestamp: 2000,
+            name: '2-Halfway',
+            hash: halfHash,
+            state: 'started',
+          },
+          { timestamp: 3000, name: '3-Clean', hash: cleanHash },
+        ],
+      });
+      const runner = new YdbMigrationRunner(mock.executor);
+
+      const statuses = await runner.status([
+        migrationFactory('1-Edited', { hash: tampered }).migration,
+        migrationFactory('2-Halfway', { hash: halfHash }).migration,
+        migrationFactory('3-Clean', { hash: cleanHash }).migration,
+      ]);
+
+      for (const status of statuses) {
+        if (status.contentChanged || status.interrupted) {
+          expect(status.applied).toBe(false);
+        }
+      }
+      const edited = statuses.find((s) => s.name === '1-Edited');
+      expect(edited).toMatchObject({ applied: false, contentChanged: true });
+      const halfway = statuses.find((s) => s.name === '2-Halfway');
+      expect(halfway).toMatchObject({ applied: false, interrupted: true });
+      const clean = statuses.find((s) => s.name === '3-Clean');
+      expect(clean).toMatchObject({ applied: true });
+    });
+
+    it('#212: a changed migration cannot satisfy the healthy-applied condition', async () => {
+      const mock = createStatefulExecutor({
+        rows: [{ timestamp: 7000, name: '1-Edited', hash: sha256('original') }],
+      });
+      const runner = new YdbMigrationRunner(mock.executor);
+
+      const [status] = await runner.status([
+        migrationFactory('1-Edited', { hash: sha256('tampered') }).migration,
+      ]);
+
+      expect(status.contentChanged).toBe(true);
+      expect(status.interrupted).toBe(false);
+      // Нормальное «здорово применено» такому статусу не подходит.
+      expect(
+        status.applied && !status.contentChanged && !status.interrupted,
+      ).toBe(false);
     });
   });
 

--- a/src/migrations/migration-runner.ts
+++ b/src/migrations/migration-runner.ts
@@ -34,6 +34,13 @@ export interface AppliedMigration {
 
 export interface YdbMigrationStatus {
   name: string;
+  /**
+   * Только «здорово применённая» миграция (#212): запись учёта есть,
+   * состояние не `started` и содержимое не менялось. Изменённая после
+   * применения (`contentChanged`) и прерванная (`interrupted`) миграции
+   * НЕ считаются applied — флаг несёт истинную причину, чтобы
+   * консьюмеры, проверяющие только `applied`, не приняли их за здоровые.
+   */
   applied: boolean;
   appliedAt?: Date;
   /** Запись есть в БД, но среди переданных миграций её нет (файл удалён). */
@@ -42,8 +49,8 @@ export interface YdbMigrationStatus {
   interrupted?: boolean;
   /**
    * Содержимое файла изменилось после применения (#101): запись учёта
-   * сопоставлена по имени, но хеш различается. Такая миграция считается
-   * «не успешно применённой» для проверок готовности — нужен явный
+   * сопоставлена по имени, но хеш различается. Для проверок готовности
+   * это «не успешно применённая» миграция (applied=false) — нужен явный
    * reconcile (восстановить содержимое или removeMigrationRecord).
    */
   contentChanged?: boolean;
@@ -228,7 +235,9 @@ export function computeMigrationStatuses(
     }
     return {
       name,
-      applied: true,
+      // `applied` — только здорово применённая (#212): изменённая после
+      // применения или прерванная миграция applied не считается.
+      applied: match.kind === 'matched' && match.record.state !== 'started',
       appliedAt: new Date(match.record.timestamp),
       interrupted: match.record.state === 'started',
       // Имя совпадает, а хеш содержимого различается (#101): файл меняли
@@ -239,11 +248,13 @@ export function computeMigrationStatuses(
   });
 
   // Orphan-записи (#101): применены, но файла миграции уже нет.
+  // Чистый orphan — информационный (applied=true); orphan в состоянии
+  // `started` — прерванный, applied=false (#212).
   for (const record of applied) {
     if (recordMatchesMigration(record, migrations)) continue;
     statuses.push({
       name: record.name,
-      applied: true,
+      applied: record.state !== 'started',
       appliedAt: new Date(record.timestamp),
       orphan: true,
       interrupted: record.state === 'started',


### PR DESCRIPTION
Closes #212.

`computeMigrationStatuses()` could emit `applied: true` together with `contentChanged: true`, so consumers reading only `applied` treated a modified migration as healthy.

## Changes

- **Contract fix (`migration-runner.ts`)**: `YdbMigrationStatus.applied` now means "healthily applied" only. A content-changed (`contentChanged`) or interrupted (`interrupted`) migration is emitted with `applied: false`; the reason flag is preserved. Clean orphans keep `applied: true` (informational); started orphans are `applied: false`.
- **Single source of truth (`migration-check.ts`)**: `evaluateMigrationCheck` counts applied via `isHealthilyApplied` (applied && !interrupted && !contentChanged), robust for both the new producer shape and legacy/hand-built `{applied: true, contentChanged: true}`.
- **CLI/JSON**: `buildJsonReport.applied` documented as healthy-applied; output unchanged.
- **Regression tests**: prove a content-changed migration cannot satisfy the healthy-applied condition; never emits `applied: true` alongside `contentChanged`/`interrupted`.
- **Docs/example**: README + `examples/09-migrations` clarify `applied` semantics.

## Verification

- Focused migration tests + full suite: 1382 passed
- `yarn build` and `yarn lint` clean