### PR TITLE
perf(query): fast-path primitive dedup in dedupeInValues (#203)

### DIFF
--- a/src/core/query-limits.spec.ts
+++ b/src/core/query-limits.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from '@jest/globals';
+import { dedupeInValues } from './query-limits.js';
+
+describe('dedupeInValues', () => {
+  it('deduplicates primitive values by value', () => {
+    expect(dedupeInValues(['a', 'b', 'a', 'c', 'b'])).toEqual(['a', 'b', 'c']);
+    expect(dedupeInValues([1, 2, 1, 3])).toEqual([1, 2, 3]);
+    expect(dedupeInValues([1n, 2n, 1n])).toEqual([1n, 2n]);
+    expect(dedupeInValues([true, false, true])).toEqual([true, false]);
+  });
+
+  it('preserves first-occurrence order', () => {
+    expect(dedupeInValues(['x', 'y', 'x', 'z', 'y', 'w'])).toEqual([
+      'x',
+      'y',
+      'z',
+      'w',
+    ]);
+    expect(dedupeInValues([1, 2, 2, 3, 1, 4, 3])).toEqual([1, 2, 3, 4]);
+  });
+
+  it('treats -0 and 0 as the same value (SameValueZero)', () => {
+    expect(dedupeInValues([0, -0, 0])).toEqual([0]);
+  });
+
+  it('compares Bytes (Uint8Array) by value, not by reference', () => {
+    const a = new Uint8Array([1, 2, 3]);
+    const b = new Uint8Array([1, 2, 3]);
+    const c = new Uint8Array([1, 2, 4]);
+    const out = dedupeInValues<Uint8Array>([a, b, c, a]);
+    expect(out).toHaveLength(2);
+    expect(out[0]).toBe(a);
+    expect(out[1]).toBe(c);
+  });
+
+  it('compares Date/Datetime/Timestamp-like values by value', () => {
+    const a = new Date('2024-01-01T00:00:00.000Z');
+    const b = new Date('2024-01-01T00:00:00.000Z');
+    const c = new Date('2025-06-15T12:30:00.000Z');
+    const out = dedupeInValues<Date>([a, b, c, a]);
+    expect(out).toHaveLength(2);
+    expect(out[0]).toBe(a);
+    expect(out[1]).toBe(c);
+  });
+
+  it('distinguishes types that native Set alone would collapse by string', () => {
+    const input1: (string | number)[] = ['1', 1, '1'];
+    expect(dedupeInValues(input1)).toEqual(['1', 1]);
+    const input2: (boolean | number)[] = [false, 0, false];
+    expect(dedupeInValues(input2)).toEqual([false, 0]);
+  });
+
+  it('treats null and undefined as distinct values', () => {
+    const input: (null | undefined)[] = [null, undefined, null];
+    expect(dedupeInValues(input)).toEqual([null, undefined]);
+  });
+
+  it('distinguishes Bytes from strings and numbers with same shape', () => {
+    const bytes = new Uint8Array([49]);
+    const input: (Uint8Array | string | number)[] = [bytes, '1', 1, bytes];
+    expect(dedupeInValues(input)).toEqual([bytes, '1', 1]);
+  });
+
+  it('handles an empty input', () => {
+    expect(dedupeInValues([])).toEqual([]);
+  });
+});

--- a/src/core/query-limits.ts
+++ b/src/core/query-limits.ts
@@ -51,6 +51,27 @@ export function chunkInValues<T>(
  * тоже схлопываются в одно значение, хотя по ссылке это разные объекты.
  */
 export function dedupeInValues<T>(values: readonly T[]): T[] {
+  const hasObject = values.some(
+    (value) => typeof value === 'object' && value !== null,
+  );
+  if (!hasObject) {
+    // Быстрый путь: все значения — примитивы (string/number/bigint/boolean/
+    // null/undefined). Нативные Set-семантики (SameValueZero с различением
+    // типов и нормализацией -0/0) в точности совпадают с каноническим
+    // value-ключом однокомпонентных примитивов (#174), поэтому сериализация
+    // каждого значения не нужна.
+    const seen = new Set<T>();
+    const out: T[] = [];
+    for (const value of values) {
+      if (!seen.has(value)) {
+        seen.add(value);
+        out.push(value);
+      }
+    }
+    return out;
+  }
+  // Fallback: есть Bytes/Date — сравнение по значению требует
+  // канонического ключа.
   const seen = new Map<string, T>();
   for (const value of values) {
     const key = valueIdentityKey([value]);


### PR DESCRIPTION
Closes #203

## What
Adds a cheap fast path to `dedupeInValues()` (used by `fetchByColumnIn` and relations for large `IN (...)` batches).

## Why
Previously every value went through `valueIdentityKey()` — canonical key serialization that allocates per value, even for primitives (string/number/bigint/boolean).

## How
- If all values are primitives (`string | number | bigint | boolean | null | undefined`), dedupe with a native `Set`, whose SameValueZero semantics (with type distinction and `-0`/`0` normalization) exactly match the canonical single-component key for primitives.
- If any value is an object, fall back to the existing canonical-key path — preserving value-based equality for `Uint8Array` (Bytes) and `Date` (Datetime/Timestamp).
- First-occurrence ordering and type distinctions preserved.

Localized to deduplication; no changes to surrounding batching code.

## Tests
`src/core/query-limits.spec.ts`: primitive dedup, order preservation, `-0`/`0`, Bytes-by-value, Date-by-value, type distinctions (`'1'`/`1`, `false`/`0`, Bytestring/number), `null`/`undefined`.

Full suite (1414) passes; build and lint clean.