### PR TITLE
docs: translate comments to English and add JSDoc

### DIFF
--- a/src/cli/args.spec.ts
+++ b/src/cli/args.spec.ts
@@ -48,7 +48,7 @@ describe('parseArgs (#103)', () => {
   });
 
   it('rejects unknown flag instead of making it positional', () => {
-    // Раньше `migration:create --nme foo` создавал миграцию с именем «--nme».
+    // Previously `migration:create --nme foo` created a migration named "--nme".
     expect(() => parseArgs(['migration:create', '--nme', 'foo'])).toThrow(
       CliArgsError,
     );
@@ -64,7 +64,7 @@ describe('parseArgs (#103)', () => {
   });
 
   it('rejects missing value at end of argv for value flags', () => {
-    // Раньше `--config` без значения тихо откатывался к env/дефолту.
+    // Previously `--config` without a value quietly fell back to env/default.
     expect(() => parseArgs(['migration:run', '--config'])).toThrow(
       /Option --config requires a non-empty value/,
     );
@@ -121,11 +121,11 @@ describe('formatError (#103)', () => {
     const out = formatError(error);
 
     expect(out).toContain('boom');
-    expect(out).not.toContain('at '); // стек не печатается без verbose
+    expect(out).not.toContain('at '); // stack is not printed without verbose
   });
 
   it('preserves the cause chain by default', () => {
-    // Раньше в catch печатался только error.message.
+    // Previously the catch block printed only error.message.
     const error = new Error('boom', {
       cause: new Error('middle', { cause: new Error('root') }),
     });
@@ -142,7 +142,7 @@ describe('formatError (#103)', () => {
 
     expect(out).toContain('Error: boom');
     expect(out).toContain('Caused by: Error: root');
-    expect(out).toMatch(/\n\s+at /); // реальные кадры стека сохранены
+    expect(out).toMatch(/\n\s+at /); // real stack frames are preserved
   });
 
   it('prints context lines first in verbose mode', () => {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,13 +1,13 @@
 /**
- * Разбор аргументов командной строки CLI (#103).
+ * CLI command-line argument parsing (#103).
  *
- * Раньше неизвестные флаги молча становились позиционными аргументами
- * (`migration:create --nme foo` создавал миграцию с именем «--nme»),
- * а `--config`/`--dir` без значения тихо откатывались к дефолтам/env.
- * Теперь разбор строгий: неизвестный флаг или пустое значение — ошибка.
+ * Unknown flags used to be silently treated as positional arguments
+ * (`migration:create --nme foo` created a migration named "--nme"), and a
+ * `--config`/`--dir` without a value quietly fell back to defaults/env.
+ * Parsing is now strict: an unknown flag or an empty value is an error.
  */
 
-/** Ошибка разбора аргументов — печатается без стека, но с подсказкой. */
+/** Argument-parsing error — printed without a stack trace but with a hint. */
 export class CliArgsError extends Error {
   constructor(message: string) {
     super(message);
@@ -15,6 +15,7 @@ export class CliArgsError extends Error {
   }
 }
 
+/** Parsed CLI arguments. */
 export interface CliArgs {
   command?: string;
   positional?: string;
@@ -28,10 +29,10 @@ export interface CliArgs {
   help?: boolean;
 }
 
-/** Флаги, принимающие значение (арность 1). */
+/** Flags that take a value (arity 1). */
 const VALUE_FLAGS = new Set(['--config', '--dir', '--output']);
 
-/** Булевы флаги (арность 0). */
+/** Boolean flags (arity 0). */
 const BOOLEAN_FLAGS = new Set([
   '--json',
   '--as-applied',
@@ -67,13 +68,13 @@ function valueFlagKey(flag: string): 'config' | 'dir' | 'output' {
 }
 
 /**
- * Строго разбирает argv:
- *  - неизвестный флаг (`--nme`, `-x`) — ошибка, а не позиционный аргумент;
- *  - `--config`/`--dir`/`--output` без значения, с пустой строкой или со следующим
- *    флагом вместо значения — ошибка, а не тихий дефолт;
- *  - поддерживается синтаксис `--flag=value`;
- *  - больше одного позиционного аргумента после команды — ошибка,
- *    лишние аргументы больше не игнорируются молча.
+ * Strictly parses argv:
+ *  - an unknown flag (`--nme`, `-x`) is an error, not a positional argument;
+ *  - `--config`/`--dir`/`--output` with no value, an empty string, or the next
+ *    flag in place of a value is an error, not a silent default;
+ *  - `--flag=value` syntax is supported;
+ *  - more than one positional argument after the command is an error —
+ *    extra arguments are no longer silently ignored.
  */
 export function parseArgs(argv: string[]): CliArgs {
   const result: CliArgs = {};
@@ -99,8 +100,8 @@ export function parseArgs(argv: string[]): CliArgs {
       const key = valueFlagKey(flag);
       if (inlineValue === undefined) {
         const next = argv[i + 1];
-        // Следующий флаг вместо значения — почти наверняка опечатка:
-        // `--config --dir x` не должен превращаться в config="--dir".
+        // A following flag instead of a value is almost certainly a typo:
+        // `--config --dir x` must not turn into config="--dir".
         if (next === undefined || isFlagLike(next)) {
           throw new CliArgsError(
             `Option ${flag} requires a non-empty value ` +
@@ -169,10 +170,11 @@ function errorChain(error: unknown): ErrorWithCause[] {
 }
 
 /**
- * Форматирует ошибку для вывода в stderr (#103):
- *  - по умолчанию — сообщение и цепочка cause («Caused by: ...»);
- *  - при verbose — строки context, затем полный стек каждого звена цепочки.
- * Раньше печатался только error.message — стек и причина терялись.
+ * Formats an error for stderr output (#103):
+ *  - by default — the message and the cause chain ("Caused by: ...");
+ *  - with verbose — context lines first, then the full stack of every link
+ *    in the chain.
+ * Previously only error.message was printed — the stack and the cause were lost.
  */
 export function formatError(
   error: unknown,

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -80,7 +80,7 @@ Exit-коды migration:check / migration:status / migration:show (#152):
 Неизвестные флаги и пустые значения опций считаются ошибкой (#103).
 `;
 
-/** Команды проверки готовности: любые их сбои — exit 5 (#152). */
+/** Readiness-check commands: any of their failures is exit 5 (#152). */
 const MIGRATION_VERIFY_COMMANDS = new Set([
   'migration:check',
   'migration:show',
@@ -93,9 +93,9 @@ async function main(): Promise<void> {
     args = parseArgs(process.argv.slice(2));
     await runCommand(args);
   } catch (error) {
-    // Exit-код может быть помечен источником (#152): у команд проверки
-    // любая ошибка выполнения (конфиг, подключение, неожиданный сбой) —
-    // отдельный код 5; остальные команды — прежний 1.
+    // The exit code may carry a source marker (#152): for the verification
+    // commands any execution failure (config, connection, unexpected crash)
+    // is the dedicated code 5; the other commands keep the old 1.
     const code = exitCodeOf(error);
     process.exitCode =
       code === DEFAULT_EXIT_CODE &&
@@ -107,7 +107,7 @@ async function main(): Promise<void> {
     console.error(
       formatError(error, {
         verbose,
-        // Полезная диагностика окружения при verbose (#103).
+        // Useful environment diagnostics when verbose (#103).
         context: [
           `cwd: ${process.cwd()}`,
           `argv: ${JSON.stringify(process.argv.slice(2))}`,
@@ -150,8 +150,8 @@ async function runCommand(args: CliArgs): Promise<void> {
         error.name === 'PromptCancelledError' &&
         process.exitCode === 130
       ) {
-        // Отмена ввода (EOF/Ctrl+C/Ctrl+D) — чистый выход без записи файла:
-        // сообщение уже напечатано, стек не нужен.
+        // Input cancelled (EOF/Ctrl+C/Ctrl+D) — clean exit without writing a
+        // file: the message is already printed, no stack trace needed.
         return;
       }
       throw error;
@@ -200,7 +200,8 @@ async function runCommand(args: CliArgs): Promise<void> {
         args.positional as string,
         plan,
       );
-      // Сводка расхождений, попавших в миграцию (и оставшихся warnings).
+      // Summary of the discrepancies that landed in the migration (plus the
+      // remaining warnings).
       const issues = diffSchemas(expected, existing);
       if (issues.length) {
         console.log('Schema diff (entity vs database):');
@@ -224,8 +225,8 @@ async function runCommand(args: CliArgs): Promise<void> {
     }
     const { driver, executor, close } = await connectCli(config);
     try {
-      // Проверяем декораторы заранее: syncer.verify молча пропускает
-      // недекорированные классы
+      // Check decorators up front: syncer.verify silently skips
+      // undecorated classes
       for (const entity of config.entities) {
         requireEntityMeta(entity);
       }
@@ -235,10 +236,10 @@ async function runCommand(args: CliArgs): Promise<void> {
         console.log('Schema OK — no issues found');
       } else {
         console.error(`Found ${issues.length} schema issue(s):`);
-        // Расхождения пишутся в stderr — цвет решаем по stderr, а не по
-        // stdout (#103): при `ydb-orm schema:verify 2>issues.txt` ANSI-коды
-        // не должны уезжать в перенаправленный файл, а при
-        // `... | cat` — теряться, если stderr остался TTY.
+        // Discrepancies are written to stderr — color is decided by stderr,
+        // not by stdout (#103): with `ydb-orm schema:verify 2>issues.txt`
+        // ANSI codes must not leak into the redirected file, and with
+        // `... | cat` they must not be lost if stderr stays a TTY.
         console.error(renderSchemaDiff(issues, { stream: process.stderr }));
         process.exitCode = 1;
       }
@@ -249,8 +250,8 @@ async function runCommand(args: CliArgs): Promise<void> {
   }
 
   if (command === 'metadata:dump') {
-    // Read-only экспорт метаданных (#37): БД не подключается вовсе — ни
-    // драйвера, ни executor'а; конфиг нужен только ради списка entities.
+    // Read-only metadata export (#37): the DB is not touched at all — no
+    // driver, no executor; the config is needed only for the entities list.
     if (!config.entities?.length) {
       throw new Error(
         'metadata:dump requires "entities" in the CLI config ' +
@@ -258,16 +259,16 @@ async function runCommand(args: CliArgs): Promise<void> {
       );
     }
     const dump = buildMetadataDump(config.entities);
-    // Команда по природе JSON-only: единственный режим вывода — весь дамп
-    // в stdout, детерминированный (стабильный порядок и структура).
+    // The command is JSON-only by nature: the single output mode is the whole
+    // dump to stdout, deterministic (stable order and structure).
     console.log(JSON.stringify(dump, null, 2));
     return;
   }
 
   if (command === 'entity:diagram') {
-    // Read-only Mermaid ER-диаграмма (#36): тот же канонический источник,
-    // что у metadata:dump (#37); БД не подключается вовсе. Вся валидация
-    // и построение — до первого байта вывода/записи файла.
+    // Read-only Mermaid ER diagram (#36): the same canonical source as
+    // metadata:dump (#37); the DB is not touched at all. All validation
+    // and building happen before the first byte of output/file write.
     if (!config.entities?.length) {
       throw new Error(
         'entity:diagram requires "entities" in the CLI config ' +
@@ -285,8 +286,8 @@ async function runCommand(args: CliArgs): Promise<void> {
   }
 
   if (command === 'migration:repair') {
-    // Восстановление после прерванной миграции (#101): запись в
-    // ydb_migrations осталась в состоянии "started" и блокирует migration:run.
+    // Recovery after an interrupted migration (#101): the ydb_migrations
+    // record is stuck in "started" state and blocks migration:run.
     requireName(command, args.positional);
     if (!args.asApplied && !args.asReverted) {
       throw new Error(
@@ -341,8 +342,9 @@ async function runCommand(args: CliArgs): Promise<void> {
     command === 'migration:show' ||
     command === 'migration:status'
   ) {
-    // Единый read-only workflow проверки (#152): состояния и exit-коды
-    // см. migrations/migration-check.ts. Миграции и схема не меняются.
+    // A single read-only verification workflow (#152): states and exit codes
+    // are documented in migrations/migration-check.ts. Migrations and the
+    // schema are never modified.
     const verdict = await runMigrationVerification({
       command,
       migrationsDir,

--- a/src/cli/completion.spec.ts
+++ b/src/cli/completion.spec.ts
@@ -7,32 +7,32 @@ import {
 } from './completion.js';
 
 /**
- * Спеки генерации shell-автодополнения (#109): раньше completion.ts не имел
- * собственных тестов — регрессия (потеря команды/шелла, битый скрипт) была бы
- * замечена только пользователем в терминале.
+ * Specs for shell-completion generation (#109): completion.ts used to have
+ * no tests of its own — a regression (a lost command/shell, a broken script)
+ * would only be noticed by a user in the terminal.
  */
 
 describe('renderCompletionScript', () => {
-  it.each([...COMPLETION_SHELLS])('генерирует скрипт для %s', (shell) => {
+  it.each([...COMPLETION_SHELLS])('generates script for %s', (shell) => {
     const script = renderCompletionScript(shell);
 
     expect(script.length).toBeGreaterThan(0);
-    // Все команды CLI присутствуют в скрипте
+    // Every CLI command is present in the script
     for (const command of CLI_COMMANDS) {
       expect(script).toContain(command.name);
     }
-    // Поддерживаемые шеллы перечислены (аргументы completion)
+    // Supported shells are listed (completion arguments)
     expect(script).toContain(COMPLETION_SHELLS.join(' '));
   });
 
-  it('bash-скрипт использует compgen и complete -F', () => {
+  it('bash script uses compgen and complete -F', () => {
     const script = renderCompletionScript('bash');
     expect(script).toContain('_ydb_orm()');
     expect(script).toContain('compgen -W');
     expect(script).toContain('complete -F _ydb_orm ydb-orm');
   });
 
-  it('zsh-скрипт объявляет команды с описаниями', () => {
+  it('zsh script declares commands with descriptions', () => {
     const script = renderCompletionScript('zsh');
     expect(script).toContain('#compdef ydb-orm');
     for (const command of CLI_COMMANDS) {
@@ -40,17 +40,17 @@ describe('renderCompletionScript', () => {
     }
   });
 
-  it('fish-скрипт регистрирует complete -c ydb-orm на каждую команду', () => {
+  it('fish script registers complete -c ydb-orm for each command', () => {
     const script = renderCompletionScript('fish');
     expect(script.match(/complete -c ydb-orm/g)?.length).toBeGreaterThanOrEqual(
       CLI_COMMANDS.length + 1,
     );
-    // Флаги со значениями помечены как требующие файл (-r -F)
+    // Value flags are marked as requiring a file (-r -F)
     expect(script).toContain('-l config -r -F');
     expect(script).toContain('-l dir -r -F');
   });
 
-  it('неизвестный шелл даёт понятную ошибку с перечнем поддерживаемых', () => {
+  it('unknown shell gives clear error listing supported shells', () => {
     expect(() => renderCompletionScript('powershell')).toThrow(
       /Unknown shell: powershell\. Supported shells: bash, zsh, fish/,
     );
@@ -58,19 +58,19 @@ describe('renderCompletionScript', () => {
   });
 });
 
-describe('isCompletionShell / константы согласованы', () => {
-  it('распознаёт поддерживаемые шеллы и отклоняет остальные', () => {
+describe('isCompletionShell / constants aligned', () => {
+  it('recognizes supported shells and rejects others', () => {
     for (const shell of COMPLETION_SHELLS) {
       expect(isCompletionShell(shell)).toBe(true);
     }
     expect(isCompletionShell('pwsh')).toBe(false);
   });
 
-  it('все флаги из CLI_FLAGS упомянуты в каждом скрипте', () => {
+  it('all flags from CLI_FLAGS mentioned in each script', () => {
     for (const shell of COMPLETION_SHELLS) {
       const script = renderCompletionScript(shell);
       for (const flag of CLI_FLAGS) {
-        // fish использует длинную форму без дефисов: -l/--config → config
+        // fish uses the long form without dashes: -l/--config → config
         if (shell === 'fish') {
           expect(script).toContain(flag.replace(/^--/, ''));
         } else {
@@ -80,7 +80,7 @@ describe('isCompletionShell / константы согласованы', () => 
     }
   });
 
-  it('имена команд уникальны', () => {
+  it('command names are unique', () => {
     const names = CLI_COMMANDS.map((c) => c.name);
     expect(new Set(names).size).toBe(names.length);
   });

--- a/src/cli/completion.ts
+++ b/src/cli/completion.ts
@@ -1,15 +1,15 @@
 /**
- * Генерация shell-автодополнения для бинаря `ydb-orm`.
- * Скрипты собираются строками, без внешних зависимостей.
+ * Shell-completion generation for the `ydb-orm` binary.
+ * Scripts are assembled from strings, without external dependencies.
  */
 
-/** Команда CLI с описанием (используется в completion-скриптах). */
+/** CLI command with a description (used in completion scripts). */
 interface CliCommand {
   name: string;
   description: string;
 }
 
-/** Все команды CLI, участвующие в автодополнении. */
+/** All CLI commands participating in completion. */
 export const CLI_COMMANDS: CliCommand[] = [
   { name: 'migration:create', description: 'Create an empty migration' },
   {
@@ -42,7 +42,7 @@ export const CLI_COMMANDS: CliCommand[] = [
   { name: 'completion', description: 'Print shell completion script' },
 ];
 
-/** Флаги, которые парсит CLI (см. parseArgs в args.ts). */
+/** Flags the CLI parses (see parseArgs in args.ts). */
 export const CLI_FLAGS = [
   '--config',
   '--dir',
@@ -53,11 +53,12 @@ export const CLI_FLAGS = [
   '--verbose',
 ];
 
-/** Поддерживаемые шеллы. */
+/** Supported shells. */
 export const COMPLETION_SHELLS = ['bash', 'zsh', 'fish'] as const;
 
 export type CompletionShell = (typeof COMPLETION_SHELLS)[number];
 
+/** Narrowing guard: whether the string names a supported completion shell. */
 export function isCompletionShell(shell: string): shell is CompletionShell {
   return (COMPLETION_SHELLS as readonly string[]).includes(shell);
 }
@@ -66,7 +67,7 @@ function commandNames(): string {
   return CLI_COMMANDS.map((c) => c.name).join(' ');
 }
 
-/** Bash completion-скрипт. */
+/** Bash completion script. */
 function renderBash(): string {
   return `# bash completion for ydb-orm
 _ydb_orm() {
@@ -100,7 +101,7 @@ complete -F _ydb_orm ydb-orm
 `;
 }
 
-/** Zsh completion-скрипт. */
+/** Zsh completion script. */
 function renderZsh(): string {
   const commands = CLI_COMMANDS.map(
     (c) => `    '${c.name}:${c.description}'`,
@@ -146,7 +147,7 @@ _ydb_orm "$@"
 `;
 }
 
-/** Fish completion-скрипт. */
+/** Fish completion script. */
 function renderFish(): string {
   const lines: string[] = ['# fish completion for ydb-orm', ''];
   lines.push(
@@ -182,8 +183,8 @@ function renderFish(): string {
 }
 
 /**
- * Возвращает completion-скрипт для указанного шелла.
- * Бросает Error с понятным сообщением для неизвестного шелла.
+ * Returns the completion script for the given shell.
+ * Throws an Error with a clear message for an unknown shell.
  */
 export function renderCompletionScript(shell: string): string {
   switch (shell) {

--- a/src/cli/config.spec.ts
+++ b/src/cli/config.spec.ts
@@ -27,8 +27,8 @@ describe('extractCliConfig (#103)', () => {
   });
 
   it('accepts a named export instead of the default one', () => {
-    // Раньше понимался только default export: файл с named экспортом
-    // давал ложную ошибку «endpoint is required».
+    // Previously only the default export was understood: a file with a named
+    // export raised a misleading "endpoint is required" error.
     const config = { endpoint };
     expect(extractCliConfig({ config }, 'cfg.ts')).toBe(config);
     expect(extractCliConfig({ cliConfig: config }, 'cfg.ts')).toBe(config);

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -5,18 +5,18 @@ import { Driver } from '@ydbjs/core';
 import { YdbExecutor, YdbModuleOptions } from '../core/interfaces.js';
 import { createDriver, createExecutor } from '../core/driver.js';
 
-/** Конфиг CLI: опции подключения + пути для миграций. */
+/** CLI config: connection options + migration paths. */
 export interface YdbCliConfig extends YdbModuleOptions {
-  /** Директория с миграциями (по умолчанию ./migrations). */
+  /** Directory with migrations (defaults to ./migrations). */
   migrationsDir?: string;
-  /** Сущности для migration:generate. */
+  /** Entities for migration:generate. */
   entities?: (new (...args: any[]) => any)[];
 }
 
 /**
- * Проверяет, что в конфиге задан способ аутентификации.
- * CLI не создаёт AuthManager самостоятельно: пользователь должен передать
- * готовый `auth` (createAuth(...)) или CredentialsProvider.
+ * Checks that the config declares an authentication method.
+ * The CLI never builds an AuthManager itself: the user must pass a ready-made
+ * `auth` (createAuth(...)) or a CredentialsProvider.
  */
 function assertCliAuth(config: YdbCliConfig): void {
   if (
@@ -39,11 +39,10 @@ const DEFAULT_CONFIG_NAMES = [
 ];
 
 /**
- * Похож ли экспорт модуля на CLI-конфиг (#103).
- * Нужен, чтобы поддержать именованные экспорты конфига:
- * раньше понимался только default, и файл вида
- * `export const config = { endpoint: ... }` давал ложную ошибку
- * «endpoint is required».
+ * Whether a module export looks like a CLI config (#103).
+ * Needed to support named config exports: only the default export used to be
+ * understood, so a file like `export const config = { endpoint: ... }` raised
+ * a misleading "endpoint is required" error.
  */
 function looksLikeConfig(value: unknown): value is YdbCliConfig {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -58,11 +57,11 @@ function looksLikeConfig(value: unknown): value is YdbCliConfig {
 }
 
 /**
- * Достаёт конфиг из импортированного модуля конфигурации.
- * Поддерживает default export и именованные экспорты; при нескольких
- * разных подходящих экспортах приоритет у `default`, иначе — неоднозначность
- * (ошибка со списком кандидатов), а не молчаливый выбор первого (#103).
- * Отсутствие endpoint — ошибка с указанием файла и имени экспорта.
+ * Extracts the config from an imported configuration module.
+ * Supports both a default export and named exports; when several different
+ * matching exports exist, `default` wins, otherwise it is an ambiguity
+ * (an error listing the candidates) rather than a silent pick of the first
+ * one (#103). A missing endpoint is an error naming the file and the export.
  */
 export function extractCliConfig(
   mod: Record<string, unknown>,
@@ -79,8 +78,8 @@ export function extractCliConfig(
     );
   }
 
-  // Дедупликация по значению: default и именованный экспорт одного
-  // и того же объекта — один кандидат.
+  // De-dup by value: a default and a named export of the same object form
+  // a single candidate.
   const byValue = new Map<YdbCliConfig, string[]>();
   for (const [name, value] of candidates) {
     const names = byValue.get(value) ?? [];
@@ -108,10 +107,10 @@ export function extractCliConfig(
 }
 
 /**
- * Ищет дефолтный конфиг в startDir и вверх по дереву каталогов до корня ФС
- * (#103). Раньше поиск шёл только в CWD — запуск из вложенной директории
- * монорепо не находил конфиг в корне проекта. В одной директории приоритет:
- * .ts → .mts → .mjs → .js.
+ * Looks for the default config in startDir and up the directory tree to the
+ * filesystem root (#103). Previously the search covered only the CWD, so
+ * running from a nested monorepo directory missed the config at the project
+ * root. Within one directory the priority is: .ts → .mts → .mjs → .js.
  */
 export function findDefaultConfig(startDir?: string): string | undefined {
   let current = path.resolve(startDir ?? process.cwd());
@@ -127,11 +126,11 @@ export function findDefaultConfig(startDir?: string): string | undefined {
 }
 
 /**
- * Загружает конфиг CLI:
- *  1. --config <path> или ydb-orm.config.{ts,mts,mjs|js}, найденный в CWD
- *     или выше; default и именованные экспорты эквивалентны;
- *  2. иначе — переменная окружения YDB_ENDPOINT / YDB_CONNECTION_STRING
- *     (требуется ydb-orm.config.ts для задания auth).
+ * Loads the CLI config:
+ *  1. --config <path> or ydb-orm.config.{ts,mts,mjs|js} found in the CWD
+ *     or above; default and named exports are equivalent;
+ *  2. otherwise — the YDB_ENDPOINT / YDB_CONNECTION_STRING environment
+ *     variables (still requires ydb-orm.config.ts to specify auth).
  */
 export async function loadCliConfig(
   configPath?: string,
@@ -166,7 +165,7 @@ export async function loadCliConfig(
   );
 }
 
-/** Подключение для команд CLI: driver + executor, закрывается через close(). */
+/** Connection for CLI commands: driver + executor, closed via close(). */
 export async function connectCli(config: YdbCliConfig): Promise<{
   driver: Driver;
   executor: YdbExecutor;

--- a/src/cli/diff.spec.ts
+++ b/src/cli/diff.spec.ts
@@ -2,9 +2,9 @@ import { renderSchemaDiff, shouldUseColor } from './diff.js';
 import type { YdbSchemaIssue } from '../schema/schema-sync.js';
 
 /**
- * Спеки человекочитаемого diff-вывода расхождений схемы (#109): группировка
- * по таблицам, маркеры по видам issues, переформатирование «было → стало»,
- * отключение цвета (не-TTY поток и NO_COLOR — регрессия #103).
+ * Specs of human-readable schema-diff output (#109): grouping by tables,
+ * markers per issue kind, "was → became" reformatting, color disabling
+ * (non-TTY stream and NO_COLOR — the #103 regression).
  */
 
 const issue = (partial: Partial<YdbSchemaIssue>): YdbSchemaIssue => ({
@@ -22,13 +22,13 @@ describe('shouldUseColor (#103)', () => {
     else process.env.NO_COLOR = originalNoColor;
   });
 
-  it('цвет выключен для не-TTY потока', () => {
+  it('color disabled for non-TTY stream', () => {
     const fakeStream = { isTTY: false } as unknown as NodeJS.WriteStream;
     delete process.env.NO_COLOR;
     expect(shouldUseColor(fakeStream)).toBe(false);
   });
 
-  it('цвет включён только для TTY без NO_COLOR', () => {
+  it('color enabled only for TTY without NO_COLOR', () => {
     const ttyStream = { isTTY: true } as unknown as NodeJS.WriteStream;
     delete process.env.NO_COLOR;
     expect(shouldUseColor(ttyStream)).toBe(true);
@@ -39,7 +39,7 @@ describe('shouldUseColor (#103)', () => {
 });
 
 describe('renderSchemaDiff', () => {
-  it('группирует issues по таблицам с сохранением порядка', () => {
+  it('groups issues by tables preserving order', () => {
     const output = renderSchemaDiff(
       [
         issue({
@@ -54,8 +54,8 @@ describe('renderSchemaDiff', () => {
     );
 
     const lines = output.split('\n');
-    // Группы в порядке первого появления; повторные issues той же таблицы
-    // попадают в существующую группу (a: 2 шт., затем b)
+    // Groups keep first-appearance order; repeated issues of the same table
+    // join the existing group (a: 2 items, then b)
     expect(lines[0]).toBe('a');
     expect(lines[1]).toContain('does not exist');
     expect(lines[2]).toContain('is missing column "c"');
@@ -63,7 +63,7 @@ describe('renderSchemaDiff', () => {
     expect(lines[4]).toContain('is missing column "c"');
   });
 
-  it('маркеры соответствуют видам расхождений', () => {
+  it('markers match discrepancy kinds', () => {
     const output = renderSchemaDiff(
       [
         issue({
@@ -95,7 +95,7 @@ describe('renderSchemaDiff', () => {
     expect(output).not.toContain('undefined');
   });
 
-  it('переформатирует type-mismatch как «было → стало»', () => {
+  it('reformats type-mismatch as "was → became"', () => {
     const output = renderSchemaDiff(
       [
         issue({
@@ -111,7 +111,7 @@ describe('renderSchemaDiff', () => {
     expect(output).not.toContain('type mismatch:');
   });
 
-  it('переформатирует index-columns-mismatch и ttl-mismatch так же', () => {
+  it('reformats index-columns-mismatch and ttl-mismatch similarly', () => {
     const output = renderSchemaDiff(
       [
         issue({
@@ -132,7 +132,7 @@ describe('renderSchemaDiff', () => {
     expect(output).toContain('TTL: P1D on column "c" → PT2H on column "c"');
   });
 
-  it('префикс таблицы убирается из текста issue', () => {
+  it('table prefix stripped from issue text', () => {
     const output = renderSchemaDiff(
       [
         issue({
@@ -146,11 +146,11 @@ describe('renderSchemaDiff', () => {
     expect(output).toContain('is missing column "email"');
   });
 
-  it('пустой список issues — пустая строка', () => {
+  it('empty issues list yields empty string', () => {
     expect(renderSchemaDiff([], { color: false })).toBe('');
   });
 
-  it('с цветом текст обёрнут в ANSI-коды; без цвета — чистый текст', () => {
+  it('with color text wrapped in ANSI codes; without color plain text', () => {
     const issues = [
       issue({ kind: 'missing-table', message: 'Table "t" does not exist' }),
     ];

--- a/src/cli/diff.ts
+++ b/src/cli/diff.ts
@@ -1,8 +1,8 @@
 /**
- * Человекочитаемый цветной вывод расхождений схемы «сущности vs БД»
- * для команд CLI (`schema:verify`, `migration:generate`).
- * ANSI-коды вручную, без зависимостей; цвет отключается при не-TTY
- * выводе и по переменной окружения NO_COLOR.
+ * Human-readable colored output of schema "entity vs DB" discrepancies for
+ * CLI commands (`schema:verify`, `migration:generate`).
+ * ANSI codes are produced by hand, with no dependencies; color is disabled
+ * on non-TTY output and by the NO_COLOR environment variable.
  */
 import type { YdbSchemaIssue } from '../schema/schema-sync.js';
 
@@ -13,7 +13,7 @@ const YELLOW = '\x1b[33m';
 const BLUE = '\x1b[34m';
 const GRAY = '\x1b[90m';
 
-/** Маркер и цвет по типу расхождения. */
+/** Marker and color per discrepancy kind. */
 const KIND_STYLE: Record<
   YdbSchemaIssue['kind'],
   { marker: string; color: string }
@@ -34,10 +34,11 @@ const KIND_STYLE: Record<
 };
 
 /**
- * Цвет включён, только если целевой поток вывода — TTY и не задана
- * NO_COLOR (#103). Раньше TTY проверялся только у stdout, хотя расхождения
- * в schema:verify пишутся в stderr — при перенаправлении stdout ANSI-коды
- * попадали в файл, а при перенаправлении stderr цвет зря отключался.
+ * Color is enabled only when the target output stream is a TTY and NO_COLOR
+ * is not set (#103). Previously TTY was checked only against stdout although
+ * schema:verify writes discrepancies to stderr — ANSI codes leaked into a
+ * file when redirecting stdout, and color was needlessly disabled when
+ * redirecting stderr.
  */
 export function shouldUseColor(
   stream: NodeJS.WriteStream = process.stdout,
@@ -45,24 +46,24 @@ export function shouldUseColor(
   return Boolean(stream.isTTY) && !process.env.NO_COLOR;
 }
 
-/** Оборачивает текст в ANSI-цвет, если раскраска включена. */
+/** Wraps text in ANSI color, if coloring is enabled. */
 function paint(text: string, color: string, colorEnabled: boolean): string {
   return colorEnabled ? `${color}${text}${RESET}` : text;
 }
 
-/** Убирает префикс `Table "<name>" ` из сообщения — таблица уже в заголовке группы. */
+/** Strips the `Table "<name>" ` prefix from the message — the table is already in the group heading. */
 function stripTablePrefix(issue: YdbSchemaIssue): string {
   return issue.message.replace(`Table "${issue.tableName}" `, '');
 }
 
 /**
- * Для type-mismatch переформатирует сообщение в «было → стало»:
+ * For type-mismatch, reformats the message as "was → became":
  * `column "c" type mismatch: expected Utf8, actual Int32`
  * → `column "c": Int32 → Utf8`.
- * Аналогично для index-columns-mismatch:
+ * Likewise for index-columns-mismatch:
  * `index "i" columns mismatch: expected [a, b], actual [b, a]`
  * → `index "i": [b, a] → [a, b]`,
- * и для ttl-mismatch:
+ * and for ttl-mismatch:
  * `TTL mismatch: expected PT2H ..., actual P1D ...`
  * → `TTL: P1D ... → PT2H ...`.
  */
@@ -94,11 +95,11 @@ function formatIssueText(issue: YdbSchemaIssue): string {
 }
 
 /**
- * Рендерит список расхождений, сгруппированный по таблицам.
- * Возвращает многострочную строку (без завершающего перевода строки).
+ * Renders the list of discrepancies, grouped by table.
+ * Returns a multi-line string (without a trailing newline).
  *
- * Цвет определяется по потоку, куда вывод реально попадает: опция
- * `stream` (по умолчанию stdout) или явный `color`.
+ * Color is decided by the stream the output actually lands in: the `stream`
+ * option (defaults to stdout) or the explicit `color` option.
  */
 export function renderSchemaDiff(
   issues: YdbSchemaIssue[],
@@ -106,7 +107,7 @@ export function renderSchemaDiff(
 ): string {
   const colorEnabled = options?.color ?? shouldUseColor(options?.stream);
 
-  // Группировка по таблицам с сохранением исходного порядка.
+  // Group by tables, preserving the original order.
   const byTable = new Map<string, YdbSchemaIssue[]>();
   for (const issue of issues) {
     const list = byTable.get(issue.tableName) ?? [];

--- a/src/cli/entity-diagram.ts
+++ b/src/cli/entity-diagram.ts
@@ -1,22 +1,23 @@
 /**
- * entity:diagram (#36): read-only рендер канонических метаданных сущностей
- * в Mermaid ER-диаграмму.
+ * entity:diagram (#36): read-only rendering of canonical entity metadata
+ * into a Mermaid ER diagram.
  *
- * Гарантии:
- *  - НИКАКОГО I/O в БД: ни драйвера, ни executor'а, ни DDL, ни миграций —
- *    функция синхронная и работает только с метаданными классов;
- *  - единственный источник данных — канонический дамп metadata:dump (#37)
- *    (buildMetadataDump): обход декораторов не дублируется; вся строгая
- *    валидация (класс без @YdbEntity, конфликт таблиц #92, отсутствие PK,
- *    join-колонки #87, join-таблицы #90/#139) наследуется оттуда — невалидные
- *    метаданные роняют команду до первого байта вывода;
- *  - детерминизм: стабильный порядок блоков сущностей, колонок и связей —
- *    повторный вызов на тех же сущностях даёт побайтово одинаковую диаграмму,
- *    порядок входного списка на вывод не влияет;
- *  - корректный Mermaid для произвольных имён: имена таблиц/метки связей
- *    всегда в двойных кавычках с экранированием, имена колонок приводятся
- *    к допустимому виду (оригинал сохраняется комментарием) — malformed-
- *    вывод невозможен.
+ * Guarantees:
+ *  - NO DB I/O whatsoever: no driver, no executor, no DDL, no migrations —
+ *    the function is synchronous and works only with class metadata;
+ *  - the only data source is the canonical metadata:dump (#37)
+ *    (buildMetadataDump): the decorator walk is not duplicated; all the
+ *    strict validation (class without @YdbEntity, table-name conflict #92,
+ *    missing PK, join columns #87, join tables #90/#139) is inherited from
+ *    there — invalid metadata fails the command before the first byte of
+ *    output;
+ *  - determinism: stable ordering of entity blocks, columns and relations —
+ *    calling the function again on the same entities yields a byte-identical
+ *    diagram, and the input list order does not affect the output;
+ *  - valid Mermaid for arbitrary names: table names/relation labels are
+ *    always double-quoted with escaping, column names are normalized to a
+ *    permissible form (the original is kept as a comment) — malformed
+ *    output is impossible.
  */
 
 import fs from 'node:fs';
@@ -32,11 +33,12 @@ import type {
 type EntityCtor = new (...args: any[]) => any;
 
 /**
- * Строит Mermaid ER-диаграмму для переданного списка сущностей.
+ * Builds a Mermaid ER diagram for the given list of entities.
  *
- * Список задаёт состав диаграммы (обычно config.entities из ydb-orm.config.ts);
- * порядок вывода от него не зависит. Чистая синхронная функция: БД не трогает,
- * ошибок конфигурации не глотает (все они всплывают из buildMetadataDump).
+ * The list defines the diagram composition (usually config.entities from
+ * ydb-orm.config.ts); the output order does not depend on it. A pure
+ * synchronous function: it never touches the DB and does not swallow
+ * configuration errors (all of them surface from buildMetadataDump).
  */
 export function buildEntityDiagram(entities: EntityCtor[]): string {
   const dump = buildMetadataDump(entities);
@@ -44,16 +46,17 @@ export function buildEntityDiagram(entities: EntityCtor[]): string {
 }
 
 /**
- * Записывает диаграмму в файл без риска молчаливой перезаписи:
- * существующий файл — ошибка (флаг 'wx'), запись атомарнее check-then-write.
+ * Writes the diagram to a file without risking a silent overwrite:
+ * an existing file is an error (the 'wx' flag), the write is atomic w.r.t.
+ * check-then-write.
  */
 export function writeDiagramFile(filePath: string, diagram: string): void {
   let fd: number;
   try {
     fd = fs.openSync(filePath, 'wx');
   } catch (error) {
-    // Проверка по коду без instanceof: в VM-окружениях (jest ESM) ошибка
-    // из нативного fs может не наследовать Error этого контекста.
+    // Check by code, not instanceof: in VM environments (jest ESM) a native
+    // fs error may not inherit this context's Error.
     if ((error as NodeJS.ErrnoException)?.code === 'EEXIST') {
       throw new Error(
         `File already exists: ${filePath} — entity:diagram never overwrites ` +
@@ -69,9 +72,9 @@ export function writeDiagramFile(filePath: string, diagram: string): void {
   }
 }
 
-// ─────────────────────────── Рендеринг ──────────────────────────────────────
+// ─────────────────────────── Rendering ──────────────────────────────────────
 
-/** Одна связь на диаграмме: `left <cardinality> right : label`. */
+/** One edge on the diagram: `left <cardinality> right : label`. */
 interface DiagramEdge {
   left: string;
   leftCard: string;
@@ -84,11 +87,11 @@ interface DiagramEdge {
 function renderDiagram(dump: MetadataDump): string {
   const lines: string[] = ['erDiagram'];
 
-  // Физические FK-колонки связей — для маркеров FK в блоках.
+  // Physical FK columns of relations — for FK markers in blocks.
   const foreignKeys = collectForeignKeys(dump.entities);
 
-  // Блоки сущностей: сначала обычные таблицы, затем join-таблицы m2m;
-  // каждая группа отсортирована по имени таблицы (детерминизм).
+  // Entity blocks: ordinary tables first, then m2m join tables; each group
+  // is sorted by table name (determinism).
   for (const entity of dump.entities) {
     lines.push(...renderEntityBlock(entity, foreignKeys.get(entity.table)));
   }
@@ -104,10 +107,10 @@ function renderDiagram(dump: MetadataDump): string {
 }
 
 /**
- * Собирает по каждой таблице множество её FK-колонок — для маркеров FK
- * в блоках: many-to-one/one-to-one держат FK у себя, у one-to-many колонка
- * физически живёт в целевой таблице (если та участвует в диаграмме).
- * Направление и кратность связей считаются отдельно.
+ * Collects, per table, the set of its FK columns — for FK markers in blocks:
+ * many-to-one/one-to-one keep the FK on their own side, while in one-to-many
+ * the column physically lives in the target table (if the latter is part of
+ * the diagram). Edge direction and cardinality are computed separately.
  */
 function collectForeignKeys(
   entities: DumpedEntity[],
@@ -144,8 +147,8 @@ function collectForeignKeys(
 }
 
 /**
- * Блок сущности: PK-колонки идут первыми в порядке объявления (порядок
- * составного PK значим в YDB, #89), остальные — по алфавиту (как в дампе).
+ * Entity block: PK columns come first in declaration order (composite-PK
+ * order matters in YDB, #89), the rest alphabetically (as in the dump).
  */
 function renderEntityBlock(
   entity: DumpedEntity,
@@ -161,7 +164,7 @@ function renderEntityBlock(
   return [`  ${quoteMermaid(entity.table)} {`, ...body, '  }'];
 }
 
-/** Колонки блока: PK — в порядке primaryKey, остальные — как в дампе. */
+/** Block columns: PK first in primaryKey order, the rest as in the dump. */
 function orderColumns(entity: DumpedEntity): DumpedColumn[] {
   const byName = new Map(entity.columns.map((column) => [column.name, column]));
   const ordered: DumpedColumn[] = [];
@@ -175,7 +178,7 @@ function orderColumns(entity: DumpedEntity): DumpedColumn[] {
   return ordered;
 }
 
-/** Строка атрибута: тип, имя, ключи (PK/FK), комментарий с оригиналом. */
+/** Attribute line: type, name, keys (PK/FK), comment with original. */
 function renderAttribute(
   column: DumpedColumn,
   foreignKeys: Set<string> | undefined,
@@ -188,8 +191,8 @@ function renderAttribute(
 }
 
 /**
- * Универсальная строка атрибута: `    <тип> <имя>[ PK[, FK][ "оригинал"]]`.
- * Имя квотировать нельзя — при санитизации оригинал сохраняется комментарием.
+ * Universal attribute line: `    <type> <name>[ PK[, FK][ "original"]]`.
+ * Name cannot be quoted — original preserved as comment during sanitization.
  */
 function renderAttributeLine(
   rawType: string,
@@ -201,13 +204,13 @@ function renderAttributeLine(
 
   const parts = [`    ${type} ${safe.name}`];
   if (keys.length) parts.push(` ${keys.join(', ')}`);
-  // Оригинальное имя сохраняется комментарием: sanitized-имя может
-  // отличаться от физической колонки.
+  // Preserve the original name as a comment: the sanitized name may
+  // differ from the physical column.
   if (safe.changed) parts.push(` ${quoteMermaid(rawName)}`);
   return parts.join('');
 }
 
-/** Блок физической join-таблицы many-to-many: обе колонки — PK + FK. */
+/** Physical many-to-many join table block: both columns are PK + FK. */
 function renderJoinTableBlock(joinTable: DumpedJoinTable): string[] {
   return [
     `  ${quoteMermaid(joinTable.table)} {`,
@@ -224,27 +227,27 @@ function renderJoinTableBlock(joinTable: DumpedJoinTable): string[] {
   ];
 }
 
-// ────────────────────────────── Связи ───────────────────────────────────────
+// ────────────────────────────── Relations ────────────────────────────────────
 
 /**
- * Связи диаграммы, детерминированно упорядоченные.
+ * Diagram edges, deterministically ordered.
  *
- *  - one-to-many ↔ many-to-one с одной и той же FK-колонкой дают одну линию:
- *    если «дочерняя» сторона (владелец FK) входит в дамп, линию рисует её
- *    many-to-one; однонаправленный one-to-many (обратной many-to-one нет)
- *    рисуется от родителя. Кратность всегда ||--o{ (родитель слева).
- *  - one-to-one: ||--o| (FK уникален, nullable-семантика в метаданных
- *    отсутствует); двусторонние one-to-one с двумя разными FK-колонками дают
- *    две линии — это две физические связи.
- *  - many-to-many рисуется через физическую join-таблицу двумя линиями
- *    ||--o{ (владелец → join → обратная сторона); сами свойства-списки
- *    отдельных линий не порождают.
+ *  - one-to-many ↔ many-to-one with the same FK column yield one line:
+ *    if the "child" side (FK owner) is in the dump, its many-to-one draws the
+ *    line; unidirectional one-to-many (no reverse many-to-one) draws from
+ *    the parent. Cardinality is always ||--o{ (parent on the left).
+ *  - one-to-one: ||--o| (FK is unique, no nullable semantics in metadata);
+ *    bidirectional one-to-one with two different FK columns yields two lines
+ *    — these are two physical relationships.
+ *  - many-to-many is drawn via the physical join table with two lines
+ *    ||--o{ (owner → join → inverse side); the list properties themselves
+ *    do not generate separate lines.
  */
 function collectEdges(dump: MetadataDump): DiagramEdge[] {
   const edges: DiagramEdge[] = [];
 
-  // Ключи линий, которые уже нарисованы стороной-владельцем FK:
-  // "<parent>|<child>|<fk>" — чтобы парный one-to-many не задублировал линию.
+  // Keys of edges already drawn by the FK-owning side:
+  // "<parent>|<child>|<fk>" — so the paired one-to-many doesn't duplicate.
   const fkOwnedEdges = new Set<string>();
 
   for (const entity of dump.entities) {
@@ -333,26 +336,27 @@ function renderEdge(edge: DiagramEdge): string {
   );
 }
 
-// ─────────────────────── Экранирование и санитизация ───────────────────────
+// ─────────────────────── Escaping and sanitization ──────────────────────────
 
 /**
- * Имя таблицы/сущности, метка связи (после двоеточия) или комментарий
- * атрибута в Mermaid ER: всегда в двойных кавычках — так безопасны пробелы,
- * точки, дефисы, юникод и любые другие символы, кроме самой двойной кавычки
- * и переводов строк, которые заменяются.
+ * Table/entity name, relation label (after colon), or attribute comment
+ * in Mermaid ER: always double-quoted — safe for spaces, dots, dashes,
+ * unicode and any other characters except the double quote itself and
+ * newlines, which are replaced.
  */
 function quoteMermaid(value: string): string {
-  // Двойная кавычка закрыла бы строку; переводы строк ломают однострочность.
+  // A double quote would close the string; newlines break the single-line form.
   return `"${value.replace(/"/g, "'").replace(/\s+/g, ' ').trim()}"`;
 }
 
 const ATTRIBUTE_SAFE = /^[A-Za-z][A-Za-z0-9_]*$/;
 
 /**
- * Имя атрибута в блоке Mermaid ER квотировать нельзя — грамматика требует
- * слово из букв/цифр/подчёркиваний, начинающееся с буквы. Недопустимые
- * символы заменяются на '_'; изменённое имя помечается, чтобы рендер добавил
- * комментарий с оригиналом. Пустое имя невозможно: fallback гарантирует слово.
+ * Attribute name in a Mermaid ER block cannot be quoted — grammar requires
+ * a word of letters/digits/underscores starting with a letter. Invalid
+ * characters are replaced with '_'; changed name is flagged so the renderer
+ * adds a comment with the original. Empty name is impossible: fallback
+ * guarantees a word.
  */
 function sanitizeAttributeName(name: string): {
   name: string;
@@ -365,8 +369,9 @@ function sanitizeAttributeName(name: string): {
 }
 
 /**
- * YDB-примитив по построению — простое слово (Utf8, Int32, ...), но рендер
- * защищается и от неожиданного значения: malformed-вывод исключён всегда.
+ * YDB primitive when rendered — just a simple word (Utf8, Int32, ...), but
+ * render guards against unexpected values too: malformed output is always
+ * excluded.
  */
 function sanitizeWord(value: string, fallback: string): string {
   return ATTRIBUTE_SAFE.test(value) ? value : fallback;

--- a/src/cli/entity-wizard.spec.ts
+++ b/src/cli/entity-wizard.spec.ts
@@ -24,7 +24,7 @@ interface ScriptedIo {
   text: () => string;
 }
 
-/** Пайп со скриптованными ответами: строки подаются по \n, затем EOF. */
+/** Pipe with scripted answers: lines fed by \n, then EOF. */
 function scripted(answers: string[]): ScriptedIo {
   const input = new PassThrough();
   const output = new PassThrough();
@@ -56,7 +56,7 @@ const expectWizardSuccess = async (
 
 describe('runEntityCreateWizard (#24)', () => {
   it('creates a minimal entity: uuid PK accepted by defaults only', async () => {
-    // таблица='' (дефолт), uuid, pk=Y, type=Uuid, another=n, write=Y
+    // table='' (default), uuid, pk=Y, type=Uuid, another=n, write=Y
     const content = await expectWizardSuccess(['', 'uuid', '', '', 'n', '']);
     expect(content).toContain(`@YdbEntity('test_thing')`);
     expect(content).toContain(`@YdbPrimaryColumn('Uuid')`);
@@ -65,7 +65,7 @@ describe('runEntityCreateWizard (#24)', () => {
   });
 
   it('creates an entity with a custom PK name and type', async () => {
-    // id, pk=Y(default n → y), type=Int64, another=n, write
+    // id, pk=Y(default n -> y), type=Int64, another=n, write
     const content = await expectWizardSuccess([
       'accounts',
       'id',
@@ -81,9 +81,9 @@ describe('runEntityCreateWizard (#24)', () => {
 
   it('adds create/update timestamp columns when selected', async () => {
     // uuid pk | created_at Timestamp createDate=Y | updated_at Datetime updateDate=Y
-    // (enum-вопрос задаётся только для Utf8/Int32 — у Timestamp его нет)
+    // (enum question only asked for Utf8/Int32 — Timestamp has none)
     const content = await expectWizardSuccess([
-      '', // таблица по умолчанию
+      '', // default table
       'uuid',
       '', // pk? Y
       '', // type Uuid
@@ -102,7 +102,7 @@ describe('runEntityCreateWizard (#24)', () => {
       'n', // createDate
       'y', // updateDate
       'n', // add another? no
-      '', // TTL? пропустить (есть date-like колонки)
+      '', // TTL? skip (has date-like columns)
       '', // write
     ]);
     expect(content).toContain(`@YdbCreateDateColumn()`);
@@ -138,29 +138,29 @@ describe('runEntityCreateWizard (#24)', () => {
   });
 
   it('re-prompts on invalid column names, duplicates and unknown types', async () => {
-    // bad-name → ошибка → дубликат uuid → ошибка → валидное имя; неизвестный тип → Utf8
+    // bad-name -> error -> duplicate uuid -> error -> valid name; unknown type -> Utf8
     const content = await expectWizardSuccess([
       '',
-      'uuid', // первая колонка (PK по умолчанию)
+      'uuid', // first column (PK by default)
       '', // pk Y
       '', // type Uuid
       '', // add another? yes
-      'bad-name', // невалидно
-      'uuid', // дубликат
+      'bad-name', // invalid
+      'uuid', // duplicate
       'title',
       'n', // pk
-      'NotAType', // неизвестный тип
+      'NotAType', // unknown type
       '', // Utf8
       'n', // encrypted
       'y', // enum?
-      'draft,published', // значения
+      'draft,published', // values
       '', // storage Utf8
       'n', // add another? no
       '', // write
     ]);
     expect(content).toContain(`@YdbEntity('test_thing')`);
     expect(content).toContain(`@YdbPrimaryColumn('Uuid')`);
-    // enum-ветка тоже отработала: колонка получила @YdbEnum поверх Utf8
+    // enum branch also worked: the column got @YdbEnum on top of Utf8
     expect(content).toContain(`@YdbColumn('Utf8')`);
     expect(content).toContain(`title: TitleEnum;`);
     expect(content).toContain("DRAFT = 'draft',");
@@ -190,7 +190,7 @@ describe('runEntityCreateWizard (#24)', () => {
 
 describe('cancellation/EOF (#24)', () => {
   it('aborts cleanly on EOF in the middle of the flow — no file written', async () => {
-    const io = scripted(['']); // только имя таблицы, дальше ввод кончился
+    const io = scripted(['']); // only table name, then input ended
     await expect(
       runEntityCreateCommand('aborted', { dir, interactive: true, ...io }),
     ).rejects.toBeInstanceOf(PromptCancelledError);
@@ -214,7 +214,7 @@ describe('cancellation/EOF (#24)', () => {
     const first = reader.ask('one: ');
     const err = new PromptCancelledError('SIGINT (Ctrl+C)');
     reader.cancel(err);
-    reader.cancel(new Error('second')); // идемпотентность
+    reader.cancel(new Error('second')); // idempotent
     await expect(first).rejects.toBe(err);
     await expect(reader.ask('two: ')).rejects.toBe(err);
     input.end();
@@ -223,9 +223,9 @@ describe('cancellation/EOF (#24)', () => {
 
 describe('non-TTY behavior (#24)', () => {
   it('does not read stdin outside TTY: deterministic default template', async () => {
-    // Входной поток никогда не заканчивается: если команда попытается
-    // читать stdin, тест зависнет и упадёт по таймауту jest.
-    const input = new PassThrough(); // ни данных, ни end()
+    // Input stream never ends: if command tries to read stdin, test would
+    // hang and fail by jest timeout.
+    const input = new PassThrough(); // no data, no end()
     const output = new PassThrough();
     let out = '';
     output.on('data', (d) => {
@@ -262,12 +262,12 @@ describe('collision handling (#24)', () => {
     const existing = path.join(dir, 'taken.entity.ts');
     fs.writeFileSync(existing, '// precious\n', 'utf-8');
 
-    // interactive:false — коллизия проверяется ещё раньше мастера.
+    // interactive:false — collision checked even before wizard.
     await expect(
       runEntityCreateCommand('taken', { dir, interactive: false }),
     ).rejects.toThrow(/already exists.*never overwrites/s);
 
-    // Ввод не потреблён и файл не изменён.
+    // Input not consumed and file not modified.
     expect(fs.readFileSync(existing, 'utf-8')).toBe('// precious\n');
   });
 

--- a/src/cli/entity-wizard.ts
+++ b/src/cli/entity-wizard.ts
@@ -1,15 +1,15 @@
 /**
- * Интерактивный мастер entity:create (#24): ввод колонок
- * (имя → тип YDB → PK/encrypted/enum/date-колонки/TTL) и генерация файла.
+ * Interactive entity:create wizard (#24): column input
+ * (name -> YDB type -> PK/encrypted/enum/date columns/TTL) and file generation.
  *
- * Гарантии:
- *  - валидация всех введённых определений ДО записи файла;
- *  - отмена/EOF (Ctrl+D/Ctrl+C) — чистый выход без записи;
- *  - существующий файл никогда не перезаписывается (проверка до старта
- *    мастера и защита в момент записи);
- *  - вне TTY ввод не читается вовсе: команда детерминированно создаёт
- *    шаблон по умолчанию и не зависает в ожидании ответов;
- *  - никаких обращений к БД и DDL — только локальная генерация файла.
+ * Guarantees:
+ *  - validation of all entered definitions BEFORE writing the file;
+ *  - cancel/EOF (Ctrl+D/Ctrl+C) — clean exit without writing;
+ *  - existing file is never overwritten (check before wizard start
+ *    and protection at write time);
+ *  - outside TTY input is not read at all: command deterministically creates
+ *    a default template and does not hang waiting for answers;
+ *  - no DB access or DDL — only local file generation.
  */
 import fs from 'node:fs';
 import { Writable } from 'node:stream';
@@ -38,20 +38,20 @@ const DATE_LIKE_TYPES = new Set<YdbPrimitive>([
 ]);
 
 export interface EntityCreateCommandOptions extends Partial<PromptIo> {
-  /** Директория файла сущности. */
+  /** Entity file directory. */
   dir: string;
   /**
-   * Принудительный режим мастера. По умолчанию мастер запускается только
-   * если input.isTTY — иначе создаётся шаблон по умолчанию без чтения ввода.
+   * Force wizard mode. By default the wizard runs only
+   * when input.isTTY — otherwise a default template is created without reading input.
    */
   interactive?: boolean;
 }
 
 /**
- * Точка входа команды entity:create.
+ * Entry point for the entity:create command.
  *
- * TTY — интерактивный мастер; не-TTY (CI/скрипты/закрытый stdin) — прежнее
- * поведение: шаблон по умолчанию (uuid PK + name), stdin не читается.
+ * TTY — interactive wizard; non-TTY (CI/scripts/closed stdin) — legacy
+ * behavior: default template (uuid PK + name), stdin not read.
  */
 export async function runEntityCreateCommand(
   name: string,
@@ -60,7 +60,7 @@ export async function runEntityCreateCommand(
   const dir = options.dir;
   const output = options.output ?? process.stdout;
 
-  // Коллизия обнаруживается ДО любых вопросов: файл никогда не перезаписывается.
+  // Collision detected BEFORE any questions: file is never overwritten.
   const target = entityFilePath(dir, name);
   if (fs.existsSync(target)) {
     throw new Error(
@@ -73,7 +73,7 @@ export async function runEntityCreateCommand(
     options.interactive ?? Boolean((input as NodeJS.ReadStream).isTTY);
 
   if (!interactive) {
-    // Детерминированный неинтерактивный путь: stdin не читается вообще.
+    // Deterministic non-interactive path: stdin is not read at all.
     return createDefaultEntity(name, dir, target, output);
   }
 
@@ -112,14 +112,14 @@ function createDefaultEntity(
 export interface EntityCreateWizardOptions extends PromptIo {
   name: string;
   dir: string;
-  /** Целевой путь файла (по умолчанию выводится из имени). */
+  /** Target file path (derived from name by default). */
   target?: string;
 }
 
 /**
- * Запускает интерактивный мастер и пишет файл сущности.
- * Бросает PromptCancelledError при EOF/Ctrl+C/Ctrl+D — файл в этом случае
- * гарантированно не создаётся.
+ * Runs the interactive wizard and writes the entity file.
+ * Throws PromptCancelledError on EOF/Ctrl+C/Ctrl+D — file is guaranteed
+ * not to be created in this case.
  */
 export async function runEntityCreateWizard(
   name: string,
@@ -132,7 +132,7 @@ export async function runEntityCreateWizard(
     io.writeLine(`Creating entity ${buildDefaultEntitySpec(name).className}`);
     io.writeLine('(empty column name finishes; Ctrl+C cancels)');
 
-    // Имя таблицы: пустой ввод принимает дефолт; невалидное переспрашивается.
+    // Table name: empty input accepts default; invalid re-prompts.
     const tableName = await askTableName(io, toSnakeCase(name));
 
     const columns: YdbEntityColumnSpec[] = [];
@@ -168,7 +168,7 @@ export async function runEntityCreateWizard(
         column.encrypted = true;
         column.blindIndex = await io.confirm('add blind index?', true);
       } else if (type === 'Utf8' || type === 'Int32') {
-        // Enum имеет смысл только для строковых и целочисленных колонок.
+        // Enum only makes sense for string and integer columns.
         if (await askEnum(io, column)) continue;
         await askDateColumns(io, column, type);
       } else {
@@ -189,7 +189,7 @@ export async function runEntityCreateWizard(
       );
     }
 
-    // TTL предлагается только для date-like колонок (unit не требуется).
+    // TTL offered only for date-like columns (unit not required).
     const dateLikeColumns = columns.filter((c) => DATE_LIKE_TYPES.has(c.type));
     let ttl: YdbEntitySpec['ttl'];
     if (dateLikeColumns.length > 0) {
@@ -214,7 +214,7 @@ export async function runEntityCreateWizard(
       ttl: ttl ?? null,
     };
 
-    // Полная валидация введённых определений ДО записи файла (#24).
+    // Full validation of entered definitions BEFORE writing the file (#24).
     const issues = validateEntitySpec(spec);
     if (issues.length) {
       for (const issue of issues) io.writeLine(`  ! ${issue}`);
@@ -234,7 +234,7 @@ export async function runEntityCreateWizard(
   }
 }
 
-/** Проблема имени колонки или null, если имя допустимо. */
+/** Column name issue or null if name is valid. */
 function columnNameIssue(
   name: string,
   existing: YdbEntityColumnSpec[],
@@ -251,7 +251,7 @@ function columnNameIssue(
   return null;
 }
 
-/** Для date-like колонок предлагает автопростановку create/update времени. */
+/** For date-like columns, offers auto-set create/update timestamps. */
 async function askDateColumns(
   io: PromptReader,
   column: YdbEntityColumnSpec,
@@ -307,9 +307,8 @@ async function askColumnType(
 }
 
 /**
- * Спрашивает enum-опции для колонки. Возвращает true, если ввод невалиден:
- * колонка при этом НЕ добавляется — пользователь вводит её заново
- * с самого начала (с имени).
+ * Asks for enum options for a column. Returns true if input is invalid:
+ * the column is NOT added — user re-enters it from the start (from name).
  */
 async function askEnum(
   io: PromptReader,

--- a/src/cli/exit-codes.ts
+++ b/src/cli/exit-codes.ts
@@ -1,41 +1,41 @@
 /**
- * Exit-коды CLI (#152).
+ * CLI exit codes (#152).
  *
- * Для `migration:check` / `migration:status` код детерминирован
- * состоянием проверки (см. migrations/migration-check.ts), чтобы CI
- * различал «не готово» разных причин и реальный сбой команды:
+ * For `migration:check` / `migration:status` the code is determined
+ * by the verification state (see migrations/migration-check.ts), so CI
+ * can distinguish different "not ready" reasons from an actual command failure:
  *
- *  0 — готово: все миграции применены; схема совпадает, если проверялась;
- *  1 — есть неприменённые миграции (pending);
- *  2 — есть прерванные миграции (`state='started'`, #101);
- *  3 — схема БД расходится с метаданными сущностей (нужен entities в конфиге);
- *  4 — содержимое применённой миграции изменилось (#101);
- *  5 — ошибка выполнения команды (подключение, конфиг, неожиданный сбой).
+ *  0 — ready: all migrations applied; schema matches if checked;
+ *  1 — pending migrations exist;
+ *  2 — interrupted migrations exist (`state='started'`, #101);
+ *  3 — DB schema diverges from entity metadata (requires entities in config);
+ *  4 — applied migration content changed (#101);
+ *  5 — command execution error (connection, config, unexpected crash).
  *
- * Остальные команды: 0 — успех/help, 1 — любая ошибка (как раньше).
+ * Other commands: 0 — success/help, 1 — any error (as before).
  */
 
-/** Готово (успех или help). */
+/** Ready (success or help). */
 export const EXIT_OK = 0;
-/** Есть неприменённые миграции. */
+/** Pending migrations exist. */
 export const EXIT_PENDING_MIGRATIONS = 1;
-/** Есть прерванные миграции (#101). */
+/** Interrupted migrations exist (#101). */
 export const EXIT_INTERRUPTED_MIGRATIONS = 2;
-/** Схема БД расходится с метаданными сущностей. */
+/** DB schema diverges from entity metadata. */
 export const EXIT_SCHEMA_DRIFT = 3;
-/** Содержимое применённой миграции изменилось (#101). */
+/** Applied migration content changed (#101). */
 export const EXIT_MODIFIED_MIGRATION = 4;
-/** Ошибка выполнения команды (check/status); остальные команды — 1. */
+/** Command execution error (check/status); other commands — 1. */
 export const EXIT_COMMAND_ERROR = 5;
 
-/** Exit-код по умолчанию для ошибок вне check/status. */
+/** Default exit code for errors outside check/status. */
 export const DEFAULT_EXIT_CODE = 1;
 
 const EXIT_CODE_TAG = Symbol('ydb-orm.cli.exitCode');
 
 /**
- * Помечает исходную ошибку exit-кодом, не заворачивая её: цепочка cause,
- * стек и сообщение остаются нетронутыми (formatError печатает как раньше).
+ * Tags the original error with an exit code, without wrapping it: the cause
+ * chain, stack, and message remain intact (formatError prints as before).
  */
 export function tagExitCode<T>(error: T, exitCode: number): T {
   if (error instanceof Error) {
@@ -45,8 +45,8 @@ export function tagExitCode<T>(error: T, exitCode: number): T {
 }
 
 /**
- * Достаёт exit-код из помеченной ошибки (или из её цепочки cause);
- * неизвестные ошибки — DEFAULT_EXIT_CODE.
+ * Extracts the exit code from a tagged error (or from its cause chain);
+ * unknown errors — DEFAULT_EXIT_CODE.
  */
 export function exitCodeOf(error: unknown): number {
   let current: unknown = error;

--- a/src/cli/generators.spec.ts
+++ b/src/cli/generators.spec.ts
@@ -85,9 +85,9 @@ describe('createEntityFile', () => {
   });
 
   it('#170: pins exclusive mode (openSync "wx"), not check-then-write', () => {
-    // Регресс-пин: атомарность живёт в одном системном вызове open(2) с
-    // O_CREAT|O_EXCL. Если реализацию вернут к existsSync()+writeFileSync,
-    // этот тест падает детерминированно.
+    // Regression-pin: atomicity lives in a single open(2) syscall with
+    // O_CREAT|O_EXCL. If the implementation reverted to existsSync()+writeFileSync,
+    // this test fails deterministically.
     const openSpy = jest.spyOn(fs, 'openSync');
     try {
       createEntityFile(dir, 'pinned');
@@ -99,12 +99,12 @@ describe('createEntityFile', () => {
   });
 
   it('#170: simultaneous writers from separate processes — exactly one wins', async () => {
-    // Настоящий race на уровне процессов: каждый child повторяет точную
-    // syscall-последовательность production-кода (openSync 'wx' → write →
-    // close) против одного и того же пути. Атомарность O_EXCL гарантирует
-    // ровно одного победителя независимо от таймингов процессов. Разные
-    // большие payload'ы позволяют поймать частичное/перекрёстное усечение
-    // (характерно для existsSync+truncate TOCTOU).
+    // A real race at the process level: each child repeats the exact
+    // syscall sequence of the production code (openSync 'wx' → write →
+    // close) against the same path. The atomicity of O_EXCL guarantees
+    // exactly one winner regardless of process timing. Different large
+    // payloads make it possible to catch partial/cross-wise truncation
+    // (typical of the existsSync+truncate TOCTOU).
     const target = path.join(dir, 'race.entity.ts');
     const count = 8;
     const filler = 'x'.repeat(64 * 1024);
@@ -146,17 +146,17 @@ describe('createEntityFile', () => {
     expect(losers).toBe(count - 1);
     expect(codes).not.toContain(2);
 
-    // Файл содержит ровно один целый payload — никакого смешивания/обрезки.
+    // The file contains exactly one complete payload — no mixing/truncation.
     const content = fs.readFileSync(target, 'utf-8');
     expect(payloads).toContain(content);
 
-    // Публичный API видит файл как существующий и не перезаписывает.
+    // The public API sees the file as existing and does not overwrite.
     expect(() => createEntityFile(dir, 'race')).toThrow(/already exists/);
   });
 });
 
 // ---------------------------------------------------------------------------
-// Генерация по спецификации (#24, entity:create)
+// Generation from spec (#24, entity:create)
 // ---------------------------------------------------------------------------
 
 describe('validateEntitySpec (#24)', () => {
@@ -275,7 +275,7 @@ describe('validateEntitySpec (#24)', () => {
   });
 
   it('rejects enum values colliding after member-name normalization (#153)', () => {
-    // Пунктуация нормализуется в '_': "a-b" и "a_b" → один член A_B.
+    // Punctuation is normalized to '_': "a-b" and "a_b" → one member A_B.
     const punct: YdbEntitySpec = validSpec();
     punct.columns.push({
       name: 'status',
@@ -290,7 +290,7 @@ describe('validateEntitySpec (#24)', () => {
       punctIssues.some((i) => i.includes('"a-b"') && i.includes('"a_b"')),
     ).toBe(true);
 
-    // Пунктуация + регистр: "foo.bar" и "FOO-BAR" → FOO_BAR.
+    // Punctuation + case: "foo.bar" and "FOO-BAR" → FOO_BAR.
     const mixed: YdbEntitySpec = validSpec();
     mixed.columns.push({
       name: 'status',
@@ -303,7 +303,7 @@ describe('validateEntitySpec (#24)', () => {
       ),
     ).toBe(true);
 
-    // Префикс цифры не спасает: "1" и "v_1" → V_1.
+    // A digit prefix doesn't help: "1" and "v_1" → V_1.
     const digit: YdbEntitySpec = validSpec();
     digit.columns.push({
       name: 'status',
@@ -417,7 +417,7 @@ describe('renderEntityFile (#24)', () => {
     );
     expect(rendered).toContain(`@YdbPrimaryColumn('Uuid')`);
     expect(rendered).toContain(`@YdbColumn('Utf8')`);
-    // Импорты сортируются и содержат только используемые декораторы.
+    // Imports are sorted and contain only the decorators actually used.
     expect(rendered.match(/^import \{$/m)).toBeTruthy();
     expect(rendered).not.toContain('YdbEncrypted');
     expect(rendered).not.toContain('YdbTtl');
@@ -516,7 +516,7 @@ describe('createEntityFileFromSpec (#24)', () => {
     ).toThrow(/Invalid entity spec/);
     expect(fs.readdirSync(dir)).toHaveLength(0);
 
-    // Коллизия нормализованных членов enum — тоже до записи файла (#153).
+    // Collision of normalized enum members — also before the file is written (#153).
     expect(() =>
       createEntityFileFromSpec(dir, {
         className: 'BadEnum',
@@ -581,8 +581,8 @@ describe('createMigrationFile', () => {
   });
 
   it('does not collide when called repeatedly at the same millisecond (#102)', () => {
-    // Фиксируем Date.now() в будущем (после любых реальных вызовов
-    // в других тестах): все три генерации попадают в одну миллисекунду.
+    // Pin Date.now() in the future (after any real calls in other tests):
+    // all three generations land in the same millisecond.
     const fixed = Date.now() + 60_000;
     const spy = jest.spyOn(Date, 'now').mockReturnValue(fixed);
     try {
@@ -598,15 +598,15 @@ describe('createMigrationFile', () => {
         expect(fs.existsSync(created.filePath)).toBe(true);
       }
 
-      // Лексикографическая сортировка загрузчика сохраняет хронологию:
-      // порядок имён после сортировки совпадает с порядком генерации.
+      // Lexicographic loader sorting preserves chronology:
+      // the name order after sorting matches the generation order.
       expect([first.name, second.name, third.name].sort()).toEqual([
         first.name,
         second.name,
         third.name,
       ]);
 
-      // Имена классов уникальны и являются валидными идентификаторами.
+      // Class names are unique and are valid identifiers.
       const classNames = [first, second, third].map(
         (created) =>
           fs
@@ -630,7 +630,7 @@ describe('createMigrationFile', () => {
     for (const created of [fromDigits, fromSymbols, fromMixed]) {
       const content = fs.readFileSync(created.filePath, 'utf-8');
       const className = content.match(/export class (\w+) implements/)?.[1];
-      // Класс не может начинаться с цифры — иначе файл не скомпилируется.
+      // A class cannot start with a digit — otherwise the file won't compile.
       expect(className).toMatch(/^[A-Za-z_$][A-Za-z0-9_$]*$/);
       expect(content).toContain(`readonly name = "${created.name}";`);
       expect(path.basename(created.filePath)).toBe(`${created.name}.ts`);

--- a/src/cli/generators.ts
+++ b/src/cli/generators.ts
@@ -8,7 +8,7 @@ import { YdbPrimitive } from '../core/types.js';
 import { validateIdentifier, validateTableName } from '../core/sql-utils.js';
 import { isoDurationToMicroseconds } from '../decorators/ttl.decorator.js';
 
-/** Разбивает строку на слова (по не-буквенно-цифровым символам и camelCase). */
+/** Splits a string into words (by non-alphanumeric and camelCase). */
 function words(input: string): string[] {
   return input
     .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
@@ -16,18 +16,21 @@ function words(input: string): string[] {
     .filter(Boolean);
 }
 
+/** Converts a string to PascalCase: splits on non-alphanumeric and camelCase boundaries. */
 export function toPascalCase(input: string): string {
   return words(input)
     .map((w) => w[0].toUpperCase() + w.slice(1).toLowerCase())
     .join('');
 }
 
+/** Converts a string to snake_case: splits on non-alphanumeric and camelCase boundaries. */
 export function toSnakeCase(input: string): string {
   return words(input)
     .map((w) => w.toLowerCase())
     .join('_');
 }
 
+/** Converts a string to kebab-case: splits on non-alphanumeric and camelCase boundaries. */
 export function toKebabCase(input: string): string {
   return words(input)
     .map((w) => w.toLowerCase())
@@ -35,10 +38,10 @@ export function toKebabCase(input: string): string {
 }
 
 /**
- * Гарантирует валидный TypeScript-идентификатор класса (#102): `toPascalCase`
- * от имени без буквенных слов ('123', '---') возвращает пустую строку или
- * строку с ведущей цифрой — такой класс не скомпилируется. Валидные имена
- * возвращаются без изменений (обратная совместимость).
+ * Ensures a valid TypeScript class identifier (#102): `toPascalCase`
+ * on a name without letter words ('123', '---') returns an empty string or
+ * a string starting with a digit — such a class won't compile. Valid names
+ * are returned unchanged (backward compatibility).
  */
 export function toValidClassName(input: string): string {
   const name = toPascalCase(input);
@@ -46,6 +49,7 @@ export function toValidClassName(input: string): string {
   return name;
 }
 
+/** Result of creating a file on disk. */
 export interface CreatedFile {
   filePath: string;
   name: string;
@@ -56,13 +60,13 @@ function writeFile(dir: string, fileName: string, content: string): string {
 }
 
 /**
- * Пишет файл по точному пути; существующий файл никогда не перезаписывается.
+ * Writes a file at an exact path; an existing file is never overwritten.
  *
- * Используется эксклюзивное открытие (флаг 'wx', как в entity-diagram.ts):
- * check-then-write через existsSync оставляет окно для гонки, где другой
- * процесс может подсунуть существующий файл или symlink между проверкой и
- * записью, и writeFileSync молча усекёт его. 'wx' не следует symlink и
- * атомарно падает EEXIST, гарантируя one-writer semantics (#170).
+ * Uses exclusive open (flag 'wx', like entity-diagram.ts):
+ * check-then-write via existsSync leaves a race window where another
+ * process could slip in an existing file or symlink between check and
+ * write, and writeFileSync would silently truncate it. 'wx' does not follow
+ * symlinks and atomically fails with EEXIST, guaranteeing one-writer semantics (#170).
  */
 function writeFileAt(filePath: string, content: string): string {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -70,8 +74,8 @@ function writeFileAt(filePath: string, content: string): string {
   try {
     fd = fs.openSync(filePath, 'wx');
   } catch (error) {
-    // Проверка по коду без instanceof: в VM-окружениях (jest ESM) ошибка
-    // из нативного fs может не наследовать Error этого контекста.
+    // Check by code, not instanceof: in VM environments (jest ESM) a native
+    // fs error may not inherit this context's Error.
     if ((error as NodeJS.ErrnoException)?.code === 'EEXIST') {
       throw new Error(
         `File already exists: ${filePath} — never overwrites existing files.`,
@@ -88,22 +92,22 @@ function writeFileAt(filePath: string, content: string): string {
 }
 
 /**
- * Последние использованные timestamp и суффикс: защита от коллизии имён
- * файлов миграций (#102). `Date.now()` имеет миллисекундную точность —
- * две генерации в пределах одной миллисекунды (или при скачке часов назад)
- * обязаны получить разные имена, иначе writeFile падает на существующем файле.
+ * Last used timestamp and suffix: protection against migration filename
+ * collisions (#102). `Date.now()` has millisecond precision — two generations
+ * within the same millisecond (or on a clock jump backward) must get
+ * different names, otherwise writeFile fails on an existing file.
  */
 let lastTimestamp = 0;
 let lastSuffix = 0;
 
 /**
- * Создаёт файл миграции. Без плана — пустой шаблон (migration:create),
- * с планом — заполненный DDL (migration:generate).
+ * Creates a migration file. Without a plan — empty template (migration:create),
+ * with a plan — filled DDL (migration:generate).
  *
- * Имя файла — `<timestamp>-<Name>`; повторная генерация в ту же миллисекунду
- * получает антиколлизионный суффикс `-1`, `-2`, … (#102). Лексикографическая
- * сортировка загрузчика сохраняется: все timestamps одной длины, короткое
- * имя (без суффикса) идёт раньше длиннее.
+ * Filename — `<timestamp>-<Name>`; re-generation within the same millisecond
+ * gets an anti-collision suffix `-1`, `-2`, ... (#102). Lexicographic
+ * sort order of the loader is preserved: all timestamps have the same length,
+ * short name (without suffix) comes before longer.
  */
 export function createMigrationFile(
   dir: string,
@@ -142,49 +146,49 @@ export function createMigrationFile(
   return { filePath, name: baseName };
 }
 
-/** Создаёт файл сущности (entity:create): `<kebab-name>.entity.ts`. */
+/** Creates an entity file (entity:create): `<kebab-name>.entity.ts`. */
 export function createEntityFile(dir: string, name: string): CreatedFile {
   return createEntityFileFromSpec(dir, buildDefaultEntitySpec(name));
 }
 
 // ---------------------------------------------------------------------------
-// Генерация сущности по спецификации (#24, интерактивный entity:create).
+// Entity generation from spec (#24, interactive entity:create).
 // ---------------------------------------------------------------------------
 
-/** Хранилище enum-колонки (совпадает с YdbEnumMeta.storage). */
+/** Enum column storage (matches YdbEnumMeta.storage). */
 export type YdbEnumStorage = 'Utf8' | 'Int32';
 
-/** Описание одной колонки/свойства генерируемой сущности. */
+/** Description of one column/property of the generated entity. */
 export interface YdbEntityColumnSpec {
-  /** Имя TS-свойства; оно же — имя колонки таблицы. */
+  /** TS property name; same as the table column name. */
   name: string;
-  /** YDB-тип колонки (@YdbColumn/@YdbPrimaryColumn). Игнорируется для encrypted-полей. */
+  /** YDB column type (@YdbColumn/@YdbPrimaryColumn). Ignored for encrypted fields. */
   type: YdbPrimitive;
-  /** Первичный ключ (@YdbPrimaryColumn). */
+  /** Primary key (@YdbPrimaryColumn). */
   primary?: boolean;
-  /** Шифруемое поле (@YdbEncrypted); тип колонки не объявляется (в БД всегда Bytes). */
+  /** Encrypted field (@YdbEncrypted); column type not declared (always Bytes in DB). */
   encrypted?: boolean;
-  /** Blind index для шифруемого поля (по умолчанию true, как у @YdbEncrypted). */
+  /** Blind index for encrypted field (default true, like @YdbEncrypted). */
   blindIndex?: boolean;
-  /** Enum-колонка: допустимые значения (@YdbEnum). */
+  /** Enum column: allowed values (@YdbEnum). */
   enumValues?: readonly string[];
-  /** Хранилище enum: Utf8 (строковое значение) или Int32 (порядковый номер). */
+  /** Enum storage: Utf8 (string value) or Int32 (ordinal). */
   enumStorage?: YdbEnumStorage;
-  /** Автопростановка времени создания (@YdbCreateDateColumn). */
+  /** Auto-set creation time (@YdbCreateDateColumn). */
   createDate?: boolean;
-  /** Автопростановка времени обновления (@YdbUpdateDateColumn). */
+  /** Auto-set update time (@YdbUpdateDateColumn). */
   updateDate?: boolean;
 }
 
-/** TTL таблицы (@YdbTtl) для date-like колонки (Date/Datetime/Timestamp). */
+/** Table TTL (@YdbTtl) for a date-like column (Date/Datetime/Timestamp). */
 export interface YdbEntityTtlSpec {
-  /** ISO 8601 duration, например "PT2H" или "P30D". */
+  /** ISO 8601 duration, e.g. "PT2H" or "P30D". */
   interval: string;
-  /** Имя date-like колонки. */
+  /** Date-like column name. */
   column: string;
 }
 
-/** Спецификация генерируемой сущности. */
+/** Specification of the generated entity. */
 export interface YdbEntitySpec {
   className: string;
   tableName: string;
@@ -195,9 +199,9 @@ export interface YdbEntitySpec {
 const IDENTIFIER_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 /**
- * Имена, которые нельзя занимать свойствами сущности: члены YdbBaseEntity
- * (Active Record API) и служебные члены любого объекта. Колонка с таким
- * именем скомпилировалась бы, но сломала бы рантайм ORM.
+ * Names that cannot be used for entity properties: YdbBaseEntity members
+ * (Active Record API) and built-in object members. A column with such
+ * a name would compile but break the ORM runtime.
  */
 const RESERVED_PROPERTY_NAMES: ReadonlySet<string> = new Set([
   'constructor',
@@ -230,7 +234,7 @@ const RESERVED_PROPERTY_NAMES: ReadonlySet<string> = new Set([
   'loadRelations',
 ]);
 
-/** YDB-примитивы, доступные в мастере entity:create (см. core/types.ts). */
+/** YDB primitives available in entity:create wizard (see core/types.ts). */
 export const ENTITY_CREATE_TYPES: readonly YdbPrimitive[] = [
   'Uuid',
   'Utf8',
@@ -247,7 +251,7 @@ export const ENTITY_CREATE_TYPES: readonly YdbPrimitive[] = [
   'JsonDocument',
 ];
 
-/** Типы, для которых имеет смысл @YdbCreateDateColumn/@YdbUpdateDateColumn/TTL. */
+/** Types for which @YdbCreateDateColumn/@YdbUpdateDateColumn/TTL make sense. */
 const DATE_LIKE_TYPES: readonly YdbPrimitive[] = [
   'Date',
   'Datetime',
@@ -259,9 +263,9 @@ function isDateLike(type: YdbPrimitive): boolean {
 }
 
 /**
- * Валидирует спецификацию сущности ДО записи файла (#24).
- * Возвращает список проблем (пустой — если всё в порядке); файл не пишется,
- * пока список непуст.
+ * Validates the entity spec BEFORE writing the file (#24).
+ * Returns a list of issues (empty if all is well); file is not written
+ * until the list is empty.
  */
 export function validateEntitySpec(spec: YdbEntitySpec): string[] {
   const issues: string[] = [];
@@ -287,9 +291,9 @@ export function validateEntitySpec(spec: YdbEntitySpec): string[] {
   }
 
   const seen = new Set<string>();
-  // Имя enum-типа выводится из имени колонки: карта для детекта коллизий
-  // ('foo_bar' и 'fooBar' → FooBarEnum) — два объявления одного типа
-  // не компилируются.
+  // Enum type name is derived from column name: map for collision detection
+  // ('foo_bar' and 'fooBar' -> FooBarEnum) — two declarations of the same
+  // type don't compile.
   const seenEnumTypeNames = new Map<string, string>();
   let primaryCount = 0;
   let createDateCount = 0;
@@ -302,8 +306,8 @@ export function validateEntitySpec(spec: YdbEntitySpec): string[] {
       continue;
     }
     if (!IDENTIFIER_RE.test(column.name)) {
-      // Свойство становится и TS-идентификатором, и SQL-колонкой:
-      // требования к обоим совпадают (ASCII буквы/цифры/_).
+      // Property becomes both a TS identifier and a SQL column:
+      // requirements for both match (ASCII letters/digits/_).
       issues.push(
         `${label}: invalid property name — must match /^[A-Za-z_][A-Za-z0-9_]*$/`,
       );
@@ -349,9 +353,9 @@ export function validateEntitySpec(spec: YdbEntitySpec): string[] {
             break;
           }
         }
-        // Нормализация имени члена lossy ("a-b" и "a_b" → A_B): дубликаты
-        // членов в одном объявлении enum не компилируются (duplicate
-        // identifier), поэтому ловим их до записи файла (#24).
+        // Member name normalization is lossy ("a-b" and "a_b" -> A_B): duplicates
+        // within one enum declaration don't compile (duplicate
+        // identifier), so we catch them before writing the file (#24).
         const valuesByMember = new Map<string, string[]>();
         for (const value of column.enumValues) {
           if (typeof value !== 'string') continue;
@@ -369,8 +373,8 @@ export function validateEntitySpec(spec: YdbEntitySpec): string[] {
             );
           }
         }
-        // Имена enum-типов выводятся из колонки тоже lossy ('foo_bar' и
-        // 'fooBar' → FooBarEnum): два объявления одного типа в файле —
+        // Enum type names are derived from column name too lossy ('foo_bar' and
+        // 'fooBar' -> FooBarEnum): two declarations of the same type in a file —
         // duplicate identifier.
         const typeName = enumTypeName(column.name);
         const typeNameOwner = seenEnumTypeNames.get(typeName);
@@ -451,7 +455,7 @@ export function validateEntitySpec(spec: YdbEntitySpec): string[] {
   return issues;
 }
 
-/** TS-тип свойства, соответствующий семантике маппера (core/mapper.ts). */
+/** TS property type corresponding to mapper semantics (core/mapper.ts). */
 function tsPropertyType(column: YdbEntityColumnSpec): string {
   if (column.enumValues) return enumTypeName(column.name);
   switch (column.type) {
@@ -479,18 +483,18 @@ function tsPropertyType(column: YdbEntityColumnSpec): string {
   return 'unknown';
 }
 
-/** Имя TS enum-типа для колонки ("status" → StatusEnum, "order_type" → OrderTypeEnum). */
+/** TS enum type name for a column ("status" -> StatusEnum, "order_type" -> OrderTypeEnum). */
 function enumTypeName(propertyName: string): string {
   const pascal = toPascalCase(propertyName);
   return `${pascal}Enum`;
 }
 
-/** Строковый литерал в исходнике с одинарными кавычками (стиль .prettierrc). */
+/** String literal in source with single quotes (per .prettierrc style). */
 function singleQuoted(value: string): string {
   return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
 }
 
-/** Имя члена enum из строкового значения ("new_order" → NEW_ORDER). */
+/** Enum member name from a string value ("new_order" -> NEW_ORDER). */
 export function toEnumMemberName(value: string): string {
   const member = value.toUpperCase().replace(/[^A-Z0-9]+/g, '_');
   if (/^[0-9]/.test(member)) return `V_${member}`;
@@ -498,9 +502,9 @@ export function toEnumMemberName(value: string): string {
 }
 
 /**
- * Рендерит исходник сущности в текущем публичном API (@YdbEntity/@YdbColumn/
- * @YdbPrimaryColumn/@YdbEnum/@YdbEncrypted/@YdbTtl/Ydb*-date-колонки).
- * Форматирование соответствует .prettierrc проекта (singleQuote, trailingComma).
+ * Renders the entity source in the current public API (@YdbEntity/@YdbColumn/
+ * @YdbPrimaryColumn/@YdbEnum/@YdbEncrypted/@YdbTtl/Ydb*-date columns).
+ * Formatting matches project .prettierrc (singleQuote, trailingComma).
  */
 export function renderEntityFile(spec: YdbEntitySpec): string {
   const issues = validateEntitySpec(spec);
@@ -532,7 +536,7 @@ export function renderEntityFile(spec: YdbEntitySpec): string {
   lines.push("} from '@ycforge/ydb-orm';");
   lines.push('');
 
-  // Enum-объявления — перед классом (на них ссылаются типы свойств).
+  // Enum declarations come before the class (property types reference them).
   for (const column of spec.columns) {
     if (!column.enumValues) continue;
     lines.push(`export enum ${enumTypeName(column.name)} {`);
@@ -552,8 +556,8 @@ export function renderEntityFile(spec: YdbEntitySpec): string {
   lines.push(`export class ${spec.className} extends YdbBaseEntity {`);
 
   spec.columns.forEach((column, index) => {
-    // Порядок соответствует фикстурам/документации:
-    // date-декораторы → колонка/PK → шифрование → enum.
+    // Order matches fixtures/docs:
+    // date decorators -> column/PK -> encryption -> enum.
     const decorators: string[] = [];
     if (column.createDate) decorators.push('@YdbCreateDateColumn()');
     if (column.updateDate) decorators.push('@YdbUpdateDateColumn()');
@@ -586,7 +590,7 @@ export function renderEntityFile(spec: YdbEntitySpec): string {
   return `${lines.join('\n')}\n`;
 }
 
-/** Путь файла сущности без записи: `<dir>/<kebab-name>.entity.ts`. */
+/** Entity file path without writing: `<dir>/<kebab-name>.entity.ts`. */
 export function entityFilePath(dir: string, name: string): string {
   const kebab = toKebabCase(name);
   const fileName = `${kebab || toPascalCase(name).toLowerCase()}.entity.ts`;
@@ -594,8 +598,8 @@ export function entityFilePath(dir: string, name: string): string {
 }
 
 /**
- * Спецификация «по умолчанию» (неинтерактивный путь entity:create):
- * uuid PK + name — тот же шаблон, что и раньше.
+ * Default spec (non-interactive entity:create path):
+ * uuid PK + name — same template as before.
  */
 export function buildDefaultEntitySpec(name: string): YdbEntitySpec {
   return {
@@ -609,8 +613,8 @@ export function buildDefaultEntitySpec(name: string): YdbEntitySpec {
 }
 
 /**
- * Валидный TS-идентификатор класса сущности (#102): как toValidClassName,
- * но префикс Entity вместо Migration (миграции не трогаем).
+ * Valid TS entity class identifier (#102): like toValidClassName,
+ * but with Entity prefix instead of Migration (migrations untouched).
  */
 export function toValidEntityClassName(input: string): string {
   const name = toPascalCase(input);
@@ -619,12 +623,12 @@ export function toValidEntityClassName(input: string): string {
 }
 
 /**
- * Создаёт файл сущности по спецификации: сначала полная валидация (#24),
- * затем запись с защитой от перезаписи существующего файла.
+ * Creates an entity file from a spec: full validation first (#24),
+ * then write with protection against overwriting an existing file.
  *
- * `filePath` — явный путь (используется CLI-мастером, чтобы pre-check
- * коллизии и фактическая запись гарантированно указывали на один файл);
- * по умолчанию имя файла выводится из имени таблицы.
+ * `filePath` — explicit path (used by CLI wizard so that pre-check
+ * collision and actual write guaranteed point to the same file);
+ * by default file name derived from table name.
  */
 export function createEntityFileFromSpec(
   dir: string,

--- a/src/cli/metadata-dump.ts
+++ b/src/cli/metadata-dump.ts
@@ -1,26 +1,26 @@
 /**
- * metadata:dump (#37): read-only экспорт метаданных сущностей
- * в детерминированный JSON.
+ * metadata:dump (#37): read-only export of entity metadata
+ * to deterministic JSON.
  *
- * Гарантии:
- *  - НИКАКОГО I/O в БД: ни драйвера, ни executor'а, ни DDL, ни миграций —
- *    функция синхронная и работает только с метаданными классов;
- *  - весь дамп строится до первого байта вывода: невалидные/незарегистрированные
- *    сущности и конфликтующие метаданные роняют команду с понятной ошибкой,
- *    а не дают частичный вывод;
- *  - детерминизм: стабильный порядок сущностей (по имени таблицы), колонок,
- *    индексов, связей, enum-ов и ключей JSON; повторный вызов на тех же
- *    сущностях даёт побайтово одинаковый JSON;
- *  - сериализуются только простые значения: никаких функций, инстансов
- *    классов, циклических ссылок или внутренних объектов фреймворка;
- *  - формат версионируется (format + version) для безопасной эволюции.
+ * Guarantees:
+ *  - NO DB I/O whatsoever: no driver, no executor, no DDL, no migrations —
+ *    the function is synchronous and works only with class metadata;
+ *  - the entire dump is built before the first byte of output: invalid/unregistered
+ *    entities and conflicting metadata fail the command with a clear error,
+ *    rather than producing partial output;
+ *  - determinism: stable order of entities (by table name), columns,
+ *    indexes, relations, enums, and JSON keys; repeated calls on the same
+ *    entities yield byte-identical JSON;
+ *  - only plain values are serialized: no functions, class instances,
+ *    cyclic references, or framework internal objects;
+ *  - format is versioned (format + version) for safe evolution.
  *
- * Реализация использует только канонические точки резолва ORM — обхода
- * декораторов нет: getYdbEntityMetadata, buildExpectedTableSchema
- * (колонки/PK/индексы/TTL + валидация), getYdbRelationsMetadata,
+ * Implementation uses only canonical ORM resolution points — no decorator
+ * walk: getYdbEntityMetadata, buildExpectedTableSchema
+ * (columns/PK/indexes/TTL + validation), getYdbRelationsMetadata,
  * resolveRelationJoinColumn (#87), resolveRelationJoinTableDefinition /
  * getManyToManyJoinTables (#90/#139), getYdbEnumMetadata, getEagerRelations.
- * Семантика наследования #92/#107 наследуется от этих функций автоматически.
+ * Inheritance semantics #92/#107 inherited from these functions automatically.
  */
 
 import type { YdbPrimitive } from '../core/types.js';
@@ -50,22 +50,22 @@ import { getEagerRelations } from '../decorators/eager.decorator.js';
 import { requireEntityMeta } from './migration-verify.js';
 import { compareStrings } from './sort.js';
 
-/** Идентификатор формата дампа (верхнеуровневое поле format). */
+/** Dump format identifier (top-level `format` field). */
 export const METADATA_DUMP_FORMAT = 'ydb-orm/metadata-dump';
 
-/** Версия формата дампа: несовместимые изменения схемы JSON увеличивают её. */
+/** Dump format version: incremented on incompatible JSON schema changes. */
 export const METADATA_DUMP_VERSION = 1;
 
 export interface DumpedColumn {
   name: string;
   type: YdbPrimitive;
-  /** Входит в первичный ключ. */
+  /** Part of the primary key. */
   primary: boolean;
 }
 
 export interface DumpedIndex {
   name: string;
-  /** Колонки индекса — порядок значим (префиксный поиск YDB). */
+  /** Index columns — order is significant (YDB prefix search). */
   columns: string[];
   unique: boolean;
 }
@@ -74,44 +74,44 @@ export interface DumpedTtl {
   column: string;
   /** ISO 8601 duration ("PT2H", "P30D"). */
   interval: string;
-  /** Единица числовой TTL-колонки; отсутствует для Date/Datetime/Timestamp. */
+  /** Numeric TTL column unit; absent for Date/Datetime/Timestamp. */
   unit?: YdbTtlUnit;
 }
 
 export interface DumpedEnum {
   property: string;
-  /** Значения enum — порядок сохранён (семантичен для storage Int32). */
+  /** Enum values — order preserved (semantically significant for Int32 storage). */
   values: string[];
   storage: 'Utf8' | 'Int32';
 }
 
 /**
- * Метаданные шифрования без секретов: только декларативная конфигурация
- * полей. Провайдеры, ключи, salt/secret-материал и runtime-состояние
- * сюда не попадают никогда.
+ * Encryption metadata without secrets: only declarative field
+ * configuration. Providers, keys, salt/secret material and runtime state
+ * are never included.
  */
 export interface DumpedEncryptedField {
   property: string;
   blindIndex: boolean;
-  /** Synthetic-колонка blind index (`{property}_bi`); null, если выключен. */
+  /** Synthetic blind index column (`{property}_bi`); null when disabled. */
   blindIndexColumn: string | null;
-  /** Ленивая дешифровка (@YdbEncrypted({ lazy: true })). */
+  /** Lazy decryption (@YdbEncrypted({ lazy: true })). */
   lazy: boolean;
-  /** Явный AAD-контекст поля; null — используется AAD по умолчанию. */
+  /** Explicit AAD context for the field; null — uses the default AAD. */
   aadOverride: string | null;
 }
 
 export interface DumpedRelationTarget {
-  /** Имя класса целевой сущности. */
+  /** Class name of the target entity. */
   entity: string;
-  /** Имя таблицы целевой сущности. */
+  /** Table name of the target entity. */
   table: string;
 }
 
 /**
- * Ссылка m2m-связи на join-таблицу из верхнеуровневого списка joinTables:
- * side='owner' — @JoinTable объявлен на этой связи; side='inverse' — на
- * противоположной стороне (owner указывает, на какой именно).
+ * M2M relation reference to a join table from the top-level joinTables
+ * list: side='owner' — @JoinTable declared on this relation;
+ * side='inverse' — declared on the opposite side (owner indicates which).
  */
 export interface DumpedJoinTableRef {
   table: string;
@@ -124,36 +124,36 @@ export interface DumpedRelation {
   type: RelationType;
   target: DumpedRelationTarget;
   /**
-   * FK-колонка: для many-to-one/one-to-one — колонка этой сущности,
-   * для one-to-many — колонка целевой сущности. Для many-to-many отсутствует.
+   * FK column: for many-to-one/one-to-one — this entity's column;
+   * for one-to-many — the target entity's column. Absent for many-to-many.
    */
   joinColumn?: string;
-  /** Свойство обратной связи на целевой сущности; null, если не объявлено. */
+  /** Inverse relation property on the target entity; null if not declared. */
   inverseProperty: string | null;
-  /** Только для many-to-many; детали — в верхнеуровневом списке joinTables. */
+  /** Only for many-to-many; details in the top-level joinTables list. */
   joinTable: DumpedJoinTableRef | null;
 }
 
 export interface DumpedEntity {
   className: string;
   table: string;
-  /** PK-колонки в порядке объявления (в YDB порядок PK значим, #89). */
+  /** PK columns in declaration order (YDB PK order is significant, #89). */
   primaryKey: string[];
   columns: DumpedColumn[];
   indexes: DumpedIndex[];
   ttl: DumpedTtl | null;
   enums: DumpedEnum[];
   encryptedFields: DumpedEncryptedField[];
-  /** PK-колонки — участники AAD-строки шифрования. */
+  /** PK columns that participate in the encryption AAD string. */
   aadFields: string[];
-  /** Колонки с автоматической JSON-сериализацией (хранятся как Utf8). */
+  /** Columns with automatic JSON serialization (stored as Utf8). */
   jsonColumns: string[];
-  /** Связи, автоматически подгружаемые при find/findAll (#107). */
+  /** Relations auto-loaded during find/findAll (#107). */
   eagerLoad: string[];
   relations: DumpedRelation[];
 }
 
-/** Физическая join-таблица many-to-many (верхнеуровневый список). */
+/** Physical many-to-many join table (top-level list). */
 export interface DumpedJoinTable {
   table: string;
   joinColumn: string;
@@ -174,20 +174,21 @@ export interface MetadataDump {
 type EntityCtor = new (...args: any[]) => any;
 
 /**
- * Строит дамп метаданных для переданного списка сущностей.
+ * Builds a metadata dump for the given list of entities.
  *
- * Список задаёт состав дампа (обычно config.entities из ydb-orm.config.ts);
- * порядок вывода от него не зависит — сущности сортируются по имени таблицы.
- * Чистая синхронная функция: БД не трогает, ошибок конфигурации не глотает.
+ * The list defines the dump composition (usually config.entities from
+ * ydb-orm.config.ts); output order does not depend on it — entities are
+ * sorted by table name. Pure synchronous function: does not touch the DB
+ * and does not swallow configuration errors.
  */
 export function buildMetadataDump(entities: EntityCtor[]): MetadataDump {
-  // requireEntityMeta падает сразу для класса без собственного @YdbEntity —
-  // иначе остальные канонические функции молча пропустили бы такой класс.
+  // requireEntityMeta fails immediately for a class without its own @YdbEntity —
+  // otherwise other canonical functions would silently pass such a class.
   for (const entity of entities) {
     requireEntityMeta(entity);
   }
 
-  // Повтор класса в списке дедуплицируется (как в buildExpectedSchemas).
+  // Duplicate class in list is deduplicated (like in buildExpectedSchemas).
   const seen = new Set<EntityCtor>();
   const uniqueEntities: EntityCtor[] = [];
   for (const entity of entities) {
@@ -197,11 +198,11 @@ export function buildMetadataDump(entities: EntityCtor[]): MetadataDump {
     }
   }
 
-  // Каноническая валидация модели: дедупликация классов, конфликт имён
-  // таблиц (#92), обязательный PK, валидность TTL против схемы. Все ошибки —
-  // до какого-либо вывода; ожидаемые схемы дальше служат каноническим
-  // источником физических колонок (включая synthetic `{field}_bi`),
-  // индексов с resolved-именами и TTL.
+  // Canonical model validation: class deduplication, table name conflicts
+  // (#92), required PK, TTL validity against schema. All errors —
+  // before any output; expected schemas further serve as the canonical
+  // source of physical columns (including synthetic `{field}_bi`),
+  // indexes with resolved names, and TTL.
   const expectedByTable = new Map(
     buildExpectedSchemas(uniqueEntities).map((schema) => [
       schema.tableName,
@@ -209,8 +210,8 @@ export function buildMetadataDump(entities: EntityCtor[]): MetadataDump {
     ]),
   );
 
-  // Join-таблицы many-to-many: канонический резолв с дедупликацией и
-  // детекцией расходящихся объявлений (#139) — конфликты роняют дамп.
+  // Many-to-many join tables: canonical resolution with deduplication and
+  // detection of conflicting declarations (#139) — conflicts fail the dump.
   const joinTableDefs = getManyToManyJoinTables(uniqueEntities);
 
   const dumpedEntities = uniqueEntities
@@ -233,9 +234,9 @@ function dumpEntity(
   joinTableDefs: ManyToManyJoinTable[],
 ): DumpedEntity {
   const meta = getYdbEntityMetadata(Entity)!;
-  // Ожидаемая схема построена канонически выше (buildExpectedSchemas):
-  // физические колонки (включая synthetic `{field}_bi`), индексы
-  // с resolved-именами и TTL.
+  // Expected schema built canonically above (buildExpectedSchemas):
+  // physical columns (including synthetic `{field}_bi`), indexes
+  // with resolved names, and TTL.
   const expected = expectedByTable.get(meta.tableName)!;
 
   const columns: DumpedColumn[] = Object.entries(expected.columns)
@@ -325,8 +326,8 @@ function dumpRelation(
   };
 
   if (relation.type !== 'many-to-many') {
-    // Тот же строгий резолв, что и в рантайме relations (#87):
-    // невалидный селектор/отсутствие join-колонки — ошибка, а не угаданная строка.
+    // Same strict resolution as in runtime relations (#87):
+    // invalid selector/missing join column — error, not a guessed string.
     dumped.joinColumn = resolveRelationJoinColumn(relation.joinColumn, {
       entityName: Entity.name,
       relationPropertyKey: relation.propertyKey,
@@ -366,12 +367,12 @@ function resolveJoinTableRef(
     (jt) => jt.propertyKey === relation.propertyKey,
   );
   if (ownJoin) {
-    // Канонический резолв объявления (#90/#87): ошибки конфигурации
-    // (нет PK, составной PK, невыводимый тип) роняют дамп.
+    // Canonical declaration resolution (#90/#87): configuration errors
+    // (no PK, composite PK, non-inferrable type) fail the dump.
     const definition = resolveRelationJoinTableDefinition(Entity, relation);
     if (!definition) {
-      // Инвариант: @JoinTable на m2m-связи декорированной сущности всегда
-      // резолвится в определение — undefined здесь невозможен.
+      // Invariant: @JoinTable on an m2m relation of a decorated entity always
+      // resolves to a definition — undefined here is impossible.
       throw new Error(
         `Cannot resolve join table for relation "${relation.propertyKey}" ` +
           `on ${Entity.name} despite a @JoinTable declaration.`,
@@ -380,9 +381,9 @@ function resolveJoinTableRef(
     return { table: definition.tableName, side: 'owner' };
   }
 
-  // Обратная сторона: join-таблица ищется среди определений, владельцами
-  // которых являются сущности текущего дампа. Без совпадения — null
-  // (владелец может не входить в список сущностей этого дампа).
+  // Inverse side: join table is searched among definitions whose owners
+  // are entities in the current dump. No match -> null
+  // (owner may not be in this dump's entity list).
   const TargetCtor = relation.target();
   let candidates = joinTableDefs.filter(
     (def) => def.ownerEntity === TargetCtor && def.inverseEntity === Entity,
@@ -408,20 +409,20 @@ function resolveJoinTableRef(
 }
 
 /**
- * Имя обратного свойства связи, если оно объявлено на целевой сущности.
+ * Inverse relation property name, if declared on the target entity.
  *
- *  - many-to-many: селектор inverseSide резолвится тем же строгим
- *    способом, что и join-колонки (#87): ровно одно чтение свойства,
- *    всё остальное — ошибка конфигурации;
- *  - one-to-many ↔ many-to-one: обратная связь ищется по той же
- *    join-колонке (значение колонки сравнивается с PK, поэтому связь
- *    пары однозначно определяется колонкой);
- *  - one-to-one: обратная one-to-one на целевой сущности (каждая сторона
- *    хранит собственную FK-колонку, поэтому соответствие — по типу и цели).
+ *  - many-to-many: inverseSide selector resolved with the same strict
+ *    method as join columns (#87): exactly one property read,
+ *    everything else — configuration error;
+ *  - one-to-many <-> many-to-one: inverse relation found by the same
+ *    join column (column value compared with PK, so the pair relation
+ *    is uniquely determined by the column);
+ *  - one-to-one: inverse one-to-one on target entity (each side stores
+ *    its own FK column, so matching is by type and target).
  *
- * Необъявленная обратная связь — норма (однонаправленные связи): null,
- * а не ошибка. Невалидные кандидаты пропускаются: их отвергнет проверка
- * самой сущности-владельца с её контекстом.
+ * Undeclared inverse relation is normal (unidirectional relations): null,
+ * not an error. Invalid candidates are skipped: they will be rejected by
+ * the owning entity's own validation with its context.
  */
 function findInverseProperty(
   Entity: EntityCtor,
@@ -441,7 +442,7 @@ function findInverseProperty(
       relationPropertyKey: relation.propertyKey,
     });
   } catch {
-    // Невалидное объявление отвергнет dumpRelation с полным контекстом.
+    // Invalid declaration will be rejected by dumpRelation with full context.
     return null;
   }
 
@@ -480,10 +481,10 @@ function findInverseProperty(
 }
 
 /**
- * Резолвит селектор inverseSide `(target) => target.property` каноническим
- * резолвером property-селекторов (#87) — та же строгость, что у join-колонок:
- * ровно одно чтение свойства, цепочки/вызовы/константы — ошибка с именем
- * сущности и связи.
+ * Resolves the inverseSide selector `(target) => target.property` using the
+ * canonical property selector resolver (#87) — same strictness as join columns:
+ * exactly one property read, chains/calls/constants — error with entity
+ * and relation name.
  */
 function resolveInverseSideProperty(
   Entity: EntityCtor,

--- a/src/cli/migration-verify.integration.spec.ts
+++ b/src/cli/migration-verify.integration.spec.ts
@@ -1,19 +1,19 @@
 /**
- * Интеграционные регресс-тесты read-only контракта (#152).
+ * Integration regression tests of the read-only contract (#152).
  *
- * В отличие от юнит-спеков с швом inspectBookkeeping, здесь вызывается
- * РЕАЛЬНЫЙ runMigrationVerification() с РЕАЛЬНЫМ дефолтным путём чтения
- * таблицы учёта (readBookkeepingSnapshot → YdbSchemaSyncer.describeTable
- * через Table service). Подменяются только транспортные границы:
- *  - driver.createClient(TableServiceDefinition) → фейковый Table client
- *    (DescribeTable отдаёт управляемые метаданные);
- *  - executor — строгий мок: ЛЮБОЙ не-SELECT бросает исключение, поэтому
- *    попытка CREATE/ALTER/INSERT/... из verification-пути роняет тест,
- *    а не проходит незамеченным; все выполненные SQL записываются и
- *    сверяются построчно.
+ * Unlike the unit specs with an inspectBookkeeping seam, here the REAL
+ * runMigrationVerification() is called with the REAL default path of reading
+ * the bookkeeping table (readBookkeepingSnapshot → YdbSchemaSyncer.describeTable
+ * via the Table service). Only transport boundaries are replaced:
+ *  - driver.createClient(TableServiceDefinition) → a fake Table client
+ *    (DescribeTable returns controlled metadata);
+ *  - executor — a strict mock: ANY non-SELECT throws, so an attempted
+ *    CREATE/ALTER/INSERT/... from the verification path fails the test
+ *    loudly rather than passing unnoticed; all executed SQL is recorded and
+ *    compared line by line.
  *
- * loadMigrations инжектируется только чтобы не зависеть от ФС — таблица
- * учёта в этих тестах читается настоящим кодом.
+ * loadMigrations is injected only to avoid depending on the filesystem — the
+ * bookkeeping table in these tests is read by the real code.
  */
 import { jest } from '@jest/globals';
 import { create } from '@bufbuild/protobuf';
@@ -36,7 +36,7 @@ import {
 
 type AnyRecord = Record<string, unknown>;
 
-/** Строгий executor: SELECT — ок (пишем SQL, отдаём строки), остальное — падение. */
+/** Strict executor: SELECT — ok (records SQL, returns rows), everything else — failure. */
 function makeStrictExecutor(resultRows: AnyRecord[] = []) {
   const executedSql: string[] = [];
 
@@ -62,7 +62,7 @@ function makeStrictExecutor(resultRows: AnyRecord[] = []) {
         return Promise.resolve()
           .then(() => {
             if (!sql.trimStart().startsWith('SELECT')) {
-              // Попытка DDL/DML из read-only пути — громкое падение теста.
+              // An attempted DDL/DML from the read-only path — a loud test failure.
               throw new Error(
                 `READ-ONLY VIOLATION: non-SELECT executed in verification path: ${sql}`,
               );
@@ -79,9 +79,9 @@ function makeStrictExecutor(resultRows: AnyRecord[] = []) {
   return {
     executor: executor as unknown,
     executedSql,
-    /** Ни одного запроса к БД вообще. */
+    /** No DB query at all. */
     expectNoSqlAtAll: () => expect(executor).not.toHaveBeenCalled(),
-    /** Ровно ожидаемый список SQL (без лишних probe/probe-like запросов). */
+    /** Exactly the expected list of SQL (no extra probe/probe-like queries). */
     expectExactly(expected: string[]) {
       expect(executedSql).toEqual(expected);
     },
@@ -213,8 +213,8 @@ describe('runMigrationVerification: real path emits no DDL/DML (#152)', () => {
   ];
 
   describe('initialized modern bookkeeping (hash/state present)', () => {
-    // В таблице нет записей для '2-Pending' и '4-Missing' — они и есть
-    // pending; запись '3-Started' осталась от оборванного запуска.
+    // The table has no records for '2-Pending' and '4-Missing' — they are
+    // the pending ones; the '3-Started' record was left from an interrupted run.
     const rows: AnyRecord[] = [
       {
         id: 1,
@@ -230,7 +230,7 @@ describe('runMigrationVerification: real path emits no DDL/DML (#152)', () => {
         hash: 'hs',
         state: 'started',
       },
-      // Имя совпадает с файлом, хеш различается — modified после apply.
+      // Name matches the file, hash differs — modified after apply.
       {
         id: 5,
         timestamp: 5000,
@@ -238,7 +238,7 @@ describe('runMigrationVerification: real path emits no DDL/DML (#152)', () => {
         hash: 'h5-old',
         state: 'applied',
       },
-      // Запись без файла — orphan.
+      // Record without a file — orphan.
       {
         id: 9,
         timestamp: 9000,
@@ -280,7 +280,7 @@ describe('runMigrationVerification: real path emits no DDL/DML (#152)', () => {
             migrations: files,
           });
 
-          // Семантика #101 сохранена: applied/pending/interrupted/
+          // #101 semantics preserved: applied/pending/interrupted/
           // modified/orphan.
           expect(verdict.pending.sort()).toEqual(['2-Pending', '4-Missing']);
           expect(verdict.interrupted).toEqual(['3-Started']);
@@ -317,7 +317,7 @@ describe('runMigrationVerification: real path emits no DDL/DML (#152)', () => {
             expect(gone).toMatchObject({ orphan: true, applied: true });
           }
 
-          // Единственный допустимый SQL — голый SELECT таблицы учёта.
+          // The only allowed SQL is the bare SELECT of the bookkeeping table.
           mock.expectExactly([
             'SELECT `id`, `timestamp`, `name`, `hash`, `state` FROM `ydb_migrations`',
           ]);
@@ -327,8 +327,8 @@ describe('runMigrationVerification: real path emits no DDL/DML (#152)', () => {
   });
 
   describe('legacy bookkeeping (no hash/state columns): read without ALTER', () => {
-    // Легаси-таблица: запись есть только у '1-LegacyApplied' — она applied
-    // по имени (семантика #101 для записей без хеша).
+    // Legacy table: only '1-LegacyApplied' has a record — it is applied
+    // by name (#101 semantics for records without a hash).
     const rows: AnyRecord[] = [
       { id: 1, timestamp: 1000, name: '1-LegacyApplied' },
     ];
@@ -352,7 +352,7 @@ describe('runMigrationVerification: real path emits no DDL/DML (#152)', () => {
           migrations: files,
         });
 
-        // Легаси-семантика (#101): записи без хеша подразумевают applied.
+        // Legacy semantics (#101): records without a hash imply applied.
         expect(verdict.appliedCount).toBe(1);
         expect(verdict.pending).toEqual(['2-LegacyPending']);
         expect(verdict.modified).toEqual([]);
@@ -389,8 +389,8 @@ describe('runMigrationVerification: real path emits no DDL/DML (#152)', () => {
             migrations: files,
           });
 
-          // «Не применено ничего»: все файлы — pending, exit-код по
-          // контракту #152 (pending → 1), таблица НЕ создаётся.
+          // "Nothing applied": all files are pending, exit code per the
+          // #152 contract (pending → 1), the table is NOT created.
           expect(verdict.state).toBe('pending');
           expect(verdict.pending).toEqual(['1-New', '2-New']);
           expect(verdict.totalMigrations).toBe(2);
@@ -410,7 +410,7 @@ describe('runMigrationVerification: real path emits no DDL/DML (#152)', () => {
             );
           }
 
-          // Ни одного SQL: читать нечего, создавать нельзя.
+          // No SQL at all: nothing to read, nothing may be created.
           mock.expectNoSqlAtAll();
         });
       }

--- a/src/cli/migration-verify.spec.ts
+++ b/src/cli/migration-verify.spec.ts
@@ -11,7 +11,7 @@ import type { AppliedMigration } from '../migrations/migration-runner.js';
 import type { MigrationBookkeepingSnapshot } from '../migrations/migration-bookkeeping.js';
 import type { YdbSchemaIssue } from '../schema/schema-sync.js';
 
-/** Мок executor-а: записывает каждый SQL и отдаёт заданные строки. */
+/** Executor mock: records each SQL and returns the given rows. */
 function makeRecordingExecutor(resultRows: Record<string, unknown>[] = []) {
   const executedSql: string[] = [];
 
@@ -48,9 +48,9 @@ function makeRecordingExecutor(resultRows: Record<string, unknown>[] = []) {
   return {
     executor: executor as unknown,
     executedSql,
-    /** Ни один SQL не выполнялся — значит, точно не было и DDL. */
+    /** No SQL was executed at all — so certainly no DDL happened. */
     expectNoSqlAtAll: () => expect(executor).not.toHaveBeenCalled(),
-    /** SQL был, но среди него нет ни одного DDL/DML-оператора. */
+    /** SQL happened, but among them there is no DDL/DML statement. */
     expectNoDdlOrDml: () => {
       for (const sql of executedSql) {
         expect(sql.toUpperCase()).not.toMatch(
@@ -79,9 +79,9 @@ function recordFromRow(row: RowSpec, id: number): AppliedMigration {
 }
 
 /**
- * Шов inspectBookkeeping: снимок собирается из строк таблицы учёта
- * БЕЗ обращения к executor-у — как и в реальном read-only потоке,
- * где метаданные берутся через DescribeTable.
+ * inspectBookkeeping seam: the snapshot is assembled from bookkeeping-table
+ * rows WITHOUT touching the executor — as in the real read-only path,
+ * where metadata comes via DescribeTable.
  */
 function makeInspect(
   rows: RowSpec[] = [],
@@ -121,7 +121,7 @@ function makeIo(): MigrationVerifyIo & {
   return io;
 }
 
-/** Миграция с замоканными up/down (типизировано как свойства — для expect). */
+/** Migration with mocked up/down (typed as properties — for expect). */
 type MockMigration = Omit<YdbMigration, 'up' | 'down'> & {
   up: jest.Mock<() => Promise<void>>;
   down: jest.Mock<() => Promise<void>>;
@@ -196,10 +196,10 @@ describe('runMigrationVerification (#152)', () => {
       'Up to date: 1 migration(s) applied',
     );
     expect(io.stderrLines).toEqual([]);
-    // Проверка не выполняет миграций: ни up(), ни down().
+    // Verification does not run migrations: neither up() nor down().
     expect(migrations[0].up).not.toHaveBeenCalled();
     expect(migrations[0].down).not.toHaveBeenCalled();
-    // Состояние читается через снимок (DescribeTable), без SQL к учёту.
+    // State is read through the snapshot (DescribeTable), without SQL to the bookkeeping.
     expect(inspect).toHaveBeenCalledTimes(1);
     mock.expectNoSqlAtAll();
   });
@@ -226,7 +226,7 @@ describe('runMigrationVerification (#152)', () => {
     expect(errText).toContain('Pending migrations (2/2):');
     expect(errText).toContain('- 1-Pending');
     expect(errText).toContain('Not ready: pending migrations');
-    // Успех не печатается при неудаче.
+    // Success is not printed on failure.
     expect(io.stdoutLines.join('\n')).not.toContain('Up to date');
     mock.expectNoSqlAtAll();
   });
@@ -332,10 +332,10 @@ describe('runMigrationVerification (#152)', () => {
     expect(errText).toContain(
       'Schema differs from entity metadata (1 issue(s)):',
     );
-    // Детальная диагностика сохранена: таблица-заголовок + колонка.
+    // Detailed diagnostics preserved: table header + column.
     expect(errText).toContain('users');
     expect(errText).toContain('is missing column "email"');
-    // Цвет по реальному потоку вывода (stderr TTY) — #103.
+    // Color by the real output stream (stderr TTY) — #103.
     expect(errText).toContain('\x1b[');
     mock.expectNoSqlAtAll();
   });
@@ -386,7 +386,7 @@ describe('runMigrationVerification (#152)', () => {
   });
 
   describe('read-only contract: no DDL/DML from verification commands (#152)', () => {
-    // Матрица из задачи: check / status / show / --json варианты.
+    // Matrix from the task: check / status / show / --json variants.
     const cases: Array<{
       command: 'migration:check' | 'migration:show' | 'migration:status';
       json: boolean;
@@ -401,8 +401,8 @@ describe('runMigrationVerification (#152)', () => {
 
     for (const { command, json } of cases) {
       it(`${command}${json ? ' --json' : ''}: never creates or alters ydb_migrations`, async () => {
-        // Если бы путь ходил в ensureMigrationsTable, executor получил бы
-        // CREATE TABLE IF NOT EXISTS (+ возможный ALTER) — тест падает.
+        // If the path went through ensureMigrationsTable, the executor would
+        // receive CREATE TABLE IF NOT EXISTS (+ possible ALTER) — the test fails.
         const mock = makeRecordingExecutor();
         const io = makeIo();
 
@@ -417,8 +417,8 @@ describe('runMigrationVerification (#152)', () => {
           io,
         });
 
-        // Строгое требование: мутирующий путь не просто «не сработал»,
-        // его нет в execution path вовсе — executor не вызывался ни разу.
+        // Strict requirement: the mutating path is not merely "didn't fire",
+        // it is absent from the execution path entirely — the executor was never called.
         mock.expectNoSqlAtAll();
         mock.expectNoDdlOrDml();
       });
@@ -460,7 +460,7 @@ describe('runMigrationVerification (#152)', () => {
         io,
       });
 
-      // Контракт #152: pending → exit 1; ничего не создано.
+      // #152 contract: pending → exit 1; nothing was created.
       expect(verdict.state).toBe('pending');
       expect(verdict.pending).toEqual(['1-New']);
       expect(io.stdoutLines.join('\n')).toContain(
@@ -705,13 +705,13 @@ describe('runMigrationVerification (#152)', () => {
       }),
     ).rejects.toBe(boom);
 
-    // Тег не ломает сообщение и цепочку cause.
+    // The tag does not break the message or the cause chain.
     expect(boom.message).toBe('connection refused');
     expect((boom as Error & { cause?: Error }).cause?.message).toBe(
       'ECONNREFUSED',
     );
     expect(exitCodeOf(boom)).toBe(5);
-    // Ничего не напечатано как успех.
+    // Nothing printed as a success.
     expect(io.stdoutLines).toEqual([]);
   });
 
@@ -768,7 +768,7 @@ describe('runMigrationVerification (#152)', () => {
       io: makeIo(),
     });
 
-    // Без entities схема не проверяется вовсе.
+    // Without entities the schema is not checked at all.
     const io2 = makeIo();
     const entities = [class Photos {}];
     await runMigrationVerification({
@@ -788,7 +788,7 @@ describe('runMigrationVerification (#152)', () => {
       mock.executor,
       entities,
     );
-    // Готово + схема совпадает.
+    // Ready + schema matches.
     expect(io2.stdoutLines.join('\n')).toContain(
       '; schema matches entity metadata',
     );

--- a/src/cli/migration-verify.ts
+++ b/src/cli/migration-verify.ts
@@ -1,25 +1,25 @@
 /**
- * Единый workflow проверки миграций для `migration:check` и
+ * Unified migration verification workflow for `migration:check` and
  * `migration:status` (#152).
  *
- * Команда только ЧИТАЕТ состояние и не выполняет НИКАКОГО DDL:
- *  - существование таблицы учёта `ydb_migrations` определяется через
- *    DescribeTable (readBookkeepingSnapshot); если её нет — база считается
- *    не инициализированной («не применено ничего»), таблица НЕ создаётся;
- *  - записи читаются голым SELECT (без CREATE/ALTER, колонки легаси-таблиц
- *    учитываются без их изменения);
- *  - для сущностей из конфига — DescribeTable через YdbSchemaSyncer.verify.
+ * Command only READS state and performs NO DDL:
+ *  - existence of the `ydb_migrations` bookkeeping table is determined via
+ *    DescribeTable (readBookkeepingSnapshot); if absent — database is
+ *    considered uninitialized ("nothing applied"), table is NOT created;
+ *  - records are read with a raw SELECT (no CREATE/ALTER, legacy table
+ *    columns accounted for without modification);
+ *  - for entities from config — DescribeTable via YdbSchemaSyncer.verify.
  *
- * Различимые состояния и exit-коды см. в
- * migrations/migration-check.ts и cli/exit-codes.ts.
+ * Distinct states and exit codes see in
+ * migrations/migration-check.ts and cli/exit-codes.ts.
  *
- * Вывод:
- *  - текстовый режим: сводка/список — в stdout, проблемы — в stderr,
- *    итоговая строка `Up to date: ...` / `Not ready: ...` по потоку
- *    результата; цвет diff-а схемы определяется по реальному потоку
- *    вывода (stderr), не по stdout (#103);
- *  - `--json`: весь машинночитаемый отчёт — только в stdout, стабильная
- *    схема (без цвета и человеческих формулировок).
+ * Output:
+ *  - text mode: summary/list — to stdout, issues — to stderr,
+ *    final line `Up to date: ...` / `Not ready: ...` per result stream;
+ *    schema diff color determined by actual output stream (stderr), not
+ *    stdout (#103);
+ *  - `--json`: entire machine-readable report — only in stdout, stable
+ *    schema (no color or human wording).
  */
 import type { Driver } from '@ydbjs/core';
 import { YdbExecutor } from '../core/interfaces.js';
@@ -45,19 +45,19 @@ import { getYdbEntityMetadata } from '../metadata/entity-metadata.js';
 import { renderSchemaDiff, shouldUseColor } from './diff.js';
 import { EXIT_COMMAND_ERROR, tagExitCode } from './exit-codes.js';
 
-/** Команды, использующие этот workflow. */
+/** Commands that use this workflow. */
 export type MigrationVerifyCommand =
   'migration:check' | 'migration:show' | 'migration:status';
 
-/** Потоки вывода команды: сводки — в stdout, проблемы — в stderr. */
+/** Command output streams: summaries to stdout, issues to stderr. */
 export interface MigrationVerifyIo {
   stdout(line: string): void;
   stderr(line: string): void;
 }
 
 /**
- * Потоки для решения о цвете (#103): по умолчанию реальные
- * process.stdout/process.stderr; в тестах подставляются фейки.
+ * Streams for color decision (#103): by default the real
+ * process.stdout/process.stderr; in tests, fakes are substituted.
  */
 export interface MigrationVerifyStreams {
   stdout?: { isTTY?: boolean | undefined };
@@ -66,15 +66,15 @@ export interface MigrationVerifyStreams {
 
 export interface RunMigrationVerificationOptions {
   command: MigrationVerifyCommand;
-  /** Директория миграций (--dir или из конфига). */
+  /** Migrations directory (--dir or from config). */
   migrationsDir: string;
   /**
-   * Сущности из конфига CLI: если заданы, дополнительно проверяется
-   * схема БД (read-only DescribeTable) — иначе состояние schema-drift
-   * недоступно и в отчёте помечается как не проверявшееся.
+   * Entities from the CLI config: if provided, DB schema is additionally
+   * checked (read-only DescribeTable) — otherwise the schema-drift state
+   * is unavailable and marked as unchecked in the report.
    */
   entities?: (new (...args: any[]) => any)[] | undefined;
-  /** Машинночитаемый вывод: всё в stdout, без цвета. */
+  /** Machine-readable output: everything in stdout, no color. */
   json?: boolean | undefined;
   io: MigrationVerifyIo;
   streams?: MigrationVerifyStreams | undefined;
@@ -83,11 +83,11 @@ export interface RunMigrationVerificationOptions {
     executor: YdbExecutor;
     close: () => void;
   }>;
-  /** Шов для тестов (по умолчанию — загрузка из директории). */
+  /** Test seam (default — load from directory). */
   loadMigrations?: ((dir: string) => Promise<YdbMigration[]>) | undefined;
   /**
-   * Read-only чтение таблицы учёта миграций (#152): DescribeTable + голый
-   * SELECT, без CREATE/ALTER. Шов для тестов.
+   * Read-only inspection of the migration bookkeeping table (#152): DescribeTable
+   * + bare SELECT, no CREATE/ALTER. Test seam.
    */
   inspectBookkeeping?:
     | ((deps: {
@@ -95,7 +95,7 @@ export interface RunMigrationVerificationOptions {
         executor: YdbExecutor;
       }) => Promise<MigrationBookkeepingSnapshot>)
     | undefined;
-  /** Шов для тестов (по умолчанию — YdbSchemaSyncer.verify). */
+  /** Test seam (default — YdbSchemaSyncer.verify). */
   verifySchema?:
     | ((
         driver: Driver,
@@ -106,8 +106,8 @@ export interface RunMigrationVerificationOptions {
 }
 
 /**
- * Возвращает метаданные сущности или падает, если класс не декорирован
- * @YdbEntity (иначе syncer.verify молча пропускает такой класс).
+ * Returns entity metadata or throws if class is not decorated
+ * with @YdbEntity (otherwise syncer.verify silently skips such a class).
  */
 export function requireEntityMeta(entity: any): any {
   const meta = getYdbEntityMetadata(entity);
@@ -133,10 +133,10 @@ function isoOrNull(date?: Date): string | null {
   return date ? date.toISOString() : null;
 }
 
-/** Строка списка `migration:status` для одной миграции (маркеры #101). */
+/** `migration:status` line for a single migration (markers #101). */
 export function renderStatusLine(status: YdbMigrationStatus): string {
   if (status.orphan) {
-    // Применена, но файла миграции больше нет (#101).
+    // Applied, but migration file no longer exists (#101).
     const flags: string[] = [];
     if (status.interrupted) flags.push('interrupted');
     if (status.contentChanged) flags.push('content changed');
@@ -152,7 +152,7 @@ export function renderStatusLine(status: YdbMigrationStatus): string {
     );
   }
   if (status.interrupted) {
-    // Прервана посреди применения/отката (#101).
+    // Interrupted mid-apply/revert (#101).
     return `[~] ${status.name} — interrupted, resolve via migration:repair`;
   }
   if (status.contentChanged) {
@@ -168,14 +168,14 @@ export function renderStatusLine(status: YdbMigrationStatus): string {
 }
 
 /**
- * Выполняет проверку и рендерит отчёт. Бросает исходную ошибку,
- * помеченную exit-кодом EXIT_COMMAND_ERROR (5): цепочка cause сохраняется.
- * Возвращает вердикт — вызывающий код ставит process.exitCode.
+ * Runs verification and renders the report. Throws the original error
+ * tagged with EXIT_COMMAND_ERROR (5): cause chain preserved.
+ * Returns verdict — caller sets process.exitCode.
  *
- * Read-only контракт (#152): состояние таблицы учёта читается через
- * readBookkeepingSnapshot (DescribeTable + голый SELECT, без DDL);
- * YdbMigrationRunner.status с его ensureMigrationsTable() здесь
- * не вызывается никогда.
+ * Read-only contract (#152): bookkeeping table state read via
+ * readBookkeepingSnapshot (DescribeTable + raw SELECT, no DDL);
+ * YdbMigrationRunner.status with its ensureMigrationsTable() never
+ * called here.
  */
 export async function runMigrationVerification(
   options: RunMigrationVerificationOptions,
@@ -204,8 +204,8 @@ export async function runMigrationVerification(
       snapshot = await inspectBookkeeping({ driver, executor });
       statuses = snapshot.exists
         ? computeMigrationStatuses(migrations, snapshot.records)
-        : // Таблицы учёта ещё нет: применено не было ничего — все
-          // миграции из файлов считаются ожидающими; таблица НЕ создаётся.
+        : // Bookkeeping table doesn't exist yet: nothing was applied — all
+          // migrations from files are considered pending; table is NOT created.
           migrations.map((migration) => ({
             name: migrationName(migration),
             applied: false,
@@ -239,7 +239,7 @@ export async function runMigrationVerification(
   }
 }
 
-/** Полностью применённые без блокирующих состояний (legacy-семантика поля). */
+/** Fully applied without blocking states (legacy field semantics). */
 function isBookkeepingApplied(verdict: MigrationCheckVerdict): boolean {
   return (
     verdict.pending.length === 0 &&
@@ -258,11 +258,11 @@ interface JsonMigrationEntry {
 }
 
 /**
- * Машинночитаемый отчёт (#152): стабильная схема, детерминированный порядок
- * ключей и строк, ISO-даты, булевы флаги всегда явные. Парсить нужно это,
- * а не цвет/формулировки текстового режима. Блок `bookkeeping` различает
- * «не инициализированную» базу (таблицы учёта ещё нет) от полностью
- * применённой.
+ * Machine-readable report (#152): stable schema, deterministic order
+ * of keys and rows, ISO dates, boolean flags always explicit. Parse this,
+ * not color/wording of text mode. The `bookkeeping` block distinguishes
+ * an "uninitialized" database (bookkeeping table doesn't exist yet) from
+ * a fully applied one.
  */
 export function buildJsonReport(
   command: MigrationVerifyCommand,
@@ -273,9 +273,9 @@ export function buildJsonReport(
 ): Record<string, unknown> {
   const migrations: JsonMigrationEntry[] = statuses.map((s) => ({
     name: s.name,
-    // `applied` в отчёте — только здорово применённая (#212): изменённая
-    // после применения и прерванная миграции не считаются applied
-    // независимо от значения поля статуса (producer уже даёт false).
+    // `applied` in report — only cleanly applied (#212): modified
+    // after apply and interrupted migrations are not considered applied
+    // regardless of status field value (producer already gives false).
     applied: s.applied && !s.interrupted && !s.contentChanged,
     appliedAt: isoOrNull(s.appliedAt),
     interrupted: s.interrupted === true,
@@ -342,13 +342,13 @@ function renderText(
   schemaIssues: YdbSchemaIssue[] | undefined,
   bookkeeping: Pick<MigrationBookkeepingSnapshot, 'exists' | 'legacy'>,
 ): void {
-  // Обёртки-стрелки: не отвязываем методы io от объекта (#103-стиль lint).
+  // Arrow wrappers: do not detach io methods from the object (#103-style lint).
   const out = (line: string) => io.stdout(line);
   const err = (line: string) => io.stderr(line);
 
   if (!bookkeeping.exists) {
-    // Свежая база: таблицы учёта ещё нет. Информация — в stdout; таблица
-    // НЕ создаётся, состояние считается «не применено ничего».
+    // Fresh database: bookkeeping table doesn't exist yet. Information — in
+    // stdout; table is NOT created, state is considered "nothing applied".
     out(
       `Bookkeeping table ydb_migrations does not exist yet — ` +
         `no migrations have been applied (nothing was created).`,
@@ -356,7 +356,7 @@ function renderText(
   }
 
   if (command === 'migration:check') {
-    // Сводка вместо полного списка: полный список — migration:status.
+    // Summary instead of a full list: the full list is in migration:status.
     out(
       `Migrations: ${verdict.appliedCount}/${verdict.totalMigrations} applied` +
         (verdict.orphaned.length
@@ -397,8 +397,8 @@ function renderText(
     }
   }
 
-  // Orphans уже видны в списке migration:status — отдельная секция только
-  // для компактного migration:check.
+  // Orphans are already visible in the migration:status list — a separate
+  // section only for the compact migration:check.
   if (command === 'migration:check' && verdict.orphaned.length) {
     err(
       `Orphan records (${verdict.orphaned.length}) — applied but no matching migration file:`,
@@ -412,7 +412,7 @@ function renderText(
     err(
       `Schema differs from entity metadata (${schemaIssues.length} issue(s)):`,
     );
-    // Цвет решаем по stderr — куда реально уезжает diff (#103).
+    // Color is decided by stderr — where the diff actually lands (#103).
     err(
       renderSchemaDiff(schemaIssues, {
         color: shouldUseColor(

--- a/src/cli/prompt.ts
+++ b/src/cli/prompt.ts
@@ -1,19 +1,19 @@
 /**
- * Минималистичные интерактивные подсказки для CLI (#24) на node:readline —
- * без внешних зависимостей.
+ * Minimal interactive prompts for the CLI (#24) on node:readline —
+ * without external dependencies.
  *
- * Строки ввода собираются в очередь независимо от того, задан ли в момент
- * прихода вопрос: скриптовый/piped-ввод и ввод с терминала обрабатываются
- * одинаково детерминированно.
+ * Input lines are collected in a queue regardless of whether a question was
+ * pending when they arrived: scripted/piped input and terminal input are
+ * both handled deterministically.
  *
- * Отмена/EOF обрабатываются явно: закрытие входного потока, Ctrl+D и Ctrl+C
- * отклоняют активный вопрос ошибкой PromptCancelledError, чтобы мастер
- * гарантированно не зависал и ничего не писал на диск.
+ * Cancel/EOF are handled explicitly: the input stream closing, Ctrl+D and
+ * Ctrl+C reject an active question with a PromptCancelledError so the wizard
+ * never hangs and never writes to disk.
  */
 import readline from 'node:readline';
 import { Readable, Writable } from 'node:stream';
 
-/** Пользователь прервал ввод (EOF/Ctrl+D/Ctrl+C/отказ в подтверждении). */
+/** User interrupted input (EOF/Ctrl+D/Ctrl+C/declined confirmation). */
 export class PromptCancelledError extends Error {
   constructor(reason: string = 'EOF') {
     super(`Input cancelled (${reason})`);
@@ -21,6 +21,7 @@ export class PromptCancelledError extends Error {
   }
 }
 
+/** I/O streams backing the prompt reader (injectable for tests). */
 export interface PromptIo {
   input: Readable;
   output: Writable;
@@ -31,6 +32,11 @@ interface PendingQuestion {
   reject: (err: Error) => void;
 }
 
+/**
+ * Reads answers from input via node:readline: lines are queued and consumed
+ * on demand, so both terminal and scripted/piped input behave identically.
+ * Handles EOF, Ctrl+C (SIGINT) and explicit cancel(); see the class' methods.
+ */
 export class PromptReader {
   private readonly rl: readline.Interface;
   private readonly output: Writable;
@@ -53,28 +59,28 @@ export class PromptReader {
       }
     });
     this.rl.on('close', () => {
-      // Введённые ранее строки остаются валидными ответами: EOF считается
-      // отменой только когда очередь пуста и активного ответа нет.
+      // Previously entered lines remain valid answers: EOF is considered a
+      // cancellation only when the queue is empty and no answer is pending.
       this.eof = true;
       if (this.queue.length === 0) {
         this.rejectPending(new PromptCancelledError('EOF'));
       }
     });
-    // Срабатывает только в интерактивном режиме (TTY); в неинтерактивном
-    // SIGINT приходит как обычный сигнал процесса и обрабатывается в cli.ts.
+    // Fires only in interactive mode (TTY); in non-interactive mode SIGINT
+    // arrives as a normal process signal handled in cli.ts.
     this.rl.on('SIGINT', () =>
       this.rejectPending(new PromptCancelledError('SIGINT (Ctrl+C)')),
     );
   }
 
-  /** Отклоняет активный вопрос ошибкой (идемпотентно для прерываний). */
+  /** Rejects an active question with an error (idempotent for interruptions). */
   private rejectPending(err: Error): void {
     const waiting = this.pending;
     this.pending = null;
     waiting?.reject(err);
   }
 
-  /** Немедленная отмена (Ctrl+C): очередь ответов игнорируется. Идемпотентно. */
+  /** Immediate cancel (Ctrl+C): queued answers are ignored. Idempotent. */
   cancel(err: Error): void {
     if (this.interrupted) return;
     this.interrupted = err;
@@ -87,9 +93,9 @@ export class PromptReader {
   }
 
   /**
-   * Задаёт вопрос, возвращает ответ без концевых пробелов ('' — пустой ввод).
-   * После исчерпания ввода/отмены любой следующий вопрос отклоняется
-   * ошибкой PromptCancelledError.
+   * Poses a question and returns the answer without trailing spaces ('' — empty input).
+   * After input is exhausted/cancelled, any following question is rejected
+   * with a PromptCancelledError.
    */
   async ask(prompt: string): Promise<string> {
     if (this.interrupted) throw this.interrupted;
@@ -104,7 +110,7 @@ export class PromptReader {
     });
   }
 
-  /** Да/нет-вопрос со значением по умолчанию; неразборчивый ввод переспрашивается. */
+  /** Yes/no question with a default value; unrecognizable input re-prompts. */
   async confirm(prompt: string, defaultValue: boolean): Promise<boolean> {
     for (;;) {
       const hint = defaultValue ? '(Y/n)' : '(y/N)';
@@ -116,7 +122,7 @@ export class PromptReader {
     }
   }
 
-  /** Печатает строку в поток вывода мастера. */
+  /** Prints a line to the wizard's output stream. */
   writeLine(text: string): void {
     this.output.write(`${text}\n`);
   }

--- a/src/cli/sort.ts
+++ b/src/cli/sort.ts
@@ -1,7 +1,7 @@
 /**
- * Детерминированное сравнение строк для сортировки (порядок code points):
- * в отличие от localeCompare не зависит от локали рантайма — повторный
- * запуск в любом окружении даёт побайтово одинаковый вывод.
+ * Deterministic string comparison for sorting (code-point order): unlike
+ * localeCompare it does not depend on the runtime locale, so repeating a
+ * run in any environment yields byte-identical output.
  */
 export function compareStrings(a: string, b: string): number {
   return a < b ? -1 : a > b ? 1 : 0;

--- a/src/core/dev-logger.ts
+++ b/src/core/dev-logger.ts
@@ -1,9 +1,9 @@
 /**
- * Каркасно-нейтральный логгер ядра.
+ * Framework-neutral core logger.
  *
- * Используется там, где раньше применялся Logger из @nestjs/common (schema
- * sync и т.п.), чтобы основной пакет не зависел от NestJS. Формат вывода
- * близок к Nest-style: `[<context>] сообщение`.
+ * Used where Logger from @nestjs/common was previously used (schema
+ * sync etc.), so the main package doesn't depend on NestJS. Output format
+ * is close to Nest-style: `[<context>] message`.
  */
 export class YdbDevLogger {
   constructor(private readonly context: string) {}

--- a/src/core/driver.retry.spec.ts
+++ b/src/core/driver.retry.spec.ts
@@ -6,10 +6,10 @@ import { StatusIds_StatusCode as Code } from '@ydbjs/api/operation';
 import type { YdbModuleOptions } from './interfaces.js';
 
 /**
- * Проводка retry-политики (#27) в createExecutor(): опция retry из
- * YdbModuleOptions реально подключает политику к операциям executor'а.
- * @ydbjs/core и @ydbjs/query подменяются до первого импорта ./driver.js —
- * сети нет, поведение клиента управляется тестом.
+ * Wiring the retry policy (#27) into createExecutor(): the retry option
+ * from YdbModuleOptions actually attaches the policy to executor operations.
+ * @ydbjs/core and @ydbjs/query are replaced before the first import of
+ * ./driver.js — there is no network, client behavior is driven by the test.
  */
 
 const BASE_OPTIONS: YdbModuleOptions = {
@@ -17,7 +17,7 @@ const BASE_OPTIONS: YdbModuleOptions = {
   auth: createAuth({ type: 'anonymous' }),
 };
 
-/** Управляемый фейк QueryClient: режим «скрипт неудач» или «всегда фатально». */
+/** Controllable fake QueryClient: "failure script" mode or "always fatal". */
 let script: Array<'fail-aborted' | 'ok'> = ['ok'];
 let mode: 'script' | 'always-fatal' = 'script';
 const executions: number[] = [];
@@ -76,8 +76,8 @@ beforeAll(async () => {
   mod = await import('./driver.js');
 });
 
-describe('createExecutor(): подключение retry-политики из опций модуля (#27)', () => {
-  it('без опции retry поведение прежнее: одна попытка на вызов', async () => {
+describe('createExecutor(): wiring retry policy from module options (#27)', () => {
+  it('without retry option behavior unchanged: one attempt per call', async () => {
     script = ['fail-aborted', 'ok'];
     executions.length = 0;
     const executor = mod.createExecutor(
@@ -86,11 +86,11 @@ describe('createExecutor(): подключение retry-политики из �
     );
 
     await expect(executor`SELECT 1`).rejects.toBeInstanceOf(YDBError);
-    // Ретраит только SDK (в фейке цикла нет) — одна попытка:
+    // Only the SDK retries (no loop in the fake) — a single attempt:
     expect(executions).toHaveLength(1);
   });
 
-  it('retry: true включает политику с дефолтами', async () => {
+  it('retry: true enables policy with defaults', async () => {
     script = ['fail-aborted', 'fail-aborted', 'ok'];
     executions.length = 0;
     const executor = mod.createExecutor(new StubDriver() as never, {
@@ -101,11 +101,11 @@ describe('createExecutor(): подключение retry-политики из �
     await expect(executor`SELECT 1`.idempotent(true)).resolves.toEqual([
       [{ ok: 1 }],
     ]);
-    // Политика довела операцию до успеха: ровно 3 обращения к БД.
+    // The policy carried the operation to success: exactly 3 DB calls.
     expect(executions).toHaveLength(3);
   });
 
-  it('детерминированная ошибка политикой не ретраится', async () => {
+  it('deterministic error not retried by policy', async () => {
     script = ['ok'];
     executions.length = 0;
     mode = 'always-fatal';
@@ -115,7 +115,7 @@ describe('createExecutor(): подключение retry-политики из �
     });
 
     await expect(executor`SELECT 1`).rejects.toBeInstanceOf(YDBError);
-    // SCHEME_ERROR — детерминированная: одна попытка без повторов.
+    // SCHEME_ERROR is deterministic: a single attempt with no retries.
     expect(executions).toHaveLength(1);
     mode = 'script';
   });

--- a/src/core/driver.spec.ts
+++ b/src/core/driver.spec.ts
@@ -5,16 +5,16 @@ import { createAuth } from '@ycforge/auth';
 import type { YdbModuleOptions } from './interfaces.js';
 
 /**
- * Спеки ядра подключения (#96): приоритет источников CredentialsProvider,
- * конфликт конфигурации и поведение с AuthManager.
+ * Specs for the connection core (#96): priority of CredentialsProvider
+ * sources, configuration conflicts, and behavior with AuthManager.
  *
- * Модуль @ydbjs/core подменяется заглушкой ДО первого импорта ./driver.js
- * (динамический импорт после jest.unstable_mockModule), чтобы createDriver
- * можно было вызвать без сети и проверить, какой провайдер дошёл до
- * конструктора Driver.
+ * The @ydbjs/core module is replaced with a stub BEFORE the first import
+ * of ./driver.js (dynamic import after jest.unstable_mockModule), so that
+ * createDriver can be called without a network and we can verify which
+ * provider reached the Driver constructor.
  */
 
-/** Заглушка провайдера с маркером: по значению видно, кто разрешён. */
+/** Stub provider with a marker: the resolved source is visible by value. */
 function makeProvider(tag: string): CredentialsProvider {
   return {
     getToken: () => Promise.resolve(`token:${tag}`),
@@ -46,7 +46,7 @@ beforeAll(async () => {
 });
 
 describe('resolveCredentialsProvider (#96)', () => {
-  it('явный opts.credentialsProvider используется как есть', () => {
+  it('explicit opts.credentialsProvider used as-is', () => {
     const custom = makeProvider('custom');
     const resolved = mod.resolveCredentialsProvider({
       ...BASE_OPTIONS,
@@ -56,7 +56,7 @@ describe('resolveCredentialsProvider (#96)', () => {
     expect(resolved).toBe(custom);
   });
 
-  it('opts.auth адаптируется в CredentialsProvider', () => {
+  it('opts.auth adapted to CredentialsProvider', () => {
     const resolved = mod.resolveCredentialsProvider({
       endpoint: 'grpc://localhost:2136/local',
       auth: createAuth({ type: 'anonymous' }),
@@ -65,7 +65,7 @@ describe('resolveCredentialsProvider (#96)', () => {
     expect(resolved.constructor.name).toBe('AnonymousCredentialsProvider');
   });
 
-  it('opts.auth: getToken делегирует AuthManager (usage ydb)', async () => {
+  it('opts.auth: getToken delegates to AuthManager (usage ydb)', async () => {
     const resolved = mod.resolveCredentialsProvider({
       endpoint: 'grpc://localhost:2136/local',
       auth: createAuth({ type: 'access_token', token: 'tok-auth' }),
@@ -74,7 +74,7 @@ describe('resolveCredentialsProvider (#96)', () => {
     await expect(resolved.getToken()).resolves.toBe('tok-auth');
   });
 
-  it('injected (DI) используется при отсутствии явного провайдера и auth', () => {
+  it('injected (DI) used when no explicit provider or auth', () => {
     const injected = makeProvider('injected');
     const resolved = mod.resolveCredentialsProvider(
       { endpoint: 'grpc://localhost:2136/local' },
@@ -84,7 +84,7 @@ describe('resolveCredentialsProvider (#96)', () => {
     expect(resolved).toBe(injected);
   });
 
-  it('driverOptions.credentialsProvider используется без явных источников', () => {
+  it('driverOptions.credentialsProvider used without explicit sources', () => {
     const lowLevel = makeProvider('low-level');
     const resolved = mod.resolveCredentialsProvider({
       endpoint: 'grpc://localhost:2136/local',
@@ -94,7 +94,7 @@ describe('resolveCredentialsProvider (#96)', () => {
     expect(resolved).toBe(lowLevel);
   });
 
-  it('конфликт credentialsProvider и driverOptions.credentialsProvider — ошибка', () => {
+  it('conflict credentialsProvider and driverOptions.credentialsProvider — error', () => {
     const custom = makeProvider('custom');
     const lowLevel = makeProvider('low-level');
 
@@ -109,7 +109,7 @@ describe('resolveCredentialsProvider (#96)', () => {
     );
   });
 
-  it('конфликт auth и driverOptions.credentialsProvider — ошибка', () => {
+  it('conflict auth and driverOptions.credentialsProvider — error', () => {
     expect(() =>
       mod.resolveCredentialsProvider({
         endpoint: 'grpc://localhost:2136/local',
@@ -121,7 +121,7 @@ describe('resolveCredentialsProvider (#96)', () => {
     );
   });
 
-  it('отсутствие auth и CredentialsProvider — понятная ошибка', () => {
+  it('missing auth and CredentialsProvider — clear error', () => {
     expect(() =>
       mod.resolveCredentialsProvider({
         endpoint: 'grpc://localhost:2136/local',
@@ -130,8 +130,8 @@ describe('resolveCredentialsProvider (#96)', () => {
   });
 });
 
-describe('resolveCredentialsProvider: приоритеты', () => {
-  it('явный opts.credentialsProvider приоритетнее opts.auth', () => {
+describe('resolveCredentialsProvider: priorities', () => {
+  it('explicit opts.credentialsProvider takes priority over opts.auth', () => {
     const custom = makeProvider('custom');
     const resolved = mod.resolveCredentialsProvider({
       endpoint: 'grpc://localhost:2136/local',
@@ -142,7 +142,7 @@ describe('resolveCredentialsProvider: приоритеты', () => {
     expect(resolved).toBe(custom);
   });
 
-  it('opts.auth приоритетнее injected (DI) провайдера', () => {
+  it('opts.auth takes priority over injected (DI) provider', () => {
     const injected = makeProvider('injected');
     const resolved = mod.resolveCredentialsProvider(
       {
@@ -155,7 +155,7 @@ describe('resolveCredentialsProvider: приоритеты', () => {
     expect(resolved).not.toBe(injected);
   });
 
-  it('injected приоритетнее driverOptions.credentialsProvider', () => {
+  it('injected takes priority over driverOptions.credentialsProvider', () => {
     const injected = makeProvider('injected');
     const lowLevel = makeProvider('low-level');
     const resolved = mod.resolveCredentialsProvider(
@@ -171,7 +171,7 @@ describe('resolveCredentialsProvider: приоритеты', () => {
 });
 
 describe('validateYdbModuleOptions (#96)', () => {
-  it('fail-fast на конфликт источников провайдера ещё до создания драйвера', () => {
+  it('fail-fast on provider source conflict before driver creation', () => {
     expect(() =>
       mod.validateYdbModuleOptions({
         endpoint: 'grpc://localhost:2136/local',
@@ -181,7 +181,7 @@ describe('validateYdbModuleOptions (#96)', () => {
     ).toThrow(/Conflicting YDB credentials configuration/);
   });
 
-  it('fail-fast на конфликт auth + driverOptions', () => {
+  it('fail-fast on auth + driverOptions conflict', () => {
     expect(() =>
       mod.validateYdbModuleOptions({
         endpoint: 'grpc://localhost:2136/local',
@@ -192,8 +192,8 @@ describe('validateYdbModuleOptions (#96)', () => {
   });
 });
 
-describe('createDriver (#96): провайдер доходит до Driver', () => {
-  it('явный opts.credentialsProvider передаётся в конструктор драйвера', async () => {
+describe('createDriver (#96): provider reaches Driver', () => {
+  it('explicit opts.credentialsProvider passed to driver constructor', async () => {
     const custom = makeProvider('custom');
 
     await mod.createDriver({
@@ -205,7 +205,7 @@ describe('createDriver (#96): провайдер доходит до Driver', ()
     expect(call.options.credentialsProvider).toBe(custom);
   });
 
-  it('аргумент createDriver() (путь NestJS DI) доходит до драйвера', async () => {
+  it('createDriver() argument (NestJS DI path) reaches driver', async () => {
     const injected = makeProvider('injected');
 
     await mod.createDriver(
@@ -217,7 +217,7 @@ describe('createDriver (#96): провайдер доходит до Driver', ()
     expect(call.options.credentialsProvider).toBe(injected);
   });
 
-  it('без кастомных источников используется auth (AuthManager)', async () => {
+  it('without custom sources auth (AuthManager) is used', async () => {
     await mod.createDriver(BASE_OPTIONS);
 
     const call = StubDriver.calls.at(-1)!;
@@ -226,7 +226,7 @@ describe('createDriver (#96): провайдер доходит до Driver', ()
     );
   });
 
-  it('конфликт ловится fail-fast: молчаливой подмены явного провайдера нет', async () => {
+  it('conflict caught fail-fast: no silent substitution of explicit provider', async () => {
     const custom = makeProvider('custom');
 
     await expect(
@@ -238,13 +238,13 @@ describe('createDriver (#96): провайдер доходит до Driver', ()
     ).rejects.toThrow(/Conflicting YDB credentials configuration/);
   });
 
-  it('отсутствие auth и CredentialsProvider — понятная ошибка', async () => {
+  it('missing auth and CredentialsProvider — clear error', async () => {
     await expect(
       mod.createDriver({ endpoint: 'grpc://localhost:2136/local' }),
     ).rejects.toThrow(/YDB auth is required/);
   });
 
-  it('остальные driverOptions сохраняются вместе с разрешённым провайдером', async () => {
+  it('other driverOptions preserved alongside resolved provider', async () => {
     const custom = makeProvider('custom');
 
     await mod.createDriver({

--- a/src/core/driver.ts
+++ b/src/core/driver.ts
@@ -13,8 +13,8 @@ import { ConsoleQueryLogger, wrapExecutorWithLogging } from './query-logger.js';
 import { withRetryPolicy } from './retry-executor.js';
 
 /**
- * Fail-fast валидация опций модуля: без endpoint драйвер упал бы позже
- * с непонятной ошибкой в недрах SDK.
+ * Fail-fast validation of module options: without an endpoint the driver
+ * would fail later with a confusing error deep inside the SDK.
  */
 export function validateYdbModuleOptions(
   opts: YdbModuleOptions,
@@ -34,8 +34,8 @@ export function validateYdbModuleOptions(
 }
 
 /**
- * Валидация опции автоматического определения формата AAD (#165): либо не
- * задана (переходный безопасный режим включён), либо строгий boolean.
+ * Validation of the automatic AAD format detection option (#165): either
+ * unset (the safe transitional mode is enabled) or a strict boolean.
  */
 function assertAadReadFallback(opts: YdbModuleOptions): void {
   const fallback = opts.aadReadFallback;
@@ -47,9 +47,9 @@ function assertAadReadFallback(opts: YdbModuleOptions): void {
 }
 
 /**
- * Валидация формата Security AAD (#165): допускаются только 'legacy' и 'v2'
- * (по умолчанию). Неизвестное значение — ошибка конфигурации, а не
- * молчаливый переход на дефолт.
+ * Validation of the Security AAD format (#165): only 'legacy' and 'v2'
+ * (default) are allowed. An unknown value is a configuration error, not a
+ * silent fallback to the default.
  */
 function assertAadFormat(opts: YdbModuleOptions): void {
   const format = opts.aadFormat;
@@ -77,10 +77,10 @@ function assertAuthPresent(
 }
 
 /**
- * Конфликт источников CredentialsProvider (#96): если задан низкоуровневый
- * driverOptions.credentialsProvider вместе с верхнеуровневым источником
- * (явный credentialsProvider или auth/AuthManager), приоритет не выбирается
- * молча — это ошибка конфигурации.
+ * CredentialsProvider source conflict (#96): if the low-level
+ * driverOptions.credentialsProvider is set together with a top-level source
+ * (an explicit credentialsProvider or auth/AuthManager), the priority is not
+ * chosen silently — it is a configuration error.
  */
 function assertNoCredentialsProviderConflict(opts: YdbModuleOptions): void {
   const lowLevel = opts.driverOptions?.credentialsProvider !== undefined;
@@ -101,17 +101,17 @@ function assertNoCredentialsProviderConflict(opts: YdbModuleOptions): void {
 }
 
 /**
- * Разрешает итоговый CredentialsProvider по детерминированному приоритету (#96):
+ * Resolves the final CredentialsProvider by the deterministic priority (#96):
  *
- *   1. opts.credentialsProvider — явный провайдер из опций модуля;
- *   2. opts.auth — AuthManager из @ycforge/auth (адаптер
- *      createYdbCredentialsProvider из '@ycforge/auth/ydb');
- *   3. injected — провайдер, пришедший из DI (YDB_CREDENTIALS_PROVIDER) или
- *      переданный аргументом в createDriver();
- *   4. opts.driverOptions.credentialsProvider — низкоуровневая опция драйвера.
+ *   1. opts.credentialsProvider — explicit provider from the module options;
+ *   2. opts.auth — AuthManager from @ycforge/auth (the adapter
+ *      createYdbCredentialsProvider from '@ycforge/auth/ydb');
+ *   3. injected — a provider arriving from DI (YDB_CREDENTIALS_PROVIDER) or
+ *      passed as an argument to createDriver();
+ *   4. opts.driverOptions.credentialsProvider — the low-level driver option.
  *
- * Комбинация (1)/(2) + (4) запрещена — ошибка конфигурации, а не молчаливый
- * выбор. Используется NestJS-модулем, createDriver() и CLI.
+ * The combination (1)/(2) + (4) is forbidden — a configuration error, not a
+ * silent choice. Used by the NestJS module, createDriver() and the CLI.
  */
 export function resolveCredentialsProvider(
   opts: YdbModuleOptions,
@@ -123,7 +123,7 @@ export function resolveCredentialsProvider(
     (opts.auth !== undefined
       ? createYdbCredentialsProvider(opts.auth, YDB_AUTH_USAGE, {
           endpoint: opts.endpoint,
-          // grpc:// — локальный insecure-эндпоинт; grpcs:// — TLS (дефолт).
+          // grpc:// — local insecure endpoint; grpcs:// — TLS (default).
           secure: !opts.endpoint.startsWith('grpc://'),
         })
       : undefined) ??
@@ -139,15 +139,15 @@ export function resolveCredentialsProvider(
   return provider;
 }
 
-/** Создаёт подключённый Driver по опциям модуля. */
+/** Creates a connected Driver from the module options. */
 export async function createDriver(
   opts: YdbModuleOptions,
   credentialsProvider?: CredentialsProvider,
 ): Promise<Driver> {
   validateYdbModuleOptions(opts, credentialsProvider);
-  // Провайдер разрешается по единому правилу приоритета (#96) и передаётся
-  // ПОСЛЕ spread driverOptions: driverOptions.credentialsProvider не может
-  // молча перезатереть уже разрешённый провайдер.
+  // The provider is resolved by the single priority rule (#96) and is passed
+  // AFTER spreading driverOptions: driverOptions.credentialsProvider cannot
+  // silently overwrite the already-resolved provider.
   const resolvedProvider = resolveCredentialsProvider(
     opts,
     credentialsProvider,
@@ -162,7 +162,7 @@ export async function createDriver(
   return driver;
 }
 
-/** Создаёт executor (query client) поверх драйвера. */
+/** Creates an executor (query client) over the driver. */
 export function createExecutor(
   driver: Driver,
   opts: YdbModuleOptions,
@@ -175,14 +175,14 @@ export function createExecutor(
       : undefined,
   });
 
-  // Адаптация клиента @ydbjs/query к интерфейсу YdbExecutor (#98):
-  // client.transaction(options, fn) — функция, возвращающая промис, а
-  // интерфейс ORM ожидает transaction(options?) => { execute(fn) }.
-  // Раньше адаптация существовала только в wrapExecutorWithLogging, из-за
-  // чего runInTransaction на «живом» SDK падал. Опции (isolation/signal/
-  // idempotent) пробрасываются в SDK как есть; timeout реализуется менеджером
-  // транзакций per-attempt (свежее AbortSignal.timeout на каждую попытку)
-  // и до SDK не доходит.
+  // Adapts the @ydbjs/query client to the YdbExecutor interface (#98):
+  // client.transaction(options, fn) is a function returning a promise, while
+  // the ORM interface expects transaction(options?) => { execute(fn) }.
+  // Previously the adaptation existed only in wrapExecutorWithLogging, which
+  // made runInTransaction crash on the "live" SDK. Options (isolation/signal/
+  // idempotent) pass through to the SDK as is; timeout is implemented by the
+  // transaction manager per attempt (a fresh AbortSignal.timeout for each
+  // attempt) and never reaches the SDK.
   const adapted = ((strings: TemplateStringsArray, ...args: any[]) =>
     client(strings, ...args)) as unknown as YdbExecutor;
 
@@ -201,9 +201,9 @@ export function createExecutor(
 
   let executor = adapted;
 
-  // Retry-политика (#27): опциональна, по умолчанию выключена (ретраит
-  // только SDK). Обёртка ставится ПОД логирование, чтобы каждая попытка
-  // политики попадала в лог отдельно.
+  // Retry policy (#27): optional, disabled by default (only the SDK retries).
+  // The wrapper is placed UNDER logging so each policy attempt is logged
+  // separately.
   if (opts.retry !== undefined && opts.retry !== false) {
     executor = withRetryPolicy(executor, opts.retry);
   }

--- a/src/core/execute-query.ts
+++ b/src/core/execute-query.ts
@@ -2,15 +2,15 @@ import type { YdbQuery } from './interfaces.js';
 import type { QueryOptions } from './query-options.js';
 
 /**
- * Применяет QueryOptions к построенному запросу и выполняет его:
- * - signal — отмена (уже абортнутый сигнал — немедленная ошибка);
- * - timeout — таймаут на попытку;
- * - idempotent (#27) — пометка `.idempotent(true)`, разрешающая
- *   retry-политике повторять запрос; без пометки запрос выполняется
- *   ровно один раз.
+ * Applies QueryOptions to a built query and executes it:
+ * - signal — cancellation (an already-aborted signal fails immediately);
+ * - timeout — per-attempt timeout;
+ * - idempotent (#27) — marks the query `.idempotent(true)`, which allows
+ *   the retry policy to repeat it; without the marker the query runs
+ *   exactly once.
  *
- * Единая точка этой логики для persistence и relations — раньше
- * дублировалась в обоих.
+ * Single definition point of this logic for persistence and relations —
+ * previously it was duplicated in both.
  */
 export async function executeYdbQuery<U>(
   query: YdbQuery,

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -13,42 +13,50 @@ import type { YdbRetryPolicyInput } from './retry.js';
 export type { QueryOptions } from './query-options.js';
 export type { QueryLogger, QueryLogEntry } from './query-logger.js';
 
+/**
+ * Configuration options for the YDB ORM module (used by
+ * YdbCoreModule.forRootAsync() and createDriver()).
+ *
+ * @see createDriver
+ * @see resolveCredentialsProvider
+ * @see withRetryPolicy
+ * @see wrapExecutorWithLogging
+ */
 export interface YdbModuleOptions {
   endpoint: string;
   /**
-   * Готовый CredentialsProvider (#96) — паттерн useExisting: передаётся
-   * как есть (OAuth-токен, тестовые реализации, переиспользование
-   * провайдера из другого модуля).
+   * A ready-made CredentialsProvider (#96) — the useExisting pattern: passed
+   * through as is (an OAuth token, test implementations, reusing a provider
+   * from another module).
    *
-   * Приоритет источников провайдера (детерминированный, см.
-   * resolveCredentialsProvider):
-   *   credentialsProvider → auth (AuthManager из @ycforge/auth) →
-   *   DI-провайдер YDB_CREDENTIALS_PROVIDER →
+   * Deterministic provider-source priority (see resolveCredentialsProvider):
+   *   credentialsProvider → auth (AuthManager from @ycforge/auth) →
+   *   DI provider YDB_CREDENTIALS_PROVIDER →
    *   driverOptions.credentialsProvider.
-   * Задание одновременно credentialsProvider и
-   * driverOptions.credentialsProvider — ошибка конфигурации:
-   * молчаливый выбор одного из них запрещён.
+   * Setting both credentialsProvider and
+   * driverOptions.credentialsProvider is a configuration error: silently
+   * picking one of them is not allowed.
    */
   credentialsProvider?: CredentialsProvider;
   /**
-   * Готовый AuthManager из пакета `@ycforge/auth` — единая точка
-   * стратегий аутентификации (iam_token / metadata / auth_key /
-   * access_token / anonymous / static). Адаптируется в CredentialsProvider
-   * через `createYdbCredentialsProvider(auth, YDB_AUTH_USAGE, options)` из
-   * `@ycforge/auth/ydb`.
+   * A ready-made AuthManager from the `@ycforge/auth` package — the single
+   * entry point for authentication strategies (iam_token / metadata /
+   * auth_key / access_token / anonymous / static). Adapted to a
+   * CredentialsProvider via `createYdbCredentialsProvider(auth, YDB_AUTH_USAGE,
+   * options)` from `@ycforge/auth/ydb`.
    *
-   * Приоритет: сразу после явного `credentialsProvider` и перед
-   * DI-провайдером `YDB_CREDENTIALS_PROVIDER` /
+   * Priority: immediately after the explicit `credentialsProvider` and before
+   * the DI provider `YDB_CREDENTIALS_PROVIDER` /
    * `driverOptions.credentialsProvider`.
-   * Задание одновременно `auth` и `driverOptions.credentialsProvider` —
-   * ошибка конфигурации (`Conflicting YDB credentials configuration`).
+   * Setting both `auth` and `driverOptions.credentialsProvider` is a
+   * configuration error (`Conflicting YDB credentials configuration`).
    */
   auth?: AuthManager;
   /**
-   * Кастомная фабрика драйвера: если задана, используется вместо создания
-   * Driver по endpoint/driverOptions. Удобно для тестов и нестандартных
-   * транспортов. Драйвер, возвращённый фабрикой, считается принадлежащим
-   * модулю: при graceful shutdown модуль закроет его через driver.close().
+   * Custom driver factory: if set, used instead of building the Driver from
+   * endpoint/driverOptions. Convenient for tests and non-standard transports.
+   * The driver returned by the factory is considered owned by the module:
+   * on graceful shutdown the module closes it via driver.close().
    */
   driverFactory?: () => Driver | Promise<Driver>;
   driverOptions?: DriverOptions;
@@ -60,117 +68,126 @@ export interface YdbModuleOptions {
   encryptionProvider?: YdbEncryptionProvider;
   blindIndexProvider?: YdbBlindIndexProvider;
   /**
-   * Формат сериализации Security AAD (#165): 'v2' (по умолчанию) — каноническая
-   * self-delimiting сериализация без коллизий от вложенных разделителей, или
-   * 'legacy' — исторический `name=value;...` ТОЛЬКО для переходного периода:
-   * смена формата меняет аутентифицированные байты, поэтому старый ciphertext
-   * под v2 не расшифруется. Миграция: пока в БД есть записи, написанные в
-   * legacy, читайте/шифруйте в 'legacy' и перешифруйте их (save/скрипт),
-   * затем переключитесь на 'v2'.
+   * Security AAD serialization format (#165): 'v2' (default) — canonical
+   * self-delimiting serialization with no collisions from nested delimiters,
+   * or 'legacy' — the historical `name=value;...` ONLY for the transition
+   * period: changing the format changes the authenticated bytes, so old
+   * ciphertext will not decrypt under v2. Migration: while the DB still holds
+   * rows written in legacy, read/encrypt in 'legacy' and re-encrypt them
+   * (save/script), then switch to 'v2'.
    */
   aadFormat?: AadFormat;
   /**
-   * Автоматическое определение формата Security AAD при дешифровке (#165):
-   * true (по умолчанию) — при сбое расшифровки основным форматом пробуется
-   * второй. Это единственный безопасный путь апгрейда существующей БД:
-   * строки, написанные до появления `v2`, остаются читаемыми после смены
-   * дефолта. false — строгий режим, пригодный только после того, как все
-   * данные перешифрованы в один формат (сбой формата падает сразу).
-   * Поля с `aadOverride` от падения формата не зависят — повтор не делается.
+   * Automatic Security AAD format detection on decryption (#165):
+   * true (default) — if the primary format fails to decrypt, the second one
+   * is tried. This is the only safe upgrade path for an existing database:
+   * rows written before `v2` existed remain readable after the default
+   * changes. false — strict mode, viable only after all data has been
+   * re-encrypted into a single format (a format failure fails immediately).
+   * Fields with `aadOverride` do not depend on format fallbacks — no retry.
    */
   aadReadFallback?: boolean;
   /**
-   * Провайдер валидации сущностей перед записью (save/insert/insertMany/update).
-   * Например, ClassValidatorProvider. Без него валидация не выполняется.
+   * Entity validation provider invoked before writes (save/insert/insertMany/update).
+   * For example, ClassValidatorProvider. Without it no validation runs.
    */
   validationProvider?: YdbValidationProvider;
   /**
-   * Версия генерируемых UUID для первичных ключей: v7 (по умолчанию,
-   * время-сортируемые) или v4 (случайные, для переходного периода).
+   * Version of generated UUIDs for primary keys: v7 (default, time-sortable)
+   * or v4 (random, for the transition period).
    */
   uuidVersion?: 'v4' | 'v7';
   /**
-   * Как в TypeORM synchronize: при старте приложения подстроить схему БД
-   * под метаданные всех сущностей (создать недостающие таблицы и колонки).
-   * Только для dev-стендов — в проде используйте миграции.
+   * Like TypeORM synchronize: on application startup align the DB schema
+   * with the metadata of all entities (create missing tables and columns).
+   * Dev-only — use migrations in production.
    */
   sync?: boolean;
   /**
-   * Логирование запросов: true (консоль по умолчанию) или экземпляр QueryLogger.
-   * Логирует SQL, имена параметров, безопасную метаинформацию значений
-   * (тип и класс размера, raw скрыт по умолчанию) и длительность.
+   * Query logging: true (default console) or a QueryLogger instance.
+   * Logs SQL, parameter names, safe value metadata (type and size class; raw
+   * is hidden by default) and duration.
    */
   logQueries?: boolean | QueryLogger;
   /**
-   * Раскрытие raw-значений параметров в логах (#168). По умолчанию
-   * (undefined/false) значения не логируются вовсе — только безопасная
-   * метаинформация (тип и укрупнённый класс размера, например
-   * `<string:1-31>` или `<bytes:128-511>`; точная длина скрыта), поэтому
-   * чувствительные данные с произвольными именами не попадают в журналы.
-   * «Значения скрыты по умолчанию» — intentional behavior change c 1.0.
-   * raw-раскрытие — явный opt-in: true (все значения), string[] / RegExp /
-   * предикат (только подходящие имена параметров). Бинарные значения
-   * маскируются всегда, даже при `true`.
+   * Raw parameter value disclosure in logs (#168). By default
+   * (undefined/false) values are not logged at all — only safe metadata
+   * (type and a coarse size class, e.g. `<string:1-31>` or `<bytes:128-511>`;
+   * the exact length is hidden), so sensitive data with arbitrary names never
+   * reaches the logs.
+   * "Values hidden by default" is an intentional behavior change since 1.0.
+   * Raw disclosure is an explicit opt-in: true (all values), string[] /
+   * RegExp / predicate (only matching parameter names). Binary values are
+   * always masked, even with `true`.
    */
   logParamValues?: YdbLogParamValues;
   /**
-   * Настройки транзакций (#98):
-   * - ambient — включить ambient-контекст транзакций (AsyncLocalStorage):
-   *   операции репозиториев внутри runInTransaction() без явного { trx }
-   *   автоматически используют активную транзакцию. По умолчанию выключено.
-   * - warnOutsideTransaction — предупреждать, когда запрос выполняется вне
-   *   какой бы то ни было транзакции. Предупреждение уходит в логгер (#206):
-   *   в `QueryLogger.warn` (опция `logQueries`) или в консольный фолбэк
-   *   `ConsoleQueryLogger`, если кастомный логгер не настроен. По умолчанию
-   *   выключено (чтобы не шуметь); включайте осознанно, например в dev-окружении.
+   * Transaction settings (#98):
+   * - ambient — enable the ambient transaction context (AsyncLocalStorage):
+   *   repository operations inside runInTransaction() without an explicit
+   *   { trx } automatically use the active transaction. Off by default.
+   * - warnOutsideTransaction — warn when a query runs outside any
+   *   transaction. The warning goes to the logger (#206): to
+   *   `QueryLogger.warn` (the `logQueries` option) or to the console
+   *   fallback `ConsoleQueryLogger` if no custom logger is configured. Off
+   *   by default (to avoid noise); enable deliberately, e.g. in dev.
    */
   transactions?: YdbTransactionsSettings;
   /**
-   * Retry-политика по типу ошибки (#27) для операций executor'а.
+   * Error-type retry policy (#27) for executor operations.
    *
-   * - `undefined` / `false` (по умолчанию) — политика выключена: повторами
-   *   одиночных запросов владеет только внутренний ретрай SDK (как в #98);
-   * - `true` — политика с дефолтами (maxAttempts: 3, bounded backoff
-   *   100..5000 мс, jitter 0.25);
-   * - объект `YdbRetryPolicyOptions` — кастомная политика.
+   * - `undefined` / `false` (default) — policy disabled: retries of single
+   *   queries are handled only by the SDK internal retry (as in #98);
+   * - `true` — policy with defaults (maxAttempts: 3, bounded backoff
+   *   100..5000 ms, jitter 0.25);
+   * - a `YdbRetryPolicyOptions` object — custom policy.
    *
-   * ПРАВИЛО ИДЕМПОТЕНТНОСТИ (fail-safe): политика повторяет только
-   * запросы, явно помеченные идемпотентными — `.idempotent(true)` на
-   * цепочке или `{ idempotent: true }` в QueryOptions. Непомеченный
-   * запрос (включая все записи по умолчанию) выполняется ровно один раз:
-   * внутренний цикл SDK гасится, двусмысленный сбой транспорта не
-   * приводит к повтору записи. Для транзакций — отдельная опция retry
-   * в runInTransaction() (колбэк обязан быть идемпотентным, #98).
-   * Когда политика включена и запрос помечен, ORM владеет ретраями
-   * через этот executor и ГАСИТ внутренний цикл SDK (одна попытка SDK
-   * на попытку ORM) — попытки не перемножаются. Статусы повтора:
-   * только ABORTED/UNAVAILABLE/OVERLOADED. См. README «Retry-политика».
+   * IDEMPOTENCY RULE (fail-safe): the policy retries only queries explicitly
+   * marked idempotent — `.idempotent(true)` on the chain or
+   * `{ idempotent: true }` in QueryOptions. An unmarked query (including all
+   * writes by default) runs exactly once: the SDK inner loop is suppressed,
+   * so an ambiguous transport failure cannot duplicate a write. For
+   * transactions there is a separate retry option in runInTransaction() (the
+   * callback must be idempotent, #98).
+   * When the policy is enabled and the query is marked, the ORM owns retries
+   * through this executor and SUPPRESSES the SDK inner loop (one SDK attempt
+   * per ORM attempt) — attempts do not multiply. Retry statuses: only
+   * ABORTED/UNAVAILABLE/OVERLOADED. See README "Retry policy".
    */
   retry?: YdbRetryPolicyInput;
 }
 
+/**
+ * Transaction-related settings of a configuration (#98): `ambient` enables
+ * the ambient transaction context, `warnOutsideTransaction` warns about
+ * queries running outside any transaction. Both are off by default.
+ */
 export interface YdbTransactionsSettings {
   ambient?: boolean;
   warnOutsideTransaction?: boolean;
 }
 
+/**
+ * A builder-style YDB query that is thenable (awaitable). Mirrors the subset
+ * of the @ydbjs/query client API used by the ORM.
+ */
 export interface YdbQuery {
   parameter(name: string, value: unknown): YdbQuery;
   timeout(timeout: number): YdbQuery;
   signal(signal: AbortSignal): YdbQuery;
   /**
-   * Пометка идемпотентности одиночного запроса (#27): разрешает
-   * retry-политике ORM (и условно-retryable статусам SDK) повторять
-   * этот запрос. По умолчанию запросы НЕ считаются идемпотентными:
-   * без пометки политика ORM выполняет запрос ровно один раз.
+   * Idempotency marker for a single query (#27): allows the ORM retry policy
+   * (and the SDK's conditionally-retryable statuses) to retry this query.
+   * By default queries are NOT considered idempotent: without the marker the
+   * ORM policy runs the query exactly once.
    */
   idempotent(flag?: boolean): YdbQuery;
   cancel(): YdbQuery;
   /**
-   * SDK-события запроса (#27): у реального Query из @ydbjs/query есть
-   * `.on('retry', ctx)` — политика ORM использует его, чтобы гасить
-   * внутренний ретрай SDK и забирать управление повторами себе.
-   * Опционально: моки и другие реализации могут её не предоставлять.
+   * SDK query events (#27): the real Query from @ydbjs/query exposes
+   * `.on('retry', ctx)` — the ORM policy uses it to suppress the SDK inner
+   * retry and take retry ownership itself. Optional: mocks and other
+   * implementations may omit it.
    */
   on?(
     event: 'retry',
@@ -180,25 +197,25 @@ export interface YdbQuery {
 }
 
 /**
- * Уровень изоляции транзакции YDB (см. TransactionExecuteOptions в @ydbjs/query).
+ * YDB transaction isolation level (see TransactionExecuteOptions in @ydbjs/query).
  */
 export type YdbIsolationLevel =
   'serializableReadWrite' | 'snapshotReadOnly' | 'snapshotReadWrite';
 
 /**
- * Опции исполнения транзакции (#98).
+ * Transaction execution options (#98).
  *
- * - isolation — уровень изоляции YDB (по умолчанию 'serializableReadWrite' на
- *   стороне SDK);
- * - signal — ГЛОБАЛЬНЫЙ AbortSignal: отменяет операцию целиком, все попытки
- *   (включая idempotent-retry); пробрасывается в SDK как есть;
- * - timeout — таймаут в миллисекундах, действует НА КАЖДУЮ ПОПЫТКУ: при
- *   idempotent-retry каждая попытка получает СВЕЖЕЕ окно таймаута, а не
- *   истёкший дедлайн первой попытки. Полный дедлайн на всю операцию задаётся
- *   явно: signal: AbortSignal.timeout(ms);
- * - idempotent — разрешить SDK повторять тело транзакции при retryable-
- *   ошибках. ВНИМАНИЕ: при повторе заново выполняется весь колбэк, поэтому
- *   побочные эффекты и lifecycle hooks могут сработать больше одного раза.
+ * - isolation — YDB isolation level (defaults to 'serializableReadWrite' on
+ *   the SDK side);
+ * - signal — GLOBAL AbortSignal: aborts the whole operation, all attempts
+ *   (including idempotent-retry); passed through to the SDK as is;
+ * - timeout — timeout in milliseconds applied PER ATTEMPT: on idempotent-retry
+ *   each attempt gets a FRESH timeout window, not the expired deadline of the
+ *   first attempt. A full deadline for the whole operation is set explicitly:
+ *   signal: AbortSignal.timeout(ms);
+ * - idempotent — allow the SDK to retry the transaction body on retryable
+ *   errors. WARNING: on a retry the whole callback executes anew, so side
+ *   effects and lifecycle hooks may fire more than once.
  */
 export interface YdbTransactionOptions {
   isolation?: YdbIsolationLevel;
@@ -207,13 +224,17 @@ export interface YdbTransactionOptions {
   idempotent?: boolean;
 }
 
-/** Хэндл открытой (открываемой) транзакции. */
+/** Handle of an open (or opening) transaction. */
 export interface YdbTransactionHandle {
   execute<T>(
     fn: (trx: YdbExecutor, signal?: AbortSignal) => Promise<T>,
   ): Promise<T>;
 }
 
+/**
+ * A thenable YDB query client: callable as a tagged-template query builder,
+ * exposing `transaction()` to execute inside a transaction.
+ */
 export interface YdbExecutor {
   (strings: TemplateStringsArray, ...args: any[]): YdbQuery;
   transaction(options?: YdbTransactionOptions): YdbTransactionHandle;

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -232,7 +232,7 @@ export interface YdbTransactionHandle {
 }
 
 /**
- * A thenable YDB query client: callable as a tagged-template query builder,
+ * YDB query executor: callable as a tagged-template query builder,
  * exposing `transaction()` to execute inside a transaction.
  */
 export interface YdbExecutor {

--- a/src/core/mapper.spec.ts
+++ b/src/core/mapper.spec.ts
@@ -170,7 +170,7 @@ describe('mapToYdb', () => {
     });
 
     it('rejects an unsafe number that would otherwise pass Int64 range', () => {
-      const unsafe = 9007199254740994; // 2^53 + 2, внутри Int64, но number округляет
+      const unsafe = 9007199254740994; // 2^53 + 2, within Int64, but number rounds it
       expect(Number.isSafeInteger(unsafe)).toBe(false);
       expect(BigInt(unsafe)).toBeLessThan(9223372036854775807n);
       expect(() => mapToYdb('Int64', unsafe)).toThrow(/safe integer/);
@@ -264,7 +264,7 @@ describe('mapToYdb', () => {
       const ms = new Date('2026-08-18T12:30:00.123Z');
       const val = mapToYdb('Timestamp', ms) as any;
       expect(val.value).toBe(BigInt(ms.getTime()) * 1000n);
-      // Субмиллисекунды не сохраняются: JS Date не может их нести.
+      // Sub-milliseconds are not preserved: a JS Date cannot carry them.
       expect(val.value % 1000n).toBe(0n);
     });
 

--- a/src/core/mapper.ts
+++ b/src/core/mapper.ts
@@ -29,17 +29,15 @@ import {
 } from '@ydbjs/value/primitive';
 import { Optional } from '@ydbjs/value/optional';
 
-/** Границы знакового 32-битного целого. */
+/** Signed 32-bit integer bounds. */
 const INT32_MIN = -2147483648; // -2^31
 const INT32_MAX = 2147483647; // 2^31 - 1
 
-/** Границы знакового 64-битного целого. */
+/** Signed 64-bit integer bounds. */
 const INT64_MIN = -9223372036854775808n; // -2^63
 const INT64_MAX = 9223372036854775807n; // 2^63 - 1
 
-/**
- * Конструкторы YDB-типов для null-значений (Optional<null>).
- */
+/** YDB type constructors for null values (Optional<null>). */
 const nullTypeFactories = {
   Uuid: () => new UuidType(),
   Utf8: () => new Utf8Type(),
@@ -57,8 +55,8 @@ const nullTypeFactories = {
 } satisfies Record<YdbPrimitive, () => unknown>;
 
 /**
- * Безопасное строковое представление значения для сообщений об ошибках:
- * не раскрывает содержимое больших строк и бинарных данных.
+ * Safe string representation of a value for error messages:
+ * does not expose contents of large strings and binary data.
  */
 function valuePreview(value: unknown): string {
   if (value === null) return 'null';
@@ -84,7 +82,7 @@ function valuePreview(value: unknown): string {
     case 'function':
       return `<function ${value.name ?? 'anonymous'}>`;
     default: {
-      // Произвольный объект — показываем JSON, а не "[object Object]".
+      // Arbitrary object — show JSON, not "[object Object]".
       try {
         const json = JSON.stringify(value);
         if (json !== undefined) {
@@ -100,12 +98,12 @@ function valuePreview(value: unknown): string {
   }
 }
 
-/** Суффикс имени поля для сообщения об ошибке (если поле указано). */
+/** Field name suffix for error messages (if field is specified). */
 function fieldSuffix(field: string | undefined): string {
   return field ? ` (field "${field}")` : '';
 }
 
-/** Оборачивает ошибку конвертации, добавляя контекст (поле, тип, значение). */
+/** Wraps a conversion error, adding context (field, type, value). */
 function wrapConversionError(
   type: YdbPrimitive,
   value: unknown,
@@ -119,20 +117,19 @@ function wrapConversionError(
 }
 
 /**
- * Нормализация JS-даты: принимает Date, число (мс от эпохи) или ISO-строку.
+ * Normalizes a JS date: accepts Date, number (epoch ms), or ISO string.
  *
- * Внимание (точность): JS `Date` хранит только миллисекунды. YDB `Timestamp` —
- * микросекунды. Конвертация идёт как `getTime() * 1000n`, поэтому
- * субмиллисекундные значения (микро-/наносекунды) принципиально не могут быть
- * сохранены: при записи они обнуляются, при чтении YDB-микросекунды теряют
- * младшие три разряда. Используйте `Timestamp` только для миллисекундной
- * точности.
+ * Note (precision): JS `Date` stores only milliseconds. YDB `Timestamp` —
+ * microseconds. Conversion is `getTime() * 1000n`, so sub-millisecond
+ * values (micro-/nanoseconds) fundamentally cannot be preserved: they are
+ * zeroed on write, and YDB microseconds lose the lower three digits on read.
+ * Use `Timestamp` only for millisecond precision.
  */
 function toJsDate(value: Date | number | string): Date {
   return value instanceof Date ? value : new Date(value);
 }
 
-/** Проверяет корректность даты; невалидные значения (Invalid Date) отклоняются. */
+/** Checks date validity; invalid values (Invalid Date) are rejected. */
 function toValidJsDate(value: Date | number | string): Date {
   const date = toJsDate(value);
   if (Number.isNaN(date.getTime())) {
@@ -141,7 +138,7 @@ function toValidJsDate(value: Date | number | string): Date {
   return date;
 }
 
-/** Обёртки JS-значений в YDB-значения с валидацией типов и диапазонов. */
+/** Wrappers of JS values into YDB values with type and range validation. */
 const valueMappers: Record<YdbPrimitive, (value: any) => unknown> = {
   Uuid: (value: string) => new Uuid(value),
   Utf8: (value: string) => new Utf8(value),
@@ -161,8 +158,8 @@ const valueMappers: Record<YdbPrimitive, (value: any) => unknown> = {
   },
   Int64: (value: bigint | number | string) => {
     if (typeof value === 'number' && !Number.isSafeInteger(value)) {
-      // JS number небезопасен выше Number.MAX_SAFE_INTEGER (2^53 - 1):
-      // BigInt(value) превратит уже округлённое число в другой BigInt.
+      // JS number is unsafe above Number.MAX_SAFE_INTEGER (2^53 - 1):
+      // BigInt(value) would turn the already rounded number into a different BigInt.
       throw new TypeError(
         `Int64 value must be a safe integer, got ${valuePreview(value)} (use bigint or string for exact values above 2^53 - 1)`,
       );
@@ -171,7 +168,7 @@ const valueMappers: Record<YdbPrimitive, (value: any) => unknown> = {
     try {
       asBigInt = BigInt(value);
     } catch (err) {
-      // BigInt() бросает сырой RangeError для дробных/NaN — добавим контекст.
+      // BigInt() throws a raw RangeError for fractions/NaN — add context.
       throw new TypeError(
         `Int64 value must be an integer, got ${valuePreview(value)}: ${err instanceof Error ? err.message : String(err)}`,
       );
@@ -187,7 +184,7 @@ const valueMappers: Record<YdbPrimitive, (value: any) => unknown> = {
   Date: (value: Date | number | string) => new YdbDate(toValidJsDate(value)),
   Datetime: (value: Date | number | string) =>
     new Datetime(toValidJsDate(value)),
-  // См. JSDoc `toJsDate` про миллисекундную точность Timestamp.
+  // See JSDoc `toJsDate` for millisecond precision of Timestamp.
   Timestamp: (value: Date | number | string) =>
     new Timestamp(toValidJsDate(value)),
   Json: (value: any) =>
@@ -197,11 +194,11 @@ const valueMappers: Record<YdbPrimitive, (value: any) => unknown> = {
 };
 
 /**
- * Преобразует JS-значение в YDB-значение.
+ * Converts a JS value to a YDB value.
  *
- * @param type целевой YDB-тип
- * @param value JS-значение (null → Optional<null>)
- * @param field имя поля для контекста ошибок конвертации (необязательно)
+ * @param type target YDB type
+ * @param value JS value (null → Optional<null>)
+ * @param field field name for conversion error context (optional)
  */
 export function mapToYdb(type: YdbPrimitive, value: unknown, field?: string) {
   const wrap = valueMappers[type];

--- a/src/core/optional-peer.ts
+++ b/src/core/optional-peer.ts
@@ -1,11 +1,11 @@
 /**
- * Загружает опциональную peer-зависимость динамическим импортом.
+ * Loads an optional peer dependency via dynamic import.
  *
- * Имя пакета передаётся строковым аргументом (а не литералом в import()),
- * чтобы сборка не требовала установленный пакет.
+ * The package name is passed as a string argument (not a literal in import())
+ * so the build doesn't require the package to be installed.
  *
- * @param name имя пакета (например, 'class-validator')
- * @param hint где пакет нужен (например, 'ClassValidatorProvider')
+ * @param name package name (e.g., 'class-validator')
+ * @param hint where the package is needed (e.g., 'ClassValidatorProvider')
  */
 export async function loadOptionalPeer<T = unknown>(
   name: string,

--- a/src/core/orm-scope.ts
+++ b/src/core/orm-scope.ts
@@ -1,42 +1,42 @@
 import type { YdbTransactionsSettings } from './interfaces.js';
 
 /**
- * Скоуп одной независимой ORM-конфигурации (#199).
+ * Scope of one independent ORM configuration (#199).
  *
- * Раньше конфигурация была процессно-глобальной: один executor, одни
- * настройки транзакций, один набор сущностей на процесс. Скоуп делает
- * конфигурацию instance-scoped: у каждого скоупа собственные настройки
- * транзакций и собственный набор сущностей, а executor/провайдеры
- * изолируются естественно — через per-class entity runtime (сущность
- * физически не может быть подключена к двум конфигурациям сразу).
+ * Previously the configuration was process-global: one executor, one
+ * transaction setting, one entity set per process. A scope makes the
+ * configuration instance-scoped: each scope has its own transaction settings
+ * and its own entity set, while executors/providers are isolated naturally —
+ * via per-class entity runtime (an entity physically cannot be attached to two
+ * configurations at once).
  *
- * Контракт владения: один класс сущности принадлежит ровно одному
- * АКТИВНОМУ скоупу. Повторная регистрация в другом скоупе —
- * детерминированная ошибка (см. claimEntitiesForScope). Освобождение —
- * releaseOrmScope() (NestJS вызывает при shutdown приложения).
+ * Ownership contract: an entity class belongs to exactly one ACTIVE scope.
+ * Re-registration in another scope is a deterministic error (see
+ * claimEntitiesForScope). Release happens via releaseOrmScope() (NestJS calls
+ * it on application shutdown).
  */
 export interface YdbOrmScope {
-  /** Имя конфигурации: 'default' или пользовательское (NestJS `name`). */
+  /** Configuration name: 'default' or a custom one (NestJS `name`). */
   readonly name: string;
   /**
-   * Настройки транзакций этой конфигурации (#98/#199). undefined —
-   * наследуются процессно-глобальные настройки (configureTransactionContext),
-   * что сохраняет прежнее поведение standalone/тестов.
+   * Transaction settings of this configuration (#98/#199). undefined —
+   * inherit the process-global settings (configureTransactionContext), which
+   * preserves the previous standalone/test behavior.
    */
   transactions?: Required<YdbTransactionsSettings>;
-  /** Сущности, привязанные к этой конфигурации. */
+  /** Entities bound to this configuration. */
   readonly entities: Set<YdbEntityClass>;
 }
 
 type YdbEntityClass = new (...args: any[]) => any;
 
-/** Имя конфигурации по умолчанию (обратная совместимость). */
+/** Default configuration name (backward compatibility). */
 export const DEFAULT_ORM_SCOPE_NAME = 'default';
 
 /**
- * Владение сущностями: класс → активный скоуп-владелец.
- * Обычный Map (не WeakMap): владение снимается явно через releaseOrmScope,
- * а GC классов сущностей на практике не происходит.
+ * Entity ownership: class → active owner scope.
+ * A plain Map (not WeakMap): ownership is removed explicitly via
+ * releaseOrmScope, and GC of entity classes does not happen in practice.
  */
 const entityOwners = new Map<YdbEntityClass, YdbOrmScope>();
 
@@ -50,9 +50,9 @@ function normalizeTransactions(
 }
 
 /**
- * Создаёт скоуп новой независимой конфигурации (#199).
+ * Creates a scope for a new independent configuration (#199).
  *
- * Standalone-пример:
+ * Standalone example:
  * ```ts
  * const reporting = createOrmScope('reporting', { transactions: { ambient: true } });
  * configureEntities([ReportEntity], { executor: reportingExecutor, scope: reporting });
@@ -77,11 +77,11 @@ export function createOrmScope(
 let defaultScope: YdbOrmScope | undefined;
 
 /**
- * Скоуп конфигурации по умолчанию — ленивый синглтон. Именно он
- * используется configureEntities() без options.scope и дефолтной
- * конфигурацией NestJS, поэтому одиночная конфигурация и повторный
- * бутстрап (тесты, hot-restart) работают как раньше: скоуп никогда
- * не освобождается, повторный claim своих же сущностей идемпотентен.
+ * Default configuration scope — a lazy singleton. It is the one used by
+ * configureEntities() without options.scope and by the default NestJS
+ * configuration, so a single configuration and repeated bootstrap (tests,
+ * hot-restart) keep working as before: the scope is never released, and
+ * re-claiming its own entities is idempotent.
  */
 export function getDefaultOrmScope(): YdbOrmScope {
   if (!defaultScope) {
@@ -91,12 +91,12 @@ export function getDefaultOrmScope(): YdbOrmScope {
 }
 
 /**
- * Привязывает сущности к скоупу конфигурации (#199).
+ * Binds entities to a configuration scope (#199).
  *
- * Сущность, уже принадлежащая ДРУГОМУ активному скоупу, — понятная
- * ошибка конфигурации (тот же класс не может жить в двух конфигурациях:
- * его per-class runtime один). Повторный claim тем же скоупом
- * идемпотентен — это re-bootstrap в рамках одной конфигурации.
+ * An entity already owned by ANOTHER active scope is a clear configuration
+ * error (the same class cannot live in two configurations: its per-class
+ * runtime is single). Re-claiming by the same scope is idempotent — this is a
+ * re-bootstrap within one configuration.
  */
 export function claimEntitiesForScope(
   scope: YdbOrmScope,
@@ -122,8 +122,8 @@ export function claimEntitiesForScope(
 }
 
 /**
- * Снимает владение скоупа над его сущностями (shutdown приложения).
- * Идемпотентно. После release сущности можно привязать к другому скоупу.
+ * Releases the scope's ownership of its entities (application shutdown).
+ * Idempotent. After release the entities can be bound to another scope.
  */
 export function releaseOrmScope(scope: YdbOrmScope): void {
   for (const entity of scope.entities) {
@@ -135,9 +135,9 @@ export function releaseOrmScope(scope: YdbOrmScope): void {
 }
 
 /**
- * Снимает владение конкретных сущностей скоупа (rollback при ошибке
- * конфигурации). Только сущности, действительно принадлежащие scope,
- * освобождаются: ранее привязанные к нему же сущности не затрагиваются.
+ * Releases ownership of specific entities from a scope (rollback on
+ * configuration error). Only entities that actually belong to the scope
+ * are released: entities previously bound to the same scope are not affected.
  */
 export function releaseEntitiesFromScope(
   scope: YdbOrmScope,
@@ -151,7 +151,7 @@ export function releaseEntitiesFromScope(
   }
 }
 
-/** Текущий владелец сущности (для тестов и диагностики). */
+/** Current entity owner (for tests and diagnostics). */
 export function getEntityOrmScope(
   entity: YdbEntityClass,
 ): YdbOrmScope | undefined {
@@ -159,9 +159,9 @@ export function getEntityOrmScope(
 }
 
 /**
- * Заявляет сущности в скоупе и возвращает список сущностей, которые были
- * ново привязаны (не принадлежали этому скоупу ранее). Используется для
- * отката владения при ошибке конфигурации.
+ * Claims entities in a scope and returns the list of entities that were
+ * newly bound (did not previously belong to this scope). Used for
+ * ownership rollback on configuration error.
  */
 export function claimEntitiesForScopeWithTracking(
   scope: YdbOrmScope,

--- a/src/core/query-limits.ts
+++ b/src/core/query-limits.ts
@@ -1,31 +1,31 @@
 /**
- * Лимиты батч-запросов (#86): единая точка определения размера чанка
- * для IN (...) списков — используется persistence (fetchByColumnIn)
- * и relations (join-таблицы many-to-many, eager/loading связей).
+ * Batch-query limits (#86): single definition point of the chunk size for
+ * IN (...) lists — used by persistence (fetchByColumnIn) and relations
+ * (many-to-many join tables, eager/loading of relations).
  */
 
 /**
- * Максимальное количество значений в одном IN (...) списке.
+ * Maximum number of values in a single IN (...) list.
  *
- * Почему именно 500:
- * - у YDB есть лимит на длину текста запроса (по умолчанию 10 KB) и
- *   суммарный размер параметров gRPC-запроса (~50 MB на параметры,
- *   но текст запроса ограничен жёстче);
- * - каждый элемент IN (...) разворачивается в отдельный плейсхолдер `$pN`
- *   (~5–8 символов текста + отдельный параметр запроса), поэтому чанк из
- *   500 значений даёт ~3–4 KB SQL-текста — с запасом до лимита даже при
- *   дополнительных WHERE-условиях;
- * - значение согласовано с практикой батчинга самого YDB CLI
- *   (дефолт 1000 параметров на batch), но консервативнее.
+ * Why 500:
+ * - YDB limits the query text length (default 10 KB) and the total size of
+ *   the gRPC request parameters (~50 MB for parameters, but the query text
+ *   is capped more strictly);
+ * - each IN (...) element expands into its own placeholder `$pN`
+ *   (~5–8 characters of SQL plus a separate request parameter), so a chunk
+ *   of 500 values yields ~3–4 KB of SQL text — safely under the limit even
+ *   with additional WHERE conditions;
+ * - the value is aligned with the batching practice of the YDB CLI itself
+ *   (default 1000 parameters per batch), but is more conservative.
  *
- * Большие списки FK/PK режутся на несколько последовательных запросов,
- * результаты объединяются без дубликатов (см. chunkInValues).
+ * Large FK/PK lists are split into several sequential queries and the
+ * results are merged without duplicates (see chunkInValues).
  */
 export const MAX_IN_CLAUSE_VALUES = 500;
 
 /**
- * Режет список значений на чанки по MAX_IN_CLAUSE_VALUES (или явному size).
- * Порядок элементов сохраняется; последний чанк может быть меньше.
+ * Splits a list of values into chunks of MAX_IN_CLAUSE_VALUES (or an explicit size).
+ * Element order is preserved; the last chunk may be smaller.
  */
 import { valueIdentityKey } from './value-identity.js';
 export function chunkInValues<T>(
@@ -43,23 +43,23 @@ export function chunkInValues<T>(
 }
 
 /**
- * Дедупликация значений FK/PK с сохранением порядка первого вхождения.
+ * Deduplicates FK/PK values preserving the order of first occurrence.
  *
- * Ключ дедупликации — канонический value-ключ (#174): скаляры
- * (string/number/bigint/boolean) сравниваются по значению, а Bytes и
- * Date — ПО ЗНАЧЕНИЮ (два равных `Uint8Array` или две равные `Date`)
- * тоже схлопываются в одно значение, хотя по ссылке это разные объекты.
+ * The deduplication key is the canonical value key (#174): scalars
+ * (string/number/bigint/boolean) are compared by value, and Bytes and
+ * Date are compared BY VALUE too — two equal `Uint8Array`s or two equal
+ * `Date`s collapse into one value even though they are different objects.
  */
 export function dedupeInValues<T>(values: readonly T[]): T[] {
   const hasObject = values.some(
     (value) => typeof value === 'object' && value !== null,
   );
   if (!hasObject) {
-    // Быстрый путь: все значения — примитивы (string/number/bigint/boolean/
-    // null/undefined). Нативные Set-семантики (SameValueZero с различением
-    // типов и нормализацией -0/0) в точности совпадают с каноническим
-    // value-ключом однокомпонентных примитивов (#174), поэтому сериализация
-    // каждого значения не нужна.
+    // Fast path: all values are primitives (string/number/bigint/boolean/
+    // null/undefined). Native Set semantics (SameValueZero with type
+    // discrimination and -0/0 normalization) exactly match the canonical
+    // value key of single-component primitives (#174), so serializing each
+    // value is unnecessary.
     const seen = new Set<T>();
     const out: T[] = [];
     for (const value of values) {
@@ -70,8 +70,8 @@ export function dedupeInValues<T>(values: readonly T[]): T[] {
     }
     return out;
   }
-  // Fallback: есть Bytes/Date — сравнение по значению требует
-  // канонического ключа.
+  // Fallback: Bytes/Date present — value-based comparison requires a
+  // canonical key.
   const seen = new Map<string, T>();
   for (const value of values) {
     const key = valueIdentityKey([value]);
@@ -80,21 +80,22 @@ export function dedupeInValues<T>(values: readonly T[]): T[] {
   return [...seen.values()];
 }
 
-/** Защитный лимит строк по умолчанию для SELECT без явного limit (#133). */
+/** Default safety row limit for SELECTs without an explicit limit (#133). */
 export const DEFAULT_RETRIEVE_LIMIT = 100;
 
-/** Максимально допустимый лимит строк в одном SELECT. */
+/** Maximum allowed row limit for a single SELECT. */
 export const MAX_RETRIEVE_LIMIT = 1000;
 
 /**
- * Итоговый LIMIT с явной семантикой (#133):
- * - лимит не задан — защитный дефолт DEFAULT_RETRIEVE_LIMIT;
- * - `0` — LIMIT 0 (пустой результат), НЕ клампится в 1;
- * - положительное целое значение — до MAX_RETRIEVE_LIMIT (потолок);
- * - отрицательное, дробное или неконечное значение — ошибка.
+ * Resolves the effective LIMIT with explicit semantics (#133):
+ * - limit not set — safety default DEFAULT_RETRIEVE_LIMIT;
+ * - `0` — LIMIT 0 (empty result), NOT clamped to 1;
+ * - positive integer — up to MAX_RETRIEVE_LIMIT (ceiling);
+ * - negative, fractional or non-finite value — error.
  *
- * Единая точка семантики для query-builder и persistence (#158): раньше
- * persistence молча клампил limit: 0 → 1 и отрицательные → 1.
+ * Single definition point of the semantics shared by the query builder and
+ * persistence (#158): previously persistence silently clamped limit: 0 → 1
+ * and negatives → 1.
  */
 export function resolveRetrieveLimit(limit: number | undefined): number {
   if (limit === undefined) {
@@ -109,8 +110,8 @@ export function resolveRetrieveLimit(limit: number | undefined): number {
 }
 
 /**
- * Итоговый OFFSET: не задан — 0; дробное округляется вниз;
- * отрицательное клампится в 0.
+ * Resolves the effective OFFSET: not set — 0; fractional values are floored;
+ * negative values are clamped to 0.
  */
 export function resolveRetrieveOffset(offset: number | undefined): number {
   const num = Number.isFinite(offset) ? Math.floor(offset as number) : 0;

--- a/src/core/query-logger.ts
+++ b/src/core/query-logger.ts
@@ -5,29 +5,29 @@ import {
 } from '../transaction/transaction-context.js';
 
 /**
- * Информация о запросе для логирования.
+ * Query information for logging.
  */
 export interface QueryLogEntry {
-  /** SQL-запрос (шаблонная строка). */
+  /** SQL query (template string). */
   sql: string;
-  /** Имена параметров (без значений). */
+  /** Parameter names (without values). */
   paramNames: string[];
-  /** Замаскированные значения параметров: raw скрыт, только тип+класс размера. */
+  /** Masked parameter values: raw is hidden, only type + size class. */
   maskedParams: Record<string, unknown>;
-  /** Длительность выполнения в миллисекундах. */
+  /** Execution duration in milliseconds. */
   durationMs: number;
-  /** Ошибка (если запрос упал). */
+  /** Error (if the query failed). */
   error?: Error;
 }
 
 /**
- * Интерфейс логгера запросов.
- * Пользователь может передать свой логгер (e.g. pino, winston, OpenTelemetry span).
+ * Query logger interface.
+ * The user may supply their own logger (e.g. pino, winston, OpenTelemetry span).
  *
- * `warn` — опциональный хук для предупреждений ORM (#206): маршрутизируются
- * через логгер, сконфигурированный через `logQueries`, например предупреждение
- * `warnOutsideTransaction`. Метод опционален для обратной совместимости —
- * логгер, не реализующий `warn`, просто не получает предупреждения.
+ * `warn` — optional hook for ORM warnings (#206): routed through the logger
+ * configured via `logQueries`, e.g. the `warnOutsideTransaction` warning. The
+ * method is optional for backward compatibility — a logger without `warn`
+ * simply does not receive warnings.
  */
 export interface QueryLogger {
   log(entry: QueryLogEntry): void;
@@ -35,42 +35,43 @@ export interface QueryLogger {
 }
 
 /**
- * Опции обёртки логирования (#168): управление раскрытием raw-значений
- * параметров. По умолчанию значения не логируются вовсе.
+ * Logging wrapper options (#168): control disclosure of raw parameter values.
+ * By default values are not logged at all.
  */
 export interface YdbLoggingOptions {
+  /** Raw-value disclosure policy for parameter names. */
   values?: YdbLogParamValues;
 }
 
-/** Максимальная длина raw-значения параметра в логах (opt-in раскрытие). */
+/** Maximum length of a raw parameter value in logs (opt-in disclosure). */
 const MAX_PARAM_LENGTH = 64;
 
 /**
- * Разрешение на раскрытие raw-значений параметров в логах (#168).
+ * Raw parameter value disclosure permission for logs (#168).
  *
- * По умолчанию (undefined/false) логгер выводит для каждого параметра только
- * безопасную метаинформацию — тип и укрупнённый класс размера
- * (`<string:1-31>`, `<json:512-2047>`), никогда не раскрывая сами значения;
- * бинарные данные (в т.ч. ciphertext колонок) маскируются всегда. Точная
- * длина не раскрывается: exact-length канал позволил бы различать значения
- * по размеру (fingerprinting). Историческая денylist-маскировка по токенам
- * имени непокрыто утекала чувствительные значения с произвольными именами
- * (`salary`, `medical_record` и т.п.), поэтому убрана (#168).
+ * By default (undefined/false) the logger prints for each parameter only safe
+ * metadata — the type and a coarse size class (`<string:1-31>`,
+ * `<json:512-2047>`), never the values themselves; binary data (including
+ * column ciphertext) is always masked. Exact length is not disclosed: an
+ * exact-length channel would let values be distinguished by size
+ * (fingerprinting). The historical denylist masking by name tokens leaked
+ * sensitive values with arbitrary names (`salary`, `medical_record`, etc.),
+ * so it was removed (#168).
  *
- * Раскрытие raw-значений — явный opt-in приложения:
- * - `true` — раскрывать все значения (кроме бинарных; заведомо unsafe-логгер);
- * - `string[]` — раскрывать только перечисленные имена параметров;
- * - `RegExp` — раскрывать по маске имени параметра;
- * - `(name: string) => boolean` — произвольный предикат приложения.
+ * Raw value disclosure is an explicit application opt-in:
+ * - `true` — disclose all values (except binary; a knowingly unsafe logger);
+ * - `string[]` — disclose only the listed parameter names;
+ * - `RegExp` — disclose by parameter-name pattern;
+ * - `(name: string) => boolean` — arbitrary application predicate.
  *
- * Blind-index хеши (`{field}_bi`) — обычные строковые параметры: по умолчанию
- * маскируются, при явном opt-in раскрываются приложением осознанно (единский
- * hard-boundary — бинарные значения).
+ * Blind-index hashes (`{field}_bi`) are ordinary string parameters: masked by
+ * default, and on explicit opt-in disclosed by the application deliberately
+ * (the only hard boundary is binary values).
  */
 export type YdbLogParamValues =
   boolean | string[] | RegExp | ((name: string) => boolean);
 
-/** Допущенное приложением имя — выбор источника raw-значений (#168). */
+/** An application-approved name — the raw-value source selector (#168). */
 function allowRawValue(
   values: YdbLogParamValues | undefined,
   name: string,
@@ -84,12 +85,12 @@ function allowRawValue(
 }
 
 /**
- * Безопасная метаинформация о значении параметра (#168): raw не логируется,
- * только тип и укрупнённый класс размера. Точная длина значения НЕ
- * раскрывается — точные `<string:N>`/`<json:N>` позволяли бы различать
- * low-cardinality значения по длине (fingerprinting). Классы размера оставляют
- * диагностическую ценность («пустой?», «массивный BLOB?») без однозначного
- * канала различения значений.
+ * Safe metadata about a parameter value (#168): the raw value is not logged,
+ * only the type and a coarse size class. The exact value length is NOT
+ * disclosed — exact `<string:N>`/`<json:N>` would allow distinguishing
+ * low-cardinality values by length (fingerprinting). Size classes retain
+ * diagnostic value ("empty?", "huge BLOB?") without an unambiguous channel to
+ * distinguish values.
  */
 function safeMetaValue(value: unknown): unknown {
   if (value instanceof Uint8Array) {
@@ -111,8 +112,8 @@ function safeMetaValue(value: unknown): unknown {
       try {
         len = JSON.stringify(value).length;
       } catch {
-        // Циклическая/несериализуемая структура: маскируем без размера,
-        // логирование не должно падать и ронять запрос (см. #190).
+        // Cyclic/non-serializable structure: mask without size;
+        // logging must not crash and take the query down (see #190).
         return '<json>';
       }
       return `<json:${lengthBucket(len)}>`;
@@ -123,8 +124,8 @@ function safeMetaValue(value: unknown): unknown {
 }
 
 /**
- * Укрупнённый класс длины для метаинформации (#190): точная длина не
- * раскрывается, чтобы по журналам нельзя было различать значения.
+ * Coarse length class for metadata (#190): the exact length is not disclosed
+ * so values cannot be distinguished from logs.
  */
 function lengthBucket(length: number): string {
   const buckets = [
@@ -139,9 +140,9 @@ function lengthBucket(length: number): string {
 }
 
 /**
- * Маскирование скалярного значения. Байты никогда не раскрываются (только
- * класс размера). Raw-значение допустимо только для имён из явного allowlist'а
- * приложения (#168); длинные строки в таком случае обрезаются.
+ * Masking of a scalar value. Bytes are never disclosed (only the size class).
+ * Raw values are allowed only for names in the application's explicit
+ * allowlist (#168); long strings are then truncated.
  */
 function maskScalarValue(
   name: string,
@@ -149,8 +150,8 @@ function maskScalarValue(
   allowRaw: boolean,
 ): unknown {
   if (value instanceof Uint8Array) {
-    // Жёсткая граница: бинарные данные никогда не раскрываются, только
-    // класс размера (точная длина скрыта, #190).
+    // Hard boundary: binary data is never disclosed, only the size class
+    // (exact length is hidden, #190).
     return `<bytes:${lengthBucket(value.length)}>`;
   }
   if (allowRaw) {
@@ -162,7 +163,7 @@ function maskScalarValue(
   return safeMetaValue(value);
 }
 
-/** Маскирование значения параметра по имени параметра. */
+/** Masks a parameter value by parameter name. */
 function maskValue(
   name: string,
   value: unknown,
@@ -182,7 +183,7 @@ function maskValue(
   return maskScalarValue(name, value, allowRawValue(values, name));
 }
 
-/** Сериализация значения параметра для консольного вывода (#190). */
+/** Serializes a parameter value for console output (#190). */
 function formatParamValue(value: unknown): string {
   if (value === undefined) return 'undefined';
   if (typeof value === 'bigint') return `${value}n`;
@@ -192,8 +193,8 @@ function formatParamValue(value: unknown): string {
       const json = JSON.stringify(value);
       if (json !== undefined) return json;
     } catch {
-      // Циклическая структура (raw opt-in раскрытие): плейсхолдер вместо
-      // падения логгера.
+      // Cyclic structure (raw opt-in disclosure): a placeholder instead of
+      // crashing the logger.
     }
     return '<circular>';
   }
@@ -202,8 +203,8 @@ function formatParamValue(value: unknown): string {
 }
 
 /**
- * Консольный логгер запросов по умолчанию.
- * Формат: [YDB] QUERY <durationMs>ms — sql с параметрами
+ * Default console query logger.
+ * Format: [YDB] QUERY <durationMs>ms — sql with parameters
  */
 export class ConsoleQueryLogger implements QueryLogger {
   log(entry: QueryLogEntry): void {
@@ -225,8 +226,8 @@ export class ConsoleQueryLogger implements QueryLogger {
   }
 
   /**
-   * Предупреждение ORM (#206): выдаётся как есть (текст содержит собственный
-   * префикс `[ydb-orm]`), чтобы контент предупреждения не искажался.
+   * ORM warning (#206): printed as is (the text carries its own `[ydb-orm]`
+   * prefix), so the warning content is not distorted.
    */
   warn(message: string): void {
     console.warn(message);
@@ -234,15 +235,15 @@ export class ConsoleQueryLogger implements QueryLogger {
 }
 
 /**
- * Приватный реестр логгеров executor'ов (#206), по образцу identity-подхода
- * #217: связь «executor → логгер» — модульно-локальная метаданные, она не
- * должна лежать в изменяемом свойстве, которое потребитель может перезаписать.
- * WeakMap не даёт внешнему коду (в т.ч. hold'ящему обёртку) подменить логгер
- * конфигурации и не ломает frozen/sealed executor'ы.
+ * Private per-executor logger registry (#206), modeled after the identity
+ * approach of #217: the "executor → logger" link is module-local metadata and
+ * must not live in a mutable property a consumer could overwrite. The WeakMap
+ * prevents external code (including a wrapper holder) from swapping the
+ * configuration logger and does not break frozen/sealed executors.
  */
 const executorLoggers = new WeakMap<YdbExecutor, QueryLogger>();
 
-/** Возвращает логгер, привязанный к executor'у в wrapExecutorWithLogging. */
+/** Returns the logger bound to an executor in wrapExecutorWithLogging. */
 export function getExecutorLogger(
   executor: YdbExecutor | undefined,
 ): QueryLogger | undefined {
@@ -253,11 +254,11 @@ export function getExecutorLogger(
 }
 
 /**
- * Резолвит логгер для операций сущности (#206): логгер, привязанный к
- * executor'у конфигурации, или единый консольный фолбэк, если логирование
- * не сконфигурировано. Фолбэк — устоявшийся `ConsoleQueryLogger`, поэтому
- * поведение без кастомного логгера сохраняется (предупреждения идут в консоль),
- * а отдельная конфигурация не может подсветить чужой кастомный логгер.
+ * Resolves the logger for entity operations (#206): the logger bound to the
+ * configuration executor, or a shared console fallback if logging is not
+ * configured. The fallback is the standalone `ConsoleQueryLogger`, so the
+ * behavior without a custom logger is preserved (warnings go to the console),
+ * and a separate configuration cannot pick up a foreign custom logger.
  */
 const fallbackQueryLogger = new ConsoleQueryLogger();
 
@@ -268,12 +269,12 @@ export function resolveExecutorLogger(
 }
 
 /**
- * Оборачивает executor логированием: замеряет длительность,
- * маскирует параметры, логирует SQL + ошибки.
+ * Wraps an executor with logging: measures duration, masks parameters, logs
+ * SQL and errors.
  *
- * @param options Настройки раскрытия raw-значений параметров (#168):
- *   по умолчанию в лог попадают только имена и метаинформация (тип + класс
- *   размера, без точной длины).
+ * @param options Raw parameter value disclosure settings (#168):
+ *   by default only names and metadata (type + size class, without exact
+ *   length) go into the log.
  */
 export function wrapExecutorWithLogging(
   executor: YdbExecutor,
@@ -295,8 +296,8 @@ export function wrapExecutorWithLogging(
         paramNames.push(name);
         maskedParams[name] = maskValue(name, value, values);
         originalParameter(name, value);
-        // Возвращаем прокси, иначе цепочка parameter().parameter() сбегает
-        // из прокси и последующие вызовы теряют логирование
+        // Return the proxy, otherwise a parameter().parameter() chain escapes
+        // the proxy and subsequent calls lose logging
         return proxied;
       },
       timeout(ms: number) {
@@ -307,9 +308,9 @@ export function wrapExecutorWithLogging(
         query.signal(signal);
         return proxied;
       },
-      // Без проброса idempotent() пометка #27 молча терялась бы на этом
-      // прокси (executeQuery вызывает query.idempotent?.(true)), и запрос
-      // выпадал бы из retry-политики при включённом logQueries.
+      // Without forwarding idempotent(), the #27 marker would be silently lost
+      // on this proxy (executeQuery calls query.idempotent?.(true)), and the
+      // query would drop out of the retry policy while logQueries is enabled.
       idempotent(flag?: boolean) {
         query.idempotent?.(flag);
         return proxied;
@@ -346,36 +347,36 @@ export function wrapExecutorWithLogging(
   wrapped.transaction = (
     txOptions?: Parameters<YdbExecutor['transaction']>[0],
   ) => {
-    // Опции транзакции (#98) пробрасываются как есть — логируется только
-    // executor, семантика исполнения не меняется.
+    // Transaction options (#98) pass through as is — only the executor is
+    // logged, execution semantics are unchanged.
     const tx = executor.transaction(txOptions);
     return {
       execute: (
         fn: (trx: YdbExecutor, signal?: AbortSignal) => Promise<unknown>,
       ) =>
         tx.execute((trx: YdbExecutor, signal?: AbortSignal) => {
-          // Транзакционный executor оборачивается тем же логгером: каждый
-          // запрос внутри runInTransaction (и вложенных транзакций) логируется
-          // с той же семантикой, что и обычные запросы.
+          // The transactional executor is wrapped with the same logger: every
+          // query inside runInTransaction (and nested transactions) is logged
+          // with the same semantics as ordinary queries.
           return fn(wrapExecutorWithLogging(trx, logger, options), signal);
         }),
     };
   };
 
-  // Identity (#207): обёртка и её исходник представляют один логический
-  // executor, поэтому обёртка наследует identity-токен исходника, а исходник
-  // при необходимости получает собственный токен. Разные обёртки одного
-  // логического executor'а разделяют токен — детекция вложенных транзакций
-  // сравнивает DB-контексты по значению, а не по ссылке на объект.
+  // Identity (#207): the wrapper and its source represent one logical
+  // executor, so the wrapper inherits the source's identity token, and the
+  // source gets its own token if needed. Different wrappers of one logical
+  // executor share the token — nested-transaction detection compares DB
+  // contexts BY VALUE, not by object reference.
   ensureExecutorIdentity(executor);
   inheritExecutorIdentity(executor, wrapped);
 
-  // Логгер путешествует вместе с executor'ом (#206): операции сущности могут
-  // достать его через getExecutorLogger/resolveExecutorLogger, поэтому
-  // предупреждения (warnOutsideTransaction) попадают в логгер СВОЕЙ
-  // конфигурации, а не в чужой или напрямую в консоль. Регистрация идёт
-  // в приватный реестр, а не в свойство обёртки — перезаписать логгер
-  // извне нельзя (см. executorLoggers).
+  // The logger travels with the executor (#206): entity operations can fetch
+  // it via getExecutorLogger/resolveExecutorLogger, so warnings
+  // (warnOutsideTransaction) reach THEIR configuration's logger, not a
+  // foreign one or the console directly. Registration goes into the private
+  // registry, not into a wrapper property — the logger cannot be overwritten
+  // externally (see executorLoggers).
   executorLoggers.set(wrapped as YdbExecutor, logger);
 
   return wrapped as YdbExecutor;

--- a/src/core/query-options.ts
+++ b/src/core/query-options.ts
@@ -1,28 +1,28 @@
 import { YdbExecutor } from './interfaces.js';
 
 export interface QueryOptions {
-  /** Транзакция / executor */
+  /** Transaction / executor */
   trx?: YdbExecutor;
-  /** AbortSignal для отмены */
+  /** AbortSignal for cancellation */
   signal?: AbortSignal;
-  /** Таймаут в миллисекундах */
+  /** Timeout in milliseconds */
   timeout?: number;
   /**
-   * Пометка идемпотентности запроса (#27). Пробрасывается в SDK как
-   * `.idempotent(true)` и разрешает retry-политике ORM повторять запрос
-   * при транзитных ошибках (ABORTED/UNAVAILABLE/OVERLOADED).
+   * Query idempotency marker (#27). Passed to SDK as
+   * `.idempotent(true)` and allows the ORM retry policy to retry the query
+   * on transient errors (ABORTED/UNAVAILABLE/OVERLOADED).
    *
-   * БЕЗ пометки запрос выполняется РОВНО ОДИН раз даже при включённой
-   * политике (`YdbModuleOptions.retry`): повтор незнакомого записывающего
-   * запроса после двусмысленного сбоя транспорта может продублировать
-   * побочные эффекты. Помечайте только операции, устойчивые к повтору
-   * (идемпотентные SELECT, INSERT по фиксированному PK и т.п.).
+   * WITHOUT the marker the query runs EXACTLY ONCE even with the
+   * policy enabled (`YdbModuleOptions.retry`): retrying an unknown write
+   * after an ambiguous transport failure could duplicate side effects.
+   * Mark only operations that are safe to repeat (idempotent SELECT,
+   * INSERT with fixed PK, etc.).
    */
   idempotent?: boolean;
-  /** Максимум строк в SELECT (по умолчанию 100) */
+  /** Maximum rows in SELECT (default 100) */
   limit?: number;
-  /** Смещение для SELECT */
+  /** Offset for SELECT */
   offset?: number;
-  /** Конкретные колонки для SELECT (вместо SELECT *) */
+  /** Specific columns for SELECT (instead of SELECT *) */
   select?: string[];
 }

--- a/src/core/retry-executor.spec.ts
+++ b/src/core/retry-executor.spec.ts
@@ -11,9 +11,9 @@ import type {
 import type { YdbRetrySleepFn } from './retry.js';
 
 /**
- * Интеграционные тесты подключения retry-политики к executor'у (#27):
- * политика реально вызывается для операций executor'а, попытки не
- * перемножаются с внутренним ретраем SDK, классификация/отмена работают.
+ * Integration tests for wiring the retry policy into an executor (#27):
+ * the policy is actually invoked for executor operations, attempts do not
+ * multiply with the SDK's internal retry, and classification/cancellation work.
  */
 
 function ydbErr(code: number): YDBError {
@@ -29,7 +29,7 @@ function recordingSleep(): { sleep: YdbRetrySleepFn; delays: number[] } {
   return { sleep, delays };
 }
 
-/** Простой фейковый запрос: без событий SDK, поведение задаётся тестом. */
+/** Simple fake query: no SDK events, behavior is set by the test. */
 interface FakeQueryState {
   signals: Array<AbortSignal | undefined>;
   paramsList: Array<Record<string, unknown>>;
@@ -86,8 +86,8 @@ function makeSimpleFlakyExecutor(
   return executor;
 }
 
-describe("withRetryPolicy(): политика вызывается через операции executor'а", () => {
-  it('выключенная политика возвращает executor как есть (#98 не меняется)', () => {
+describe('withRetryPolicy(): policy invoked via executor operations', () => {
+  it('disabled policy returns executor as-is (#98 unchanged)', () => {
     const base = makeSimpleFlakyExecutor(['ok'], {
       signals: [],
       paramsList: [],
@@ -96,10 +96,10 @@ describe("withRetryPolicy(): политика вызывается через о
     expect(withRetryPolicy(base, undefined)).toBe(base);
   });
 
-  it('транзитные ошибки ретраятся: три исполнения, параметры воспроизводятся', async () => {
+  it('transient errors retried: three executions, parameters reproduced', async () => {
     const { sleep, delays } = recordingSleep();
     const state: FakeQueryState = { signals: [], paramsList: [] };
-    // fail, fail, ok — и далее ok (на случай лишних попыток)
+    // fail, fail, ok — and then ok (in case of excess attempts)
     const base = makeSimpleFlakyExecutor(
       ['fail-aborted', 'fail-aborted', 'ok'],
       state,
@@ -116,15 +116,15 @@ describe("withRetryPolicy(): политика вызывается через о
 
     expect(rows).toEqual([[{ id: 'x' }]]);
     expect(state.paramsList).toHaveLength(3);
-    // Параметры билдера воспроизводятся на каждой попытке политики:
+    // Builder parameters are reproduced on each policy attempt:
     for (const params of state.paramsList) {
       expect(params).toEqual({ ':p1': 'v1' });
     }
-    // Задержки политики: 100 -> 200 (дефолты, jitter выключен).
+    // Policy delays: 100 -> 200 (defaults, jitter disabled).
     expect(delays).toEqual([100, 200]);
   });
 
-  it('детерминированная ошибка не ретрается — одно исполнение', async () => {
+  it('deterministic error not retried — single execution', async () => {
     const { sleep } = recordingSleep();
     const boom = ydbErr(Code.BAD_REQUEST);
     let calls = 0;
@@ -158,14 +158,14 @@ describe("withRetryPolicy(): политика вызывается через о
     expect(calls).toBe(1);
   });
 
-  it('исчерпание maxAttempts: ровно N исполнений, последняя ошибка как есть', async () => {
+  it('maxAttempts exhaustion: exactly N executions, last error as-is', async () => {
     const { sleep } = recordingSleep();
     const state: FakeQueryState = { signals: [], paramsList: [] };
     const base = makeSimpleFlakyExecutor(['fail-aborted'], state);
 
     const last = new Error('last');
-    // Подменить последнюю ошибку нельзя (скрипт всегда abort) — проверяем
-    // число исполнений: ровно maxAttempts, без умножения.
+    // The last error cannot be swapped out (the script always aborts) — we
+    // check the execution count: exactly maxAttempts, without multiplication.
     await expect(
       withRetryPolicy(base, { maxAttempts: 4, sleep })`SELECT 1`.idempotent(
         true,
@@ -176,7 +176,7 @@ describe("withRetryPolicy(): политика вызывается через о
   });
 });
 
-describe('withRetryPolicy(): отмена и сигналы попытки', () => {
+describe('withRetryPolicy(): cancellation and attempt signals', () => {
   function honoringSleep(): { sleep: YdbRetrySleepFn } {
     const sleep: YdbRetrySleepFn = (_ms, signal) => {
       if (signal?.aborted) {
@@ -190,7 +190,7 @@ describe('withRetryPolicy(): отмена и сигналы попытки', () 
     return { sleep };
   }
 
-  it('сигнал пользователя доходит до каждой попытки запроса', async () => {
+  it('user signal reaches every query attempt', async () => {
     const { sleep } = honoringSleep();
     const controller = new AbortController();
     const state: FakeQueryState = { signals: [], paramsList: [] };
@@ -199,13 +199,13 @@ describe('withRetryPolicy(): отмена и сигналы попытки', () 
 
     await wrapped`SELECT 1`.signal(controller.signal);
 
-    // Единственная попытка получила связанный сигнал попытки политики:
+    // The single attempt received the policy's linked per-attempt signal:
     expect(state.signals).toHaveLength(1);
     expect(state.signals[0]).toBeInstanceOf(AbortSignal);
     expect(controller.signal.aborted).toBe(false);
   });
 
-  it('отмена во время backoff останавливает операцию с причиной отмены', async () => {
+  it('cancellation during backoff stops operation with cancellation reason', async () => {
     const { sleep } = honoringSleep();
     const controller = new AbortController();
     const state: FakeQueryState = { signals: [], paramsList: [] };
@@ -230,11 +230,11 @@ describe('withRetryPolicy(): отмена и сигналы попытки', () 
       message: 'stop-after-first-attempt',
     });
     void pendingReject;
-    // Ровно одна попытка БД: отмена запретила вторую.
+    // Exactly one DB attempt: cancellation blocked the second.
     expect(state.signals).toHaveLength(1);
   });
 
-  it('уже отменённый сигнал политики — ни одного обращения к БД', async () => {
+  it('already aborted policy signal — zero DB calls', async () => {
     const { sleep } = recordingSleep();
     const controller = new AbortController();
     controller.abort(new Error('cancelled'));
@@ -252,11 +252,12 @@ describe('withRetryPolicy(): отмена и сигналы попытки', () 
   });
 });
 
-describe('withRetryPolicy(): гашение внутреннего ретрая SDK (событие retry)', () => {
+describe('withRetryPolicy(): silencing SDK internal retry (retry event)', () => {
   /**
-   * Имитация SDK-запроса (@ydbjs/query): внутренний цикл хочет повторять
-   * транзитную ошибку бесконечно; событие 'retry' эмитится после задержки,
-   * следующая попытка начинается с throwIfAborted на сигнале запроса.
+   * Imitates an SDK query (@ydbjs/query): the internal loop wants to retry
+   * a transient error forever; the 'retry' event fires after the delay,
+   * and the next attempt starts with a throwIfAborted check on the query
+   * signal.
    */
   function makeSdkLikeExecutor(options: {
     failuresBeforeSuccess: number;
@@ -299,11 +300,11 @@ describe('withRetryPolicy(): гашение внутреннего ретрая 
                 failureCount += 1;
                 options.executions.push(failureCount);
                 const boom = ydbErr(Code.ABORTED);
-                // SDK-стратегия решает повторить: событие после задержки.
+                // SDK strategy decides to retry: event after the delay.
                 for (const listener of listeners) {
                   listener({ attempt: failureCount, error: boom });
                 }
-                // Политика отменила сигнал — следующей попытки не будет:
+                // The policy cancelled the signal — no next attempt:
                 if (signal?.aborted) {
                   const abortError = new Error('The operation was aborted');
                   abortError.name = 'AbortError';
@@ -322,7 +323,7 @@ describe('withRetryPolicy(): гашение внутреннего ретрая 
     return executor;
   }
 
-  it('одна попытка политики = одна попытка SDK: попытки НЕ перемножаются', async () => {
+  it('one policy attempt = one SDK attempt: attempts do NOT multiply', async () => {
     const { sleep } = recordingSleep();
     const executions: number[] = [];
     const base = makeSdkLikeExecutor({
@@ -339,13 +340,13 @@ describe('withRetryPolicy(): гашение внутреннего ретрая 
     await expect(wrapped`SELECT 1`.idempotent(true)).resolves.toEqual([
       [{ done: true }],
     ]);
-    // Две транзитные неудачи + успех = РОВНО 3 обращения к БД. Внутренний
-    // цикл SDK (неограниченный бюджет) погашен политикой: без гашения
-    // каждая попытка политики уходила бы в бесконечный цикл SDK.
+    // Two transient failures + success = EXACTLY 3 DB calls. The SDK's
+    // internal loop (unbounded budget) is silenced by the policy: without
+    // silencing, each policy attempt would spin in the SDK's infinite loop.
     expect(executions).toEqual([1, 2, 3]);
   });
 
-  it('исходная ошибка доходит до политики, а не AbortError от отмены', async () => {
+  it('original error reaches policy, not AbortError from cancellation', async () => {
     const { sleep } = recordingSleep();
     const executions: number[] = [];
     const base = makeSdkLikeExecutor({ failuresBeforeSuccess: 1, executions });
@@ -363,14 +364,14 @@ describe('withRetryPolicy(): гашение внутреннего ретрая 
     await expect(wrapped`SELECT 1`.idempotent(true)).resolves.toEqual([
       [{ done: true }],
     ]);
-    // Политика увидела именно YDBError ABORTED, а не AbortError подмены:
+    // The policy saw exactly the YDBError ABORTED, not a substituted AbortError:
     expect(seenErrors).toHaveLength(1);
     expect(seenErrors[0]).toBeInstanceOf(YDBError);
   });
 });
 
-describe('withRetryPolicy(): transaction() пробрасывается как есть', () => {
-  it('хэндл транзакции не оборачивается политикой', async () => {
+describe('withRetryPolicy(): transaction() passed through as-is', () => {
+  it('transaction handle not wrapped by policy', async () => {
     const openedOptions: YdbTransactionOptions[] = [];
     const handle: YdbTransactionHandle = {
       execute: async (fn) =>
@@ -396,13 +397,13 @@ describe('withRetryPolicy(): transaction() пробрасывается как �
   });
 });
 
-describe('withRetryPolicy(): правило идемпотентности (#27, fail-safe)', () => {
+describe('withRetryPolicy(): idempotency rule (#27, fail-safe)', () => {
   /**
-   * SDK-подобный запрос с внутренним «бесконечным» циклом повтора
-   * (как @ydbjs/query): всегда-повторяемые статусы ретраются независимо
-   * от пометки idempotent, событие 'retry' эмитится после каждой неудачи,
-   * следующая попытка выполняется только при живом сигнале.
-   * realExecutions — счётчик РЕАЛЬНЫХ обращений к БД.
+   * SDK-like query with an internal "infinite" retry loop (like
+   * @ydbjs/query): always-retried statuses retry regardless of the
+   * idempotent flag, the 'retry' event fires after each failure, and the
+   * next attempt runs only while the signal is live.
+   * realExecutions — counter of REAL DB calls.
    */
   function makeSdkLikeExecutor(options: {
     failuresBeforeSuccess: number;
@@ -459,7 +460,7 @@ describe('withRetryPolicy(): правило идемпотентности (#27,
                 for (const listener of listeners) {
                   listener({ attempt: failures, error: boom });
                 }
-                // Политика погасила внутренний цикл — следующей попытки нет:
+                // The policy silenced the internal loop — no next attempt:
                 if (signal?.aborted) {
                   const abortError = new Error('The operation was aborted');
                   abortError.name = 'AbortError';
@@ -480,7 +481,7 @@ describe('withRetryPolicy(): правило идемпотентности (#27,
 
   const TRANSIENT = [Code.ABORTED, Code.UNAVAILABLE, Code.OVERLOADED];
 
-  it('(1) непомеченный запрос + транзитная ошибка → ровно одна попытка БД', async () => {
+  it('(1) unmarked query + transient error → exactly one DB attempt', async () => {
     const { sleep } = recordingSleep();
     const realExecutions: number[] = [];
     const base = makeSdkLikeExecutor({
@@ -499,12 +500,12 @@ describe('withRetryPolicy(): правило идемпотентности (#27,
     await expect(wrapped`UPSERT users SET ...`).rejects.toBeInstanceOf(
       YDBError,
     );
-    // Внутренний цикл SDK хочет повторять бесконечно — политика гасит его:
-    // РОВНО одно обращение к БД, повтор записи невозможен.
+    // The SDK's internal loop wants to retry forever — the policy silences
+    // it: EXACTLY one DB call, a write retry is impossible.
     expect(realExecutions).toHaveLength(1);
   });
 
-  it('(2) помеченный idempotent запрос ретраится до maxAttempts', async () => {
+  it('(2) idempotent-marked query retried up to maxAttempts', async () => {
     const { sleep } = recordingSleep();
     const realExecutions: number[] = [];
     const marks: boolean[] = [];
@@ -525,11 +526,11 @@ describe('withRetryPolicy(): правило идемпотентности (#27,
       wrapped`SELECT * FROM users`.idempotent(true),
     ).resolves.toEqual([[{ done: true }]]);
     expect(realExecutions).toEqual([1, 2, 3]);
-    // Пометка проброшена в SDK-запрос на каждой попытке:
+    // The flag is forwarded to the SDK query on each attempt:
     expect(marks).toEqual([true, true, true]);
   });
 
-  it('(3) непомеченная запись не ретраится ни при одном из транзитных статусов', async () => {
+  it('(3) unmarked write not retried for any transient status', async () => {
     for (const code of TRANSIENT) {
       const { sleep } = recordingSleep();
       const realExecutions: number[] = [];
@@ -546,7 +547,7 @@ describe('withRetryPolicy(): правило идемпотентности (#27,
     }
   });
 
-  it('(4) помеченный запрос ретрается при каждом из транзитных статусов', async () => {
+  it('(4) marked query retried for each transient status', async () => {
     for (const code of TRANSIENT) {
       const { sleep } = recordingSleep();
       const realExecutions: number[] = [];
@@ -565,8 +566,8 @@ describe('withRetryPolicy(): правило идемпотентности (#27,
     }
   });
 
-  it('(5) попытки политики и SDK не перемножаются в обе стороны', async () => {
-    // a) непомеченный: один реальный вызов при «вечном» желании SDK повторять.
+  it('(5) policy and SDK attempts do not multiply in either direction', async () => {
+    // a) unmarked: one real call despite the SDK's "eternal" wish to retry.
     {
       const { sleep } = recordingSleep();
       const realExecutions: number[] = [];
@@ -581,7 +582,7 @@ describe('withRetryPolicy(): правило идемпотентности (#27,
       ).rejects.toBeInstanceOf(YDBError);
       expect(realExecutions).toHaveLength(1);
     }
-    // b) помеченный: исчерпание ровно на maxAttempts, без лишних попыток SDK.
+    // b) marked: exhausts exactly at maxAttempts, without extra SDK attempts.
     {
       const { sleep } = recordingSleep();
       const realExecutions: number[] = [];
@@ -604,7 +605,7 @@ describe('withRetryPolicy(): правило идемпотентности (#27,
     }
   });
 
-  it('.idempotent(false)/без пометки — одно исполнение; пометка доходит до SDK', async () => {
+  it('.idempotent(false)/no mark — single execution; mark reaches SDK', async () => {
     const { sleep } = recordingSleep();
     const marks: boolean[] = [];
     const realExecutions: number[] = [];
@@ -622,7 +623,7 @@ describe('withRetryPolicy(): правило идемпотентности (#27,
     ).rejects.toBeInstanceOf(YDBError);
     expect(realExecutions).toHaveLength(1);
 
-    // Успешный помеченный запрос: флаг дошёл до SDK-запроса.
+    // Successful marked query: the flag reached the SDK query.
     const okBase = makeSdkLikeExecutor({
       failuresBeforeSuccess: 0,
       statusCodes: TRANSIENT,

--- a/src/core/retry-executor.ts
+++ b/src/core/retry-executor.ts
@@ -19,25 +19,25 @@ import {
 } from '../transaction/transaction-context.js';
 
 /**
- * Подключение retry-политики к executor'у (#27).
+ * Wire-up of the retry policy to the executor (#27).
  *
- * Приоритет слоёв повтора (детерминированный):
- * - политика выключена — одиночные запросы ретраит только внутренний
- *   цикл SDK (@ydbjs/query), как в #98;
- * - политика включена — владение ретраями ПЕРЕХОДИТ к ORM: на каждую
- *   попытку политики приходится ровно одна попытка SDK. Внутренний цикл
- *   SDK гасится через событие `retry` запроса: ORM отменяет сигнал
- *   попытки, SDK не выполняет следующую попытку, а исходная ошибка
- *   забирается из контекста события и классифицируется политикой.
- *   Максимум обращений к БД равен maxAttempts — умножения попыток нет.
+ * Deterministic retry layering:
+ * - policy disabled — single queries are retried only by the SDK inner loop
+ *   (@ydbjs/query), as in #98;
+ * - policy enabled — retry ownership PASSES to the ORM: each policy attempt
+ *   accounts for exactly one SDK attempt. The SDK inner loop is suppressed
+ *   via the query's `retry` event: the ORM aborts the attempt signal, the SDK
+ *   does not run the next attempt, and the original error is taken from the
+ *   event context and classified by the policy. The maximum number of DB
+ *   calls equals maxAttempts — attempts do not multiply.
  */
 
-/** Ошибка вида AbortError (отмена), в отличие от прикладных ошибок. */
+/** AbortError-like error (cancellation), as opposed to application errors. */
 function isAbortLike(error: unknown): boolean {
   return error instanceof Error && error.name === 'AbortError';
 }
 
-/** Объединяет сигналы отмены (undefined-ы отбрасываются). */
+/** Combines abort signals (undefined values are dropped). */
 function combineSignals(
   signals: Array<AbortSignal | undefined>,
 ): AbortSignal | undefined {
@@ -65,28 +65,27 @@ function policyToOptions(
 }
 
 /**
- * Создаёт прокси-запрос под политикой: операции билдера запоминаются и
- * воспроизводятся на КАЖДОЙ попытке политики (у SDK-запроса результат
- * выполнения кешируется в инстансе — переиспользовать его нельзя).
+ * Creates a policy-backed query proxy: builder operations are remembered and
+ * replayed on EVERY policy attempt (an SDK query instance caches its
+ * execution result — it cannot be reused).
  *
- * Прокси владеет ОДНИМ общим исполнением операции (#172): первый же
- * `.then()`/await создаёт промис исполнения и кеширует его; повторные
- * подписки того же запроса цепляются за тот же промис и НЕ вызывают
- * `makeBase()` повторно. Это касается и непомеченных (fail-safe)
- * запросов — дублирования обращения к БД из-за двух await нет.
+ * The proxy owns ONE shared execution of the operation (#172): the first
+ * `.then()`/await creates the execution promise and caches it; subsequent
+ * subscriptions of the same query attach to the same promise and do not call
+ * `makeBase()` again. This also applies to unmarked (fail-safe) queries —
+ * two awaits do not duplicate the DB call.
  *
- * Отмена (.cancel()) — тоже на уровне прокси (#172): общий AbortController
- * собирается в сигнал операции (вместе с пользовательским и политики) и
- * используется И для попыток SDK, И для backoff политики. Поэтому cancel()
- * полностью останавливает операцию: отменяет летящую попытку, прерывает
- * ожидание задержки и запрещает новые попытки.
+ * Cancellation (.cancel()) is also at the proxy level (#172): a shared
+ * AbortController is combined into the operation signal (together with the
+ * user's and the policy's) and is used BOTH for SDK attempts AND for the
+ * policy backoff. Therefore cancel() fully stops the operation: it aborts an
+ * in-flight attempt, interrupts the delay wait and forbids new attempts.
  *
- * Правило безопасности (#27): повторять можно ТОЛЬКО запрос, явно
- * помеченный идемпотентным (`.idempotent(true)` / `{ idempotent: true }`).
- * Непомеченный запрос выполняется РОВНО ОДИН раз даже при включённой
- * политике: у SDK внутренний цикл тоже гасится, чтобы двусмысленный
- * сбой транспорта не привёл к повтору записи. SDK-запросу пометка
- * пробрасывается как `.idempotent(true)`.
+ * Safety rule (#27): only a query explicitly marked idempotent
+ * (`.idempotent(true)` / `{ idempotent: true }`) may be retried. An unmarked
+ * query runs EXACTLY ONCE even with the policy enabled: its SDK inner loop is
+ * also suppressed so an ambiguous transport failure cannot duplicate a write.
+ * The marker is forwarded to the SDK query as `.idempotent(true)`.
  */
 function createPolicyQuery(
   makeBase: () => YdbQuery,
@@ -95,28 +94,30 @@ function createPolicyQuery(
   const params: Array<[string, unknown]> = [];
   let timeoutMs: number | undefined;
   let userSignal: AbortSignal | undefined;
-  // undefined = пользователь не вызывал .idempotent() — считаем НЕ
-  // идемпотентным (fail-safe); true = помечен; false = помечен явно.
+  // undefined = the user did not call .idempotent() — we treat the query as
+  // NON-idempotent (fail-safe); true = marked; false = explicitly unmarked.
   let markedIdempotent: boolean | undefined;
   let current: YdbQuery | undefined;
 
-  // Общий сигнал отмены прокси (#172): cancel() абортит его — он отменяет
-  // и текущую попытку SDK (сигнал доходит до запроса через combineSignals),
-  // и backoff политики (signal в runWithRetry), и запрещает новые попытки.
+  // Shared proxy cancellation signal (#172): cancel() aborts it — it cancels
+  // the in-flight SDK attempt (the signal reaches the query via
+  // combineSignals), the policy backoff (signal in runWithRetry), and
+  // forbids new attempts.
   const controller = new AbortController();
   const cancelError: Error = new Error('The operation was aborted');
   cancelError.name = 'AbortError';
 
-  // Единственное исполнение операции на весь прокси-запрос (#172):
-  // два .then()/await на одном запросе НЕ дублируют обращение к БД.
+  // Single execution of the operation for the whole proxy query (#172):
+  // two .then()/awaits on one query do not duplicate the DB call.
   let settled: Promise<unknown> | undefined;
-  // Флаг: исполнение начато (первый .then()/await).
-  // После этого мутирующие методы билдера запрещены.
+  // Flag: execution has started (the first .then()/await).
+  // After that the mutating builder methods are forbidden.
   let started = false;
 
   const runOnce = async (policySignal?: AbortSignal): Promise<unknown> => {
-    // Отмена до старта (cancel() до первого await) — ни одного обращения
-    // к БД (#172); для помеченных запросов дублирует проверку runWithRetry.
+    // Cancellation before start (cancel() before the first await) — no DB
+    // call at all (#172); for marked queries it duplicates the runWithRetry
+    // check.
     if (policySignal?.aborted) throw abortReasonToError(policySignal.reason);
 
     const query = makeBase();
@@ -125,11 +126,11 @@ function createPolicyQuery(
     if (timeoutMs !== undefined) query.timeout(timeoutMs);
     if (markedIdempotent === true) query.idempotent?.(true);
 
-    // Гашение внутреннего ретрая SDK: после первой неудачи SDK хочет
-    // повторить (событие 'retry' после своей задержки) — отменяем сигнал
-    // попытки, SDK бросает AbortError ДО следующего обращения к БД, а мы
-    // подменяем его исходной ошибкой из контекста события. Для
-    // непомеченного запроса это даёт строго однократное исполнение.
+    // Suppress the SDK inner retry: after its first failure the SDK wants to
+    // retry (the 'retry' event fires after its own delay) — we abort the
+    // attempt signal, the SDK throws AbortError BEFORE the next DB call, and
+    // we replace it with the original error from the event context. For
+    // unmarked queries this guarantees strictly-once execution.
     const attemptController = new AbortController();
     let captured = false;
     let capturedError: unknown;
@@ -194,15 +195,15 @@ function createPolicyQuery(
       return proxy;
     },
     cancel(): YdbQuery {
-      // Текущая попытка SDK + весь жизненный цикл операции.
+      // Cancel the in-flight SDK attempt plus the whole operation lifecycle.
       current?.cancel();
       controller.abort(cancelError);
       return proxy;
     },
     then(onFulfilled?, onRejected?) {
-      // Первый подписчик создаёт и кеширует общее исполнение операции
-      // (#172); последующие подписки цепляются за тот же промис и не
-      // трогают БД повторно.
+      // The first subscriber creates and caches the shared operation execution
+      // (#172); subsequent subscriptions attach to the same promise and do not
+      // touch the DB again.
       if (settled === undefined) {
         started = true;
         const operationSignal = combineSignals([
@@ -215,14 +216,14 @@ function createPolicyQuery(
           signal: operationSignal,
         };
 
-        // Fail-safe (#27): без явной пометки идемпотентности политика НЕ
-        // применяется — ровно одна попытка БД.
+        // Fail-safe (#27): without an explicit idempotency marker the policy
+        // is NOT applied — exactly one DB attempt.
         settled =
           markedIdempotent === true
             ? runWithRetry(runOnce, options)
             : Promise.resolve().then(() => runOnce(operationSignal));
-        // Кешированное отклонение не должно стать unhandled rejection,
-        // пока у операции нет подписчиков (#172).
+        // A cached rejection must not become an unhandled rejection while the
+        // operation has no subscribers (#172).
         settled.catch(() => {});
       }
       return settled.then(onFulfilled, onRejected);
@@ -232,24 +233,24 @@ function createPolicyQuery(
 }
 
 /**
- * Подключает retry-политику (#27) к executor'у: каждый запрос через
- * возвращённый executor выполняется под политикой (классификация по
- * статусам ABORTED/UNAVAILABLE/OVERLOADED, bounded backoff + jitter,
- * отмена сигналом). `transaction()` пробрасывается как есть — повторами
- * тела транзакции управляет опция `retry` в runInTransaction().
+ * Attaches the retry policy (#27) to an executor: every query through the
+ * returned executor runs under the policy (classification by statuses
+ * ABORTED/UNAVAILABLE/OVERLOADED, bounded backoff + jitter, signal-based
+ * cancellation). `transaction()` is passed through as is — retries of the
+ * transaction body are governed by the `retry` option in runInTransaction().
  *
- * ПРАВИЛО ИДЕМПОТЕНТНОСТИ (#27, fail-safe): политика ретраит только
- * запросы, ЯВНО помеченные идемпотентными — `.idempotent(true)` на цепочке
- * или `{ idempotent: true }` в QueryOptions. Непомеченный запрос (в т.ч.
- * любой INSERT/UPSERT/UPDATE/DELETE по умолчанию) выполняется РОВНО ОДИН
- * раз даже при включённой политике: внутренний цикл SDK для него тоже
- * гасится, чтобы двусмысленный сбой транспорта не продублировал запись.
- * Повторять можно только операции, устойчивые к повтору.
+ * IDEMPOTENCY RULE (#27, fail-safe): the policy retries only queries
+ * EXPLICITLY marked idempotent — `.idempotent(true)` on the chain or
+ * `{ idempotent: true }` in QueryOptions. An unmarked query (including any
+ * INSERT/UPSERT/UPDATE/DELETE by default) runs EXACTLY ONCE even with the
+ * policy enabled: its SDK inner loop is also suppressed, so an ambiguous
+ * transport failure cannot duplicate a write. Only retry-tolerant operations
+ * may be retried.
  *
- * Выключенная политика (`false`/`undefined`) возвращает executor без
- * изменений — поведение идентично #98.
+ * A disabled policy (`false`/`undefined`) returns the executor unchanged —
+ * behavior identical to #98.
  *
- * Оборачивайте ОДИН раз; вложение нескольких политик перемножит попытки.
+ * Wrap ONCE; nesting several policies would multiply attempts.
  */
 export function withRetryPolicy(
   executor: YdbExecutor,
@@ -275,9 +276,9 @@ export function withRetryPolicy(
     options?: YdbTransactionOptions,
   ) => executor.transaction(options);
 
-  // Identity (#207): обёртка наследует identity-токен исходника (см. также
-  // wrapExecutorWithLogging), чтобы разные обёртки одного логического
-  // executor'а распознавались как один DB-контекст.
+  // Identity (#207): the wrapper inherits the identity token of its source
+  // (see also wrapExecutorWithLogging), so different wrappers of one logical
+  // executor are recognized as one DB context.
   ensureExecutorIdentity(executor);
   inheritExecutorIdentity(executor, wrapped);
 

--- a/src/core/retry.spec.ts
+++ b/src/core/retry.spec.ts
@@ -14,19 +14,19 @@ import type { YdbRetrySleepFn } from './retry.js';
 import type { YdbExecutor } from '../core/interfaces.js';
 
 /**
- * Юнит-тесты retry-политики по типу ошибки (#27): классификация строго по
- * структурным статусам YDB, ограничение попыток, bounded exponential
- * backoff + jitter, отмена через AbortSignal и отсутствие скрытого
- * ретрая вокруг транзакций (#98). Все задержки инъецируются — реальных
- * снов нет, тесты детерминированы.
+ * Unit tests for the error-type-driven retry policy (#27): classification
+ * strictly by YDB structural status codes, attempt limiting, bounded
+ * exponential backoff + jitter, cancellation via AbortSignal, and the
+ * absence of hidden retry around transactions (#98). All delays are
+ * injected — no real sleeping, so the tests are deterministic.
  */
 
-/** YDB-ошибка с заданным статус-кодом (структурная классификация). */
+/** A YDB error with the given status code (structural classification). */
 function ydbErr(code: number): YDBError {
   return new YDBError(code, []);
 }
 
-/** Записывающая задержка: вместо сна копит вычисленные задержки. */
+/** Recording sleep: instead of sleeping, accumulates the computed delays. */
 function recordingSleep(): { sleep: YdbRetrySleepFn; delays: number[] } {
   const delays: number[] = [];
   const sleep: YdbRetrySleepFn = (ms) => {
@@ -36,14 +36,14 @@ function recordingSleep(): { sleep: YdbRetrySleepFn; delays: number[] } {
   return { sleep, delays };
 }
 
-/** Детерминированный rng: отдаёт значения из очереди по кругу. */
+/** Deterministic rng: yields values from the queue cyclically. */
 function seqRng(values: number[]) {
   let i = 0;
   return () => values[i++ % values.length];
 }
 
-describe('classifyYdbError(): классификация по статус-кодам (#27)', () => {
-  it('только ABORTED/UNAVAILABLE/OVERLOADED — transient', () => {
+describe('classifyYdbError(): classification by status codes (#27)', () => {
+  it('only ABORTED/UNAVAILABLE/OVERLOADED are transient', () => {
     expect([...TRANSIENT_YDB_STATUSES].sort((a, b) => a - b)).toEqual(
       [Code.ABORTED, Code.UNAVAILABLE, Code.OVERLOADED].sort((a, b) => a - b),
     );
@@ -53,18 +53,18 @@ describe('classifyYdbError(): классификация по статус-ко�
     expect(isTransientYdbError(ydbErr(Code.OVERLOADED))).toBe(true);
   });
 
-  it('статусы, которые SDK ретраит, политикой НЕ ретраются (политика строже)', () => {
-    // BAD_SESSION/SESSION_BUSY SDK всегда повторяет внутри себя — ORM-политика
-    // не должна дублировать это; иначе попытки перемножаются.
+  it('statuses that the SDK retries are NOT retried by the policy (policy is stricter)', () => {
+    // BAD_SESSION/SESSION_BUSY the SDK always retries internally — the ORM
+    // policy must not duplicate that; otherwise attempts multiply.
     expect(classifyYdbError(ydbErr(Code.BAD_SESSION))).toBe('fatal');
     expect(classifyYdbError(ydbErr(Code.SESSION_BUSY))).toBe('fatal');
-    // Условно-retryable у SDK — для политики fatal:
+    // Conditionally retryable in the SDK — fatal for the policy:
     expect(classifyYdbError(ydbErr(Code.SESSION_EXPIRED))).toBe('fatal');
     expect(classifyYdbError(ydbErr(Code.UNDETERMINED))).toBe('fatal');
     expect(classifyYdbError(ydbErr(Code.TIMEOUT))).toBe('fatal');
   });
 
-  it('детерминированные ошибки приложения/схемы/запроса — fatal', () => {
+  it('deterministic application/schema/query errors are fatal', () => {
     const deterministic = [
       Code.BAD_REQUEST,
       Code.UNAUTHORIZED,
@@ -83,7 +83,7 @@ describe('classifyYdbError(): классификация по статус-ко�
     }
   });
 
-  it('CommitError раскрывается в причину (структурно, без текста)', () => {
+  it('CommitError is unwrapped to the cause (structurally, without text)', () => {
     expect(
       classifyYdbError(new CommitError('commit failed', ydbErr(Code.ABORTED))),
     ).toBe('transient');
@@ -95,7 +95,7 @@ describe('classifyYdbError(): классификация по статус-ко�
     expect(classifyYdbError(new CommitError('commit failed'))).toBe('fatal');
   });
 
-  it('всё не-YDB (прикладные ошибки, отмены) — fatal', () => {
+  it('everything non-YDB (application errors, cancellations) is fatal', () => {
     const named = (name: string): Error =>
       Object.assign(new Error(name), { name });
 
@@ -111,7 +111,7 @@ describe('classifyYdbError(): классификация по статус-ко�
 });
 
 describe('computeRetryDelayMs(): bounded exponential backoff + jitter', () => {
-  it('экспоненциальный рост без jitter: base, 2*base, 4*base...', () => {
+  it('exponential growth without jitter: base, 2*base, 4*base...', () => {
     const opts = { baseDelayMs: 100, maxDelayMs: 10_000, jitterRatio: 0 };
     expect(computeRetryDelayMs(1, opts, seqRng([0]))).toBe(100);
     expect(computeRetryDelayMs(2, opts, seqRng([0]))).toBe(200);
@@ -119,7 +119,7 @@ describe('computeRetryDelayMs(): bounded exponential backoff + jitter', () => {
     expect(computeRetryDelayMs(4, opts, seqRng([0]))).toBe(800);
   });
 
-  it('рост ограничен maxDelayMs (bounded)', () => {
+  it('growth is bounded by maxDelayMs', () => {
     const opts = { baseDelayMs: 1000, maxDelayMs: 2500, jitterRatio: 0 };
     expect(computeRetryDelayMs(1, opts, seqRng([0]))).toBe(1000);
     expect(computeRetryDelayMs(2, opts, seqRng([0]))).toBe(2000);
@@ -127,14 +127,14 @@ describe('computeRetryDelayMs(): bounded exponential backoff + jitter', () => {
     expect(computeRetryDelayMs(10, opts, seqRng([0]))).toBe(2500);
   });
 
-  it('jitter сжимает задержку вниз в [(1-r)*raw, raw]', () => {
+  it('jitter compresses delay down to [(1-r)*raw, raw]', () => {
     const opts = { baseDelayMs: 200, maxDelayMs: 10_000, jitterRatio: 0.5 };
-    expect(computeRetryDelayMs(1, opts, seqRng([0]))).toBe(100); // нижняя граница
-    expect(computeRetryDelayMs(1, opts, seqRng([0.999999]))).toBe(200); // верхняя
+    expect(computeRetryDelayMs(1, opts, seqRng([0]))).toBe(100); // lower bound
+    expect(computeRetryDelayMs(1, opts, seqRng([0.999999]))).toBe(200); // upper bound
     expect(computeRetryDelayMs(1, opts, seqRng([0.5]))).toBe(150);
   });
 
-  it('jitter никогда не превышает raw и maxDelayMs', () => {
+  it('jitter never exceeds raw and maxDelayMs', () => {
     const opts = { baseDelayMs: 100, maxDelayMs: 300, jitterRatio: 1 };
     for (let attempt = 1; attempt <= 12; attempt += 1) {
       const delay = computeRetryDelayMs(attempt, opts, seqRng([0.99]));
@@ -144,15 +144,15 @@ describe('computeRetryDelayMs(): bounded exponential backoff + jitter', () => {
     }
   });
 
-  it('без опций используются дефолты политики', () => {
-    // Дефолты: base 100, jitterRatio 0.25; rng -> 0 даёт нижнюю границу
-    // коридора джиттера: round(100 * (1 - 0.25)) = 75.
+  it('defaults are used when no options provided', () => {
+    // Defaults: base 100, jitterRatio 0.25; rng -> 0 gives the lower bound of
+    // the jitter corridor: round(100 * (1 - 0.25)) = 75.
     expect(computeRetryDelayMs(1, undefined, seqRng([0]))).toBe(75);
   });
 });
 
-describe('validateYdbRetryPolicyOptions(): fail-fast валидация', () => {
-  it('undefined и корректные опции проходят', () => {
+describe('validateYdbRetryPolicyOptions(): fail-fast validation', () => {
+  it('undefined and valid options pass', () => {
     expect(() => validateYdbRetryPolicyOptions(undefined)).not.toThrow();
     const signal = new AbortController().signal;
     expect(() =>
@@ -170,7 +170,7 @@ describe('validateYdbRetryPolicyOptions(): fail-fast валидация', () => 
     ).not.toThrow();
   });
 
-  it('невалидные значения отклоняются сразу', async () => {
+  it('invalid values are rejected immediately', async () => {
     expect(() => validateYdbRetryPolicyOptions(null as never)).toThrow();
     expect(() => validateYdbRetryPolicyOptions(42 as never)).toThrow();
     expect(() => validateYdbRetryPolicyOptions({ maxAttempts: 0 })).toThrow(
@@ -203,15 +203,15 @@ describe('validateYdbRetryPolicyOptions(): fail-fast валидация', () => 
     expect(() =>
       validateYdbRetryPolicyOptions({ onRetry: 'nope' as never }),
     ).toThrow(/onRetry/);
-    // runWithRetry валидирует опции до первой попытки:
+    // runWithRetry validates options before the first attempt:
     await expect(
       runWithRetry(() => Promise.resolve(1), { maxAttempts: 0 }),
     ).rejects.toThrow(/maxAttempts/);
   });
 });
 
-describe('runWithRetry(): повторы только транзитных ошибок (#27)', () => {
-  it('успех с первой попытки — fn вызвана один раз', async () => {
+describe('runWithRetry(): retries only transient errors (#27)', () => {
+  it('success on first attempt — fn called once', async () => {
     const { sleep, delays } = recordingSleep();
     const fn = jest.fn(() => Promise.resolve('ok'));
 
@@ -220,7 +220,7 @@ describe('runWithRetry(): повторы только транзитных ош�
     expect(delays).toEqual([]);
   });
 
-  it('транзитная ошибка, затем успех — ровно один повтор', async () => {
+  it('transient error then success — exactly one retry', async () => {
     const { sleep, delays } = recordingSleep();
     const boom = ydbErr(Code.ABORTED);
     let calls = 0;
@@ -233,11 +233,11 @@ describe('runWithRetry(): повторы только транзитных ош�
       runWithRetry(fn, { sleep, jitterRatio: 0, rng: seqRng([0]) }),
     ).resolves.toBe('recovered');
     expect(fn).toHaveBeenCalledTimes(2);
-    // Дефолтная база 100 мс, jitter выключен явно:
+    // Default base is 100 ms, jitter explicitly disabled:
     expect(delays).toEqual([DEFAULT_YDB_RETRY_POLICY_OPTIONS.baseDelayMs]);
   });
 
-  it('детерминированная/прикладная ошибка пробрасывается немедленно', async () => {
+  it('deterministic/application error is propagated immediately', async () => {
     const { sleep, delays } = recordingSleep();
 
     for (const error of [
@@ -252,9 +252,10 @@ describe('runWithRetry(): повторы только транзитных ош�
     expect(delays).toEqual([]);
   });
 
-  it('исчерпание попыток пробрасывает ПОСЛЕДНЮЮ ошибку как есть', async () => {
+  it('exhausted attempts propagates the LAST error as-is', async () => {
     const { sleep } = recordingSleep();
-    // Все три ошибки транзитные — иначе политика остановится раньше на фатальной.
+    // All three errors are transient — otherwise the policy would stop
+    // earlier on a fatal one.
     const errors = [
       ydbErr(Code.OVERLOADED),
       ydbErr(Code.UNAVAILABLE),
@@ -269,7 +270,7 @@ describe('runWithRetry(): повторы только транзитных ош�
     expect(fn).toHaveBeenCalledTimes(3);
   });
 
-  it('maxAttempts: 1 — одна попытка без задержек даже для транзитной ошибки', async () => {
+  it('maxAttempts: 1 — one attempt without delays even for transient error', async () => {
     const { sleep, delays } = recordingSleep();
     const boom = ydbErr(Code.UNAVAILABLE);
     const fn = jest.fn(() => Promise.reject(boom));
@@ -282,8 +283,8 @@ describe('runWithRetry(): повторы только транзитных ош�
   });
 });
 
-describe('runWithRetry(): детерминированный backoff и хуки', () => {
-  it('последовательность задержек: экспонента с учётом cap и jitter', async () => {
+describe('runWithRetry(): deterministic backoff and hooks', () => {
+  it('delay sequence: exponential with cap and jitter', async () => {
     const { sleep, delays } = recordingSleep();
     const boom = ydbErr(Code.ABORTED);
     const fn = jest.fn(() => Promise.reject(boom));
@@ -299,12 +300,12 @@ describe('runWithRetry(): детерминированный backoff и хуки
       }),
     ).rejects.toBe(boom);
 
-    // Попытки 1..4, повторы после 1..3: 100 -> 200 -> 250(cap)
+    // Attempts 1..4, retries after 1..3: 100 -> 200 -> 250(cap)
     expect(fn).toHaveBeenCalledTimes(4);
     expect(delays).toEqual([100, 200, 250]);
   });
 
-  it('onRetry вызывается перед каждым повтором с контекстом попытки', async () => {
+  it('onRetry called before each retry with attempt context', async () => {
     const { sleep } = recordingSleep();
     const boom = ydbErr(Code.ABORTED);
     let calls = 0;
@@ -339,7 +340,7 @@ describe('runWithRetry(): детерминированный backoff и хуки
     });
   });
 
-  it('onRetry не вызывается при фатальной ошибке и при исчерпании', async () => {
+  it('onRetry not called on fatal error or exhaustion', async () => {
     const { sleep } = recordingSleep();
     const fatal = new Error('deterministic');
     const onRetry = jest.fn<() => void>(() => {});
@@ -359,7 +360,7 @@ describe('runWithRetry(): детерминированный backoff и хуки
     expect(onRetry).not.toHaveBeenCalled();
   });
 
-  it('кастомный shouldRetry замещает классификацию по умолчанию', async () => {
+  it('custom shouldRetry overrides default classification', async () => {
     const { sleep, delays } = recordingSleep();
     const appError = new Error('flaky infra wrapped as app error');
     let calls = 0;
@@ -377,7 +378,7 @@ describe('runWithRetry(): детерминированный backoff и хуки
     expect(fn).toHaveBeenCalledTimes(2);
     expect(delays.length).toBe(1);
 
-    // И наоборот: shouldRetry: () => false отключает повторы вовсе.
+    // And conversely: shouldRetry: () => false disables retries entirely.
     const boom = ydbErr(Code.ABORTED);
     const strictFn = jest.fn(() => Promise.reject(boom));
     await expect(
@@ -387,8 +388,8 @@ describe('runWithRetry(): детерминированный backoff и хуки
   });
 });
 
-describe('runWithRetry(): отмена через AbortSignal', () => {
-  it('уже отменённый сигнал — fn не вызывается, отклонение с причиной', async () => {
+describe('runWithRetry(): cancellation via AbortSignal', () => {
+  it('already aborted signal — fn not called, rejection with reason', async () => {
     const controller = new AbortController();
     const cancelReason = new Error('cancelled-before-start');
     controller.abort(cancelReason);
@@ -400,7 +401,7 @@ describe('runWithRetry(): отмена через AbortSignal', () => {
     expect(fn).not.toHaveBeenCalled();
   });
 
-  it('не-Error причина отмены заворачивается в Error c исходником в cause', async () => {
+  it('non-Error cancellation reason wrapped in Error with original in cause', async () => {
     const controller = new AbortController();
     controller.abort('cancelled-with-string');
     const fn = jest.fn(() => Promise.resolve('never'));
@@ -414,7 +415,7 @@ describe('runWithRetry(): отмена через AbortSignal', () => {
     expect(fn).not.toHaveBeenCalled();
   });
 
-  it('отмена во время ожидания задержки прерывает pending retry', async () => {
+  it('cancellation during backoff wait interrupts pending retry', async () => {
     const controller = new AbortController();
     const cancelReason = new Error('cancelled-mid-backoff');
     let sleepCalls = 0;
@@ -436,7 +437,7 @@ describe('runWithRetry(): отмена через AbortSignal', () => {
     expect(onRetry).not.toHaveBeenCalled();
   });
 
-  it('отмена между попытками запрещает старт следующей', async () => {
+  it('cancellation between attempts prevents next attempt start', async () => {
     const controller = new AbortController();
     const cancelReason = new Error('stopped-after-first-failure');
     const { sleep } = recordingSleep();
@@ -458,12 +459,12 @@ describe('runWithRetry(): отмена через AbortSignal', () => {
   });
 });
 
-describe('интеграция с транзакциями: без умножения попыток (#98 + #27)', () => {
+describe('transaction integration: no attempt multiplication (#98 + #27)', () => {
   interface FakeTxCall {
     options: Record<string, unknown>;
   }
 
-  /** Минимальный фейковый executor БД с управляемым поведением execute(). */
+  /** Minimal fake DB executor with controllable execute() behavior. */
   function makeFakeDb(
     executeImpl: (
       fn: any,
@@ -529,7 +530,7 @@ describe('интеграция с транзакциями: без умноже�
     return new mod.YdbTransactionManager(dbExecutor);
   }
 
-  it('runInTransaction НЕ имеет скрытого ORM-ретрая: транзитная ошибка выходит сразу', async () => {
+  it('runInTransaction has NO hidden ORM retry: transient error surfaces immediately', async () => {
     const boom = ydbErr(Code.ABORTED);
     let bodyCalls = 0;
     const db = makeFakeDb((_fn, _opts, _trx, _signal) => {
@@ -542,19 +543,19 @@ describe('интеграция с транзакциями: без умноже�
     await expect(
       manager.runInTransaction(() => Promise.resolve('x')),
     ).rejects.toBe(boom);
-    // Ровно одна попытка: ретраить тело транзакции — работа SDK (idempotent),
-    // а не скрытая политика ORM.
+    // Exactly one attempt: retrying a transaction body is the SDK's job
+    // (idempotent), not a hidden ORM policy.
     expect(bodyCalls).toBe(1);
     expect(db.transactions).toHaveLength(1);
   });
 
-  it('явная композиция: runWithRetry ПОВЕРХ idempotent-транзакции дополняет SDK-ретрай', async () => {
+  it('explicit composition: runWithRetry ON TOP of idempotent transaction complements SDK retry', async () => {
     const boom = ydbErr(Code.UNAVAILABLE);
     let sdkAttempts = 0;
 
-    // Имитация @ydbjs/query: ПЕРВАЯ попытка тела транзакции падает транзитной
-    // ошибкой, SDK-idempotent-повтор (вторая попытка ВНУТРИ execute)
-    // успешен — наружу транзитная ошибка не выходит.
+    // Imitate @ydbjs/query: the FIRST transaction body attempt fails with a
+    // transient error, the SDK-idempotent retry (second attempt INSIDE
+    // execute) succeeds — no transient error escapes to the surface.
     const db = makeFakeDb(
       async (fn: any, opts: any, trx: any, signal: AbortSignal) => {
         for (;;) {
@@ -563,7 +564,7 @@ describe('интеграция с транзакциями: без умноже�
             if (sdkAttempts === 1 && opts.idempotent) throw boom;
             return await fn(trx, signal);
           } catch (error) {
-            if (error === boom && sdkAttempts < 2) continue; // SDK ретраит сам
+            if (error === boom && sdkAttempts < 2) continue; // SDK retries itself
             throw error;
           }
         }
@@ -578,8 +579,8 @@ describe('интеграция с транзакциями: без умноже�
       }),
     );
 
-    // Внешний ретрай срабатывает нулевой раз: транзитная ошибка поглощена
-    // SDK-idempotent-повтором ВНУТРИ, политика наружу её не видит.
+    // The outer retry fires zero times: the transient error is absorbed by
+    // the SDK-idempotent retry INSIDE, so the policy never sees it.
     await expect(runWithRetry(outerFn, { maxAttempts: 3 })).resolves.toBe(
       'inner',
     );
@@ -588,7 +589,7 @@ describe('интеграция с транзакциями: без умноже�
     expect(db.transactions[0].options).toMatchObject({ idempotent: true });
   });
 
-  it('фатальная ошибка транзакции внешним ретраем не повторяется', async () => {
+  it('fatal transaction error not retried by outer retry', async () => {
     const fatal = ydbErr(Code.BAD_REQUEST);
     const db = makeFakeDb(() => Promise.reject(fatal));
     const manager = await makeManager(db.executor);

--- a/src/core/retry.ts
+++ b/src/core/retry.ts
@@ -2,27 +2,27 @@ import { CommitError, YDBError } from '@ydbjs/error';
 import { StatusIds_StatusCode } from '@ydbjs/api/operation';
 
 /**
- * Retry-политика ORM по типу ошибки (#27).
+ * ORM error-type retry policy (#27).
  *
- * SDK (@ydbjs/query) УЖЕ ретраит одиночные запросы и тело транзакции
- * (см. «Retry-семантика» в README): у него свой неограниченный по умолчанию
- * бюджет и своя классификация ошибок. Поэтому эта политика — ЯВНАЯ утилита
- * без скрытого глобального состояния: пользователь сам решает, какие
- * составные операции обернуть в runWithRetry(). Оборачивать одиночные
- * запросы и runInTransaction() не нужно и вредно — попытки SDK и ORM
- * перемножатся.
+ * The SDK (@ydbjs/query) ALREADY retries single queries and the transaction
+ * body (see "Retry semantics" in the README): it has its own by-default
+ * unlimited budget and its own error classification. This policy is therefore
+ * an EXPLICIT utility without hidden global state: the user decides which
+ * composite operations to wrap in runWithRetry(). Wrapping single queries and
+ * runInTransaction() is not needed and is harmful — SDK and ORM attempts would
+ * multiply.
  *
- * Классификация ошибок — ТОЛЬКО по структурным признакам (статус-код YDB
- * из @ydbjs/error), никогда по тексту сообщения.
+ * Error classification is based ONLY on structural features (the YDB status
+ * code from @ydbjs/error), never on the message text.
  */
 
 /**
- * Статусы YDB, которые политика считает транзитными (#27): только
- * ABORTED / UNAVAILABLE / OVERLOADED. Всё остальное — включая статусы,
- * которые SDK считает условно-retryable (SESSION_EXPIRED, UNDETERMINED,
- * TIMEOUT) и ошибки сессий (BAD_SESSION, SESSION_BUSY) — политикой ORM
- * не ретраится: это либо детерминированные ошибки, либо внутренняя
- * забота SDK-ретрая.
+ * YDB statuses the policy treats as transient (#27): only
+ * ABORTED / UNAVAILABLE / OVERLOADED. Everything else — including statuses
+ * the SDK considers conditionally-retryable (SESSION_EXPIRED, UNDETERMINED,
+ * TIMEOUT) and session errors (BAD_SESSION, SESSION_BUSY) — is not retried
+ * by the ORM policy: these are either deterministic errors or the SDK
+ * internal retry's concern.
  */
 export const TRANSIENT_YDB_STATUSES: ReadonlySet<number> = new Set([
   StatusIds_StatusCode.ABORTED,
@@ -30,88 +30,92 @@ export const TRANSIENT_YDB_STATUSES: ReadonlySet<number> = new Set([
   StatusIds_StatusCode.OVERLOADED,
 ] as const);
 
-/** Результат классификации ошибки. */
+/** Result of error classification. */
 export type YdbErrorKind = 'transient' | 'fatal';
 
-/** Сигнатура функции задержки (инъецируется в тестах). */
+/** Signature of the sleep function (injected in tests). */
 export type YdbRetrySleepFn = (
   ms: number,
   signal?: AbortSignal,
 ) => Promise<void>;
 
-/** Сигнатура генератора случайных чисел [0, 1) для jitter. */
+/** Signature of the random number generator (0..1) used for jitter. */
 export type YdbRetryRng = () => number;
 
 /**
- * Контекст попытки для хука onRetry: вызывается перед каждой повторной
- * попыткой (после отработки задержки).
+ * Attempt context passed to the onRetry hook: called before each retry
+ * (after the delay has elapsed).
  */
 export interface YdbRetryAttemptContext {
-  /** Номер НЕУДАЧНОЙ попытки (начиная с 1). */
+  /** Number of the FAILED attempt (1-based). */
   attempt: number;
-  /** Ошибка, приведшая к повтору. */
+  /** Error that caused the retry. */
   error: unknown;
-  /** Задержка перед повторной попыткой, мс. */
+  /** Delay before the retry, ms. */
   delayMs: number;
 }
 
 /**
- * Опции retry-политики (#27).
+ * Retry policy options (#27).
  *
- * Все поля опциональны; значения по умолчанию см.
- * DEFAULT_YDB_RETRY_POLICY_OPTIONS. Опции валидируются fail-fast:
- * невалидное значение — ошибка сразу, а не тихо проигнорированная опция.
+ * All fields are optional; the defaults live in DEFAULT_YDB_RETRY_POLICY_OPTIONS.
+ * Options are validated fail-fast: an invalid value is an immediate error,
+ * not a silently ignored option.
  */
 export interface YdbRetryPolicyOptions {
   /**
-   * Максимум попыток ВКЛЮЧАЯ первую (по умолчанию 3). Целое число ≥ 1.
+   * Maximum number of attempts INCLUDING the first (default 3). Integer >= 1.
    */
   maxAttempts?: number;
   /**
-   * Базовая задержка экспоненциального backoff, мс (по умолчанию 100).
-   * Попытка N (с единицы) ждёт baseDelayMs * 2^(N-1), ограничено maxDelayMs.
+   * Base exponential-backoff delay, ms (default 100). Attempt N (1-based)
+   * waits baseDelayMs * 2^(N-1), capped at maxDelayMs.
    */
   baseDelayMs?: number;
   /**
-   * Верхняя граница задержки, мс (по умолчанию 5000). Bounded backoff:
-   * рост экспоненты останавливается на этом значении.
+   * Upper delay bound, ms (default 5000). Bounded backoff: exponential
+   * growth stops at this value.
    */
   maxDelayMs?: number;
   /**
-   * Доля jitter в [0, 1] (по умолчанию 0.25): итоговая задержка равномерно
-   * распределена в [(1 - ratio) * raw, raw], где raw — задержка до jitter.
-   * 0 — отключить jitter; 1 — «полный» jitter (от 0 до raw).
+   * Jitter share in [0, 1] (default 0.25): the final delay is uniformly
+   * distributed in [(1 - ratio) * raw, raw], where raw is the delay before
+   * jitter. 0 disables jitter; 1 is "full" jitter (from 0 to raw).
    */
   jitterRatio?: number;
   /**
-   * Сигнал отмены: отменяет ожидание текущей задержки и запрещает старт
-   * новых попыток. Отмена НЕ превращается в повтор — операция завершается
-   * причиной отмены (signal.reason).
+   * Cancellation signal: aborts the current delay wait and forbids new
+   * attempts. Cancellation does NOT turn into a retry — the operation
+   * finishes with the cancellation reason (signal.reason).
    */
   signal?: AbortSignal;
   /**
-   * Хук перед каждой повторной попыткой (после задержки): логирование,
-   * метрики. Ошибки хука не глотаются — пробрасываются как есть.
+   * Hook called before each retry (after the delay): logging, metrics. Hook
+   * errors are not swallowed — they propagate as is.
    */
   onRetry?: (ctx: YdbRetryAttemptContext) => void;
   /**
-   * Кастомный предикат повторяемости: замещает классификацию по умолчанию
-   * (classifyYdbError). Расширение точки для нестандартных обёрток ошибок;
-   * дефолт строго ретраит только ABORTED/UNAVAILABLE/OVERLOADED.
+   * Custom retryability predicate: replaces the default classification
+   * (classifyYdbError). Extension point for non-standard error wrappers; the
+   * default strictly retries only ABORTED/UNAVAILABLE/OVERLOADED.
    */
   shouldRetry?: (error: unknown) => boolean;
-  /** Шов для тестов: подмена ожидания (по умолчанию setTimeout+signal). */
+  /** Test seam: replaces the wait (default setTimeout+signal). */
   sleep?: YdbRetrySleepFn;
-  /** Шов для тестов: детерминированный источник случайности для jitter. */
+  /** Test seam: deterministic randomness source for jitter. */
   rng?: YdbRetryRng;
 }
 
+/** Default maximum number of attempts (including the first). */
 export const RETRY_DEFAULT_MAX_ATTEMPTS = 3;
+/** Default base backoff delay in milliseconds. */
 export const RETRY_DEFAULT_BASE_DELAY_MS = 100;
+/** Default upper backoff delay bound in milliseconds. */
 export const RETRY_DEFAULT_MAX_DELAY_MS = 5_000;
+/** Default jitter ratio. */
 export const RETRY_DEFAULT_JITTER_RATIO = 0.25;
 
-/** Значения по умолчанию политики (заморожены). */
+/** Policy default values (frozen). */
 export const DEFAULT_YDB_RETRY_POLICY_OPTIONS: Readonly<
   Required<
     Pick<
@@ -127,14 +131,14 @@ export const DEFAULT_YDB_RETRY_POLICY_OPTIONS: Readonly<
 });
 
 /**
- * Классифицирует ошибку по структурным признакам (#27):
+ * Classifies an error by structural features (#27):
  *
- * - CommitError (ошибка коммита из @ydbjs/query) — раскрывается в cause;
- * - YDBError — transient только при коде ABORTED/UNAVAILABLE/OVERLOADED;
- * - всё остальное (включая обычные Error приложения/валидации/схемы и
- *   AbortError/TimeoutError) — fatal, повтор запрещён.
+ * - CommitError (a commit error from @ydbjs/query) — unwrapped into its cause;
+ * - YDBError — transient only for codes ABORTED/UNAVAILABLE/OVERLOADED;
+ * - anything else (including ordinary application/validation/schema Errors
+ *   and AbortError/TimeoutError) — fatal, retry is forbidden.
  *
- * Текст сообщения не анализируется никогда.
+ * The message text is never analyzed.
  */
 export function classifyYdbError(error: unknown): YdbErrorKind {
   if (error instanceof CommitError) {
@@ -146,19 +150,18 @@ export function classifyYdbError(error: unknown): YdbErrorKind {
   return 'fatal';
 }
 
-/** true, если ошибка транзитная по умолчательной политике (#27). */
+/** true if the error is transient under the default policy (#27). */
 export function isTransientYdbError(error: unknown): boolean {
   return classifyYdbError(error) === 'transient';
 }
 
 /**
- * Входной формат политики в конфигурации (#27): `false`/`undefined` —
- * выключено (ретраит только SDK), `true` — значения по умолчанию,
- * объект — кастомная политика.
+ * Policy input format for configuration (#27): `false`/`undefined` — disabled
+ * (only the SDK retries), `true` — defaults, an object — custom policy.
  */
 export type YdbRetryPolicyInput = boolean | YdbRetryPolicyOptions;
 
-/** Политика с разрешёнными значениями по умолчанию (результат резолва). */
+/** Policy with resolved defaults (the result of resolution). */
 export interface YdbResolvedRetryPolicy extends Required<
   Pick<
     YdbRetryPolicyOptions,
@@ -173,10 +176,10 @@ export interface YdbResolvedRetryPolicy extends Required<
 }
 
 /**
- * Разрешает вход политики (`boolean | YdbRetryPolicyOptions`) в полную
- * конфигурацию с дефолтами (#27). `undefined`/`false` → null (политика
- * выключена — ретраит только SDK, поведение #98 не меняется).
- * Невалидные опции — fail-fast ошибка.
+ * Resolves a policy input (`boolean | YdbRetryPolicyOptions`) into a full
+ * configuration with defaults (#27). `undefined`/`false` → null (policy
+ * disabled — only the SDK retries, #98 behavior unchanged).
+ * Invalid options are a fail-fast error.
  */
 export function resolveYdbRetryPolicy(
   input?: YdbRetryPolicyInput,
@@ -203,9 +206,9 @@ export function resolveYdbRetryPolicy(
 }
 
 /**
- * Fail-fast валидация опций политики: неизвестных ключей нет (структура
- * типизирована), проверяются значения диапазонов. Невалидное значение —
- * ошибка конфигурации сразу.
+ * Fail-fast validation of policy options: there are no unknown keys (the
+ * structure is typed), value ranges are checked. An invalid value is an
+ * immediate configuration error.
  */
 export function validateYdbRetryPolicyOptions(
   options?: YdbRetryPolicyOptions,
@@ -259,13 +262,13 @@ export function validateYdbRetryPolicyOptions(
 }
 
 /**
- * Чистая функция расчёта задержки перед повторной попыткой (#27):
+ * Pure function computing the delay before a retry (#27):
  *
  *   raw     = min(baseDelayMs * 2^(attempt-1), maxDelayMs)
  *   delayMs = round(raw * (1 - jitterRatio + jitterRatio * rng()))
  *
- * Результат всегда ограничен maxDelayMs (bounded backoff), детерминирован
- * при фиксированных опциях и rng. `attempt` нумеруется с единицы.
+ * The result is always capped at maxDelayMs (bounded backoff), deterministic
+ * given fixed options and rng. `attempt` is 1-based.
  */
 export function computeRetryDelayMs(
   attempt: number,
@@ -288,11 +291,11 @@ export function computeRetryDelayMs(
 }
 
 /**
- * Нормализует причину отмены к Error: причина abort() может быть любым
- * значением (в т.ч. строкой или undefined) — не-Error заворачивается,
- * исходное значение сохраняется в cause. Строковые/числовые причины
- * попадают и в сообщение; произвольные объекты не строковятся
- * (небезопасно) — они видны только через cause.
+ * Normalizes a cancellation reason to an Error: the abort() reason may be any
+ * value (including a string or undefined) — non-Errors are wrapped, the
+ * original value is kept in cause. String/numeric reasons also end up in the
+ * message; arbitrary objects are not stringified (unsafe) — they are visible
+ * only via cause.
  */
 export function abortReasonToError(reason: unknown): Error {
   if (reason instanceof Error) return reason;
@@ -310,7 +313,7 @@ export function abortReasonToError(reason: unknown): Error {
   );
 }
 
-/** Задержка по умолчанию: setTimeout, прерываемый сигналом отмены. */
+/** Default delay: setTimeout, interruptible by an abort signal. */
 function defaultSleep(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     if (signal?.aborted) {
@@ -335,29 +338,28 @@ function defaultSleep(ms: number, signal?: AbortSignal): Promise<void> {
 }
 
 /**
- * Выполняет fn под retry-политикой по типу ошибки (#27).
+ * Runs fn under the error-type retry policy (#27).
  *
- * Семантика:
- * - максимум `maxAttempts` попыток ВКЛЮЧАЯ первую; между попытками —
- *   экспоненциальный backoff с jitter, ограниченный maxDelayMs;
- * - повторяются ТОЛЬКО транзитные ошибки (по умолчанию — статус-коды
- *   ABORTED/UNAVAILABLE/OVERLOADED, классификация структурная);
- *   детерминированные/прикладные ошибки пробрасываются немедленно;
- * - исчерпание попыток пробрасывает ПОСЛЕДНЮЮ ошибку как есть (без
- *   заворачивания) — структура YDBError сохраняется для вызывающего;
- * - `signal` отменяет ожидание задержки и запрещает новые попытки;
- *   операция завершается причиной отмены: если signal.reason — не Error,
- *   он заворачивается в Error (исходное значение — в cause);
- * - колбэк должен быть идемпотентным или устойчивым к повтору: при
- *   повторе заново выполняется вся fn (те же требования, что к
- *   idempotent-транзакциям #98);
- * - fn получает сигнал отмены политики (для связывания с сигналами
- *   нижележащих операций — так сигнал попытки доходит до БД).
+ * Semantics:
+ * - at most `maxAttempts` attempts INCLUDING the first; between attempts —
+ *   exponential backoff with jitter, capped at maxDelayMs;
+ * - retried are ONLY transient errors (by default — status codes
+ *   ABORTED/UNAVAILABLE/OVERLOADED, structural classification);
+ *   deterministic/application errors propagate immediately;
+ * - exhausting attempts rethrows the LAST error as is (without wrapping) —
+ *   the YDBError structure is preserved for the caller;
+ * - `signal` aborts the delay wait and forbids new attempts; the operation
+ *   finishes with the cancellation reason: if signal.reason is not an Error,
+ *   it is wrapped in an Error (the original value — in cause);
+ * - the callback must be idempotent or retry-tolerant: on a retry the whole
+ *   fn runs anew (the same requirement as for idempotent transactions #98);
+ * - fn receives the policy's cancellation signal (to wire it into the signals
+ *   of underlying operations — so the attempt's signal reaches the DB).
  *
- * Интеграция с executor/транзакциями (#27): используйте withRetryPolicy()
- * и опцию retry runInTransaction() — они применяют эту политику к операциям,
- * НЕ дублируя внутренний ретрай SDK (детерминированный приоритет слоёв
- * описан в README «Retry-политика по типу ошибки»).
+ * Executor/transaction integration (#27): use withRetryPolicy() and the retry
+ * option of runInTransaction() — they apply this policy to operations WITHOUT
+ * duplicating the SDK internal retry (the deterministic layer priority is
+ * described in the README "Error-type retry policy").
  */
 export async function runWithRetry<T>(
   fn: (signal?: AbortSignal) => Promise<T>,
@@ -390,6 +392,6 @@ export async function runWithRetry<T>(
     }
   }
 
-  /* istanbul ignore next: цикл всегда возвращается или бросает выше */
+  /* istanbul ignore next: the loop above always returns or throws */
   throw new Error('unreachable');
 }

--- a/src/core/sql-utils.ts
+++ b/src/core/sql-utils.ts
@@ -7,11 +7,10 @@ export function validateIdentifier(name: string, context: string): void {
 }
 
 /**
- * Валидация имени таблицы сущности (@YdbEntity). Правила те же, что и у
- * quoteIdentifier: ASCII-буквы/цифры/подчёркивание, первый символ — буква
- * или подчёркивание. Вызывается в декораторе, поэтому невалидное имя
- * падает при загрузке модуля — до того, как из него соберут путь для
- * DescribeTable или DDL (#91).
+ * Entity table name validation (@YdbEntity). Same rules as
+ * quoteIdentifier: ASCII letters/digits/underscore, first character must be
+ * a letter or underscore. Called in the decorator, so an invalid name fails
+ * at module load — before it's used for DescribeTable or DDL (#91).
  */
 export function validateTableName(name: string): void {
   if (typeof name !== 'string' || !IDENTIFIER_REGEX.test(name)) {
@@ -22,7 +21,7 @@ export function validateTableName(name: string): void {
   }
 }
 
-/** Экранирование идентификаторов YQL (backticks) */
+/** YQL identifier escaping (backticks) */
 export function quoteIdentifier(name: string): string {
   validateIdentifier(name, 'identifier');
   return `\`${name}\``;

--- a/src/core/standalone.ts
+++ b/src/core/standalone.ts
@@ -26,13 +26,13 @@ import {
 import { v4 as uuidv4, v7 as uuidv7 } from 'uuid';
 
 /**
- * Конфигурация сущностей для программного использования без NestJS.
- * Валидирует метаданные каждой сущности, устанавливает executor,
- * генератор UUID (uuidVersion), провайдеры шифрования и валидации
- * на каждую переданную сущность и создаёт для неё YdbRepository.
+ * Entity configuration for programmatic use without NestJS.
+ * Validates each entity's metadata, sets the executor,
+ * UUID generator (uuidVersion), encryption and validation providers
+ * on each provided entity, and creates a YdbRepository for it.
  *
- * Повторный вызов полностью заменяет конфигурацию: если провайдеры
- * не переданы, прошлые сбрасываются (актуально для тестов и hot-restart).
+ * Repeated calls fully replace the configuration: if providers
+ * are not passed, previous ones are reset (relevant for tests and hot-restart).
  *
  * @example
  * ```ts
@@ -50,25 +50,25 @@ export function configureEntities(
     encryptionProvider?: YdbEncryptionProvider;
     blindIndexProvider?: YdbBlindIndexProvider;
     validationProvider?: YdbValidationProvider;
-    /** Версия генерируемых UUID для PK: v7 (по умолчанию) или v4. */
+    /** Version of generated UUIDs for PK: v7 (default) or v4. */
     uuidVersion?: 'v4' | 'v7';
     /**
-     * Формат сериализации Security AAD (#165): 'v2' (по умолчанию) или
-     * 'legacy' — только для переходного периода (дешифровка старого ciphertext).
+     * Security AAD serialization format (#165): 'v2' (default) or
+     * 'legacy' — only for the transition period (decryption of old ciphertext).
      */
     aadFormat?: AadFormat;
     /**
-     * Автоматическое определение формата AAD при чтении (#165): true (по
-     * умолчанию) — при сбое основного формата пробуется второй, legacy-строки
-     * читаемы после апгрейда на v2; false — строгий режим после перешифровки.
+     * Automatic AAD format detection on read (#165): true (by
+     * default) — on primary format failure the second is tried, legacy rows
+     * remain readable after upgrade to v2; false — strict mode after
+     * re-encryption.
      */
     aadReadFallback?: boolean;
     /**
-     * Скоуп независимой ORM-конфигурации (#199), создаётся через
-     * createOrmScope(). По умолчанию — процессный скоуп 'default'
-     * (прежнее поведение одиночной конфигурации). Один класс сущности
-     * может принадлежать только одному активному скоупу: регистрация
-     * в чужом скоупе — ошибка.
+     * Scope of an independent ORM configuration (#199), created via
+     * createOrmScope(). Defaults to the process-wide 'default' scope
+     * (legacy single-configuration behavior). An entity class can belong
+     * to only one active scope: registration in a foreign scope is an error.
      */
     scope?: YdbOrmScope;
   },
@@ -82,8 +82,8 @@ export function configureEntities(
 
   const scope = options.scope ?? getDefaultOrmScope();
 
-  // 1. Валидируем все сущности ДО привязки к скоупу: невалидная
-  // сущность не получает executor/провайдеры и не оставляет владения.
+  // 1. Validate all entities BEFORE binding to scope: an invalid
+  // entity does not receive executor/providers and leaves no ownership.
   for (const entity of entities) {
     assertEntityClass(entity);
     const issues = validateEntityMetadataIssues(
@@ -103,15 +103,15 @@ export function configureEntities(
     }
   }
 
-  // 2. Привязываем сущности к скоупу (идемпотентно) и запоминаем,
-  // какие из них были ново заявлены — для отката при ошибке конфигурации.
+  // 2. Bind entities to scope (idempotently) and remember
+  // which ones were newly claimed — for rollback on configuration error.
   const newlyClaimed = claimEntitiesForScopeWithTracking(scope, entities);
 
-  // 3. Применяем runtime-конфигурацию. Снимаем снимок состояния
-  // каждого класса сущности перед применением, чтобы при ошибке
-  // в середине цикла откатить все мутации (executor, providers, uuidGenerator,
-  // aadFormat, scope, transactions, repository) и оставить сущности
-  // в точно таком же состоянии, как до вызова configureEntities.
+  // 3. Apply runtime configuration. Take a snapshot of each entity
+  // class state before applying, so that on error mid-loop we can
+  // roll back all mutations (executor, providers, uuidGenerator,
+  // aadFormat, scope, transactions, repository) and leave entities
+  // in exactly the same state as before configureEntities.
   const runtimeSnapshots = new Map<typeof YdbBaseEntity, EntityRuntime>();
   for (const entity of entities) {
     const entityClass = entity as unknown as typeof YdbBaseEntity;

--- a/src/core/value-identity.ts
+++ b/src/core/value-identity.ts
@@ -1,20 +1,19 @@
 /**
- * Инъективная каноническая кодировка YDB-значений в строковый ключ (#174).
+ * Injective canonical encoding of YDB values into a string key (#174).
  *
- * Нужна везде, где Map/Set идентифицируют строки по значению колонки:
- * - дедупликация PK/FK между IN(...)-чанками в fetchByColumnIn (#86);
- * - группировка inverse-строк и владельцев в relations-мапах (#174);
- * - повторяющиеся PK-компоненты, гидратированные в РАЗНЫЕ инстансы
- *   (два `Uint8Array([1,2])` и две равные `Date`) должны считаться одним
- *   значением — сравнение по ссылке дало бы «не найден» для валидных связей.
+ * Needed wherever Map/Set identify rows by column value:
+ * - PK/FK deduplication across IN(...) chunks in fetchByColumnIn (#86);
+ * - grouping of inverse rows and owners in relations maps (#174);
+ * - repeated PK components hydrated into DIFFERENT instances
+ *   (two `Uint8Array([1,2])` and two equal `Date`) must count as one
+ *   value — reference comparison would give "not found" for valid relations.
  *
- * Конкатенация с разделителем (`String(a) + '|' + String(b)`) НЕинъективна:
- * ('a|b', 'c') и ('a', 'b|c') дают один ключ 'a|b|c'. Поэтому используется
- * двоичная кодировка без разделителей:
- * [тег типа][длина payload (4 байта, big-endian)][payload].
- * Границы компонентов восстанавливаются однозначно по объявленной длине,
- * типы различаются тегом, поэтому разные значения не могут дать одинаковый
- * ключ.
+ * Concatenation with a delimiter (`String(a) + '|' + String(b)`) is NON-injective:
+ * ('a|b', 'c') and ('a', 'b|c') produce the same key 'a|b|c'. Therefore a
+ * delimiter-free binary encoding is used:
+ * [type tag][payload length (4 bytes, big-endian)][payload].
+ * Component boundaries are recovered unambiguously by the declared length,
+ * types are distinguished by tag, so different values cannot produce the same key.
  */
 
 const valueTag = {
@@ -30,7 +29,7 @@ const valueTag = {
 
 const textEncoder = new TextEncoder();
 
-/** Добавляет payload с префиксом длины (4 байта BE) — самоделимитация. */
+/** Adds payload with length prefix (4 bytes BE) — self-delimiting. */
 function appendLengthPrefixed(out: number[], payload: Uint8Array): void {
   const len = payload.length;
   out.push(
@@ -42,7 +41,7 @@ function appendLengthPrefixed(out: number[], payload: Uint8Array): void {
   for (let i = 0; i < len; i++) out.push(payload[i]);
 }
 
-/** IEEE-754 double как 8 байт BE. */
+/** IEEE-754 double as 8 bytes BE. */
 function appendFloat64(out: number[], value: number): void {
   const buf = new ArrayBuffer(8);
   new DataView(buf).setFloat64(0, value);
@@ -52,11 +51,11 @@ function appendFloat64(out: number[], value: number): void {
 const VALUE_HEX_CHARS = '0123456789abcdef';
 
 /**
- * Канонический value-ключ кортежа YDB-значений: инъективное отображение
- * компонентов (string | number | bigint | boolean | Uint8Array | Date |
- * null/undefined) в hex-строку. Детерминировано: одинаковые значения —
- * одинаковый ключ, разные — гарантированно разные. Bytes и Date
- * сравниваются ПО ЗНАЧЕНИЮ, а не по ссылке.
+ * Canonical value-key of a YDB value tuple: injective mapping
+ * of components (string | number | bigint | boolean | Uint8Array | Date |
+ * null/undefined) to a hex string. Deterministic: same values — same key,
+ * different — guaranteed different. Bytes and Date compared BY VALUE,
+ * not by reference.
  */
 export function valueIdentityKey(components: readonly unknown[]): string {
   const out: number[] = [];
@@ -71,7 +70,7 @@ export function valueIdentityKey(components: readonly unknown[]): string {
         appendLengthPrefixed(out, textEncoder.encode(value));
         break;
       case 'number': {
-        // -0 и 0 — одно значение по SameValueZero (как в Set).
+        // -0 and 0 are one value per SameValueZero (like in Set).
         out.push(valueTag.number);
         appendFloat64(out, Object.is(value, -0) ? 0 : value);
         break;
@@ -85,8 +84,8 @@ export function valueIdentityKey(components: readonly unknown[]): string {
         break;
       case 'object': {
         if (ArrayBuffer.isView(value)) {
-          // Bytes-колонки YDB гидратируются в Uint8Array; сравнение
-          // побайтовое (String() дал бы '[object Uint8Array]' для всех).
+          // YDB bytes columns hydrate to Uint8Array; comparison
+          // is bytewise (String() would give '[object Uint8Array]' for all).
           const view = value;
           out.push(valueTag.bytes);
           appendLengthPrefixed(
@@ -94,8 +93,8 @@ export function valueIdentityKey(components: readonly unknown[]): string {
             new Uint8Array(view.buffer, view.byteOffset, view.byteLength),
           );
         } else if (value instanceof Date) {
-          // Date/Datetime/Timestamp-колонки; невалидная дата — ошибка
-          // конфигурации, а не источник коллизий.
+          // Date/Datetime/Timestamp columns; invalid date is a
+          // configuration error, not a collision source.
           if (Number.isNaN(value.getTime())) {
             throw new Error(
               'Invalid Date in value identity key: cannot build identity key',

--- a/src/decorators/column.decorator.ts
+++ b/src/decorators/column.decorator.ts
@@ -27,8 +27,8 @@ export function YdbColumn(type: YdbPrimitive): PropertyDecorator {
 }
 
 /**
- * Primary key decorator (optional, for future migrations/indexes).
- * Essentially the same as YdbColumn but with an additional meta-label.
+ * Primary key column decorator.
+ * Sets the YDB type of the column and marks it as part of the entity's primary key.
  *
  * @param type - YDB primitive type for the primary key column.
  * @returns Property decorator function.

--- a/src/decorators/column.decorator.ts
+++ b/src/decorators/column.decorator.ts
@@ -6,9 +6,13 @@ import {
 } from '../metadata/entity-metadata.js';
 
 /**
- * Декоратор свойства. Задаёт YDB-тип колонки.
- * Метаданные клонируются перед изменением (copy-on-write), чтобы
- * наследники не портили метаданные родительского класса.
+ * Property decorator. Sets the YDB type of the column.
+ *
+ * Metadata is cloned before being modified (copy-on-write), so that
+ * subclasses do not corrupt the parent class's metadata.
+ *
+ * @param type - YDB primitive type for the column.
+ * @returns Property decorator function.
  */
 export function YdbColumn(type: YdbPrimitive): PropertyDecorator {
   return (target, propertyKey) => {
@@ -23,8 +27,11 @@ export function YdbColumn(type: YdbPrimitive): PropertyDecorator {
 }
 
 /**
- * Декоратор первичного ключа (опционально, для будущих миграций/индексов).
- * По сути — тот же YdbColumn, но с дополнительной мета-меткой.
+ * Primary key decorator (optional, for future migrations/indexes).
+ * Essentially the same as YdbColumn but with an additional meta-label.
+ *
+ * @param type - YDB primitive type for the primary key column.
+ * @returns Property decorator function.
  */
 export function YdbPrimaryColumn(type: YdbPrimitive): PropertyDecorator {
   return (target, propertyKey) => {

--- a/src/decorators/eager.decorator.ts
+++ b/src/decorators/eager.decorator.ts
@@ -3,13 +3,16 @@ import 'reflect-metadata';
 export const YDB_EAGER_KEY = 'ydb:eagerLoad';
 
 /**
- * Автоматически подгружает указанные relations при find / findAll.
+ * Eagerly loads the specified relations on find / findAll.
  *
- * Семантика наследования: связи родителя не затираются — список дочернего
- * класса объединяется с унаследованным (сначала родительские имена, затем
- * новые из потомка). Повторы по имени отбрасываются: первое объявление
- * выигрывает, каждая связь встречается в списке один раз.
+ * Inheritance semantics: the parent's relations are not overwritten — the
+ * child class's list merges with the inherited one (parent names first,
+ * then new ones from the child). Duplicate names are dropped: the first
+ * declaration wins, and each relation appears in the list once.
+ *
+ * @param relations - Array of relation property names to eager load.
  * @example @EagerLoad(['orders', 'profile'])
+ * @returns Class decorator function.
  */
 export function EagerLoad(relations: string[]): ClassDecorator {
   return (target) => {
@@ -23,6 +26,12 @@ export function EagerLoad(relations: string[]): ClassDecorator {
   };
 }
 
+/**
+ * Returns the eager load relations for an entity class.
+ *
+ * @param target - Entity class constructor.
+ * @returns Array of relation property names to eager load.
+ */
 export function getEagerRelations(target: any): string[] {
   return Reflect.getMetadata(YDB_EAGER_KEY, target) || [];
 }

--- a/src/decorators/encryption.decorator.ts
+++ b/src/decorators/encryption.decorator.ts
@@ -5,46 +5,58 @@ import {
 } from '../metadata/entity-metadata.js';
 import type { EncryptedFieldMeta } from '../metadata/entity-metadata.js';
 
-/** Суффикс synthetic-колонки blind index (см. @YdbEncrypted({ blindIndex })). */
+/**
+ * Suffix of the synthetic blind-index column (see @YdbEncrypted({ blindIndex })).
+ * Used by persistence, schema sync, metadata validation, and CLI.
+ */
 export const BLIND_INDEX_SUFFIX = '_bi';
 
 /**
- * Имя synthetic-колонки blind index для зашифрованного поля:
- * `{propertyKey}_bi`. Единственная точка именования — persistence, schema
- * sync, валидация метаданных и CLI используют её вместо inline-шаблонов.
+ * Name of the synthetic blind-index column for an encrypted field:
+ * `{propertyKey}_bi`. The single naming point — persistence, schema sync,
+ * metadata validation and the CLI use it instead of inline templates.
+ *
+ * @param propertyKey - The entity property name.
+ * @returns Blind index column name with `_bi` suffix.
  */
 export function blindIndexColumnName(propertyKey: string): string {
   return `${propertyKey}${BLIND_INDEX_SUFFIX}`;
 }
 
+/**
+ * Options for @YdbEncrypted decorator.
+ */
 export interface YdbEncryptedOptions {
   blindIndex?: boolean;
   aadOverride?: string;
   /**
-   * Ленивая дешифровка (по умолчанию false): поле не дешифруется
-   * при чтении из БД — в инстансе остаётся ciphertext. Дешифровка
-   * выполняется явно: await entity.decryptField('field') или
-   * await entity.decryptLazyFields(). toJSON() бросает ошибку,
-   * пока lazy-поле не дешифровано. Экономит CPU на запросах,
-   * где значение поля не нужно.
+   * Lazy decryption (default false): the field is not decrypted when read
+   * from the DB — ciphertext stays on the instance. Decryption is done
+   * explicitly: await entity.decryptField('field') or
+   * await entity.decryptLazyFields(). toJSON() throws an error until a
+   * lazy field has been decrypted. Saves CPU on queries where the field
+   * value is not needed.
    */
   lazy?: boolean;
 }
 
 /**
- * Помечает поле как шифруемое. Без параметров = { blindIndex: true }.
- * Шифротекст всегда хранится в YDB-колонке `Bytes` (raw bytes) — тип из
- * @YdbColumn для таких полей игнорируется, объявлять его не нужно.
- * Опция lazy: true откладывает дешифровку до явного вызова
- * decryptField()/decryptLazyFields() на инстансе.
+ * Marks a field as encrypted. No parameters = { blindIndex: true }.
+ * Ciphertext is always stored in a YDB `Bytes` column (raw bytes) — the
+ * type from @YdbColumn is ignored for such fields and need not be declared.
+ * The lazy: true option defers decryption until an explicit call to
+ * decryptField()/decryptLazyFields() on the instance.
  *
- * Семантика наследования и повторного применения: последняя декларация
- * побеждает (last-write-wins, как у @YdbEnum) — повторное применение на
- * том же классе и переопределение унаследованного свойства не создаёт
- * дублей в метаданных. Иначе дешифровка обработала бы поле дважды:
- * второй проход отдал бы провайдеру уже расшифрованный plaintext как
- * ciphertext. Метаданные клонируются перед изменением (copy-on-write),
- * чтобы наследники не портили метаданные родительского класса.
+ * Inheritance and re-application semantics: the last declaration wins
+ * (last-write-wins, like @YdbEnum) — re-applying on the same class and
+ * overriding an inherited property does not create duplicates in metadata.
+ * Otherwise decryption would process the field twice: the second pass would
+ * hand the provider already-decrypted plaintext as if it were ciphertext.
+ * Metadata is cloned before being modified (copy-on-write), so that
+ * subclasses do not corrupt the parent class's metadata.
+ *
+ * @param options - Encryption options: blindIndex, aadOverride, lazy.
+ * @returns Property decorator function.
  */
 export function YdbEncrypted(options?: YdbEncryptedOptions): PropertyDecorator {
   return (target, propertyKey) => {
@@ -65,12 +77,15 @@ export function YdbEncrypted(options?: YdbEncryptedOptions): PropertyDecorator {
 }
 
 /**
- * Помечает поле первичного ключа как участника AAD (Additional Authenticated Data).
- * Может применяться только к колонкам, объявленным через @YdbPrimaryColumn.
+ * Marks a primary key field as a participant of the AAD (Additional
+ * Authenticated Data). Can only be applied to columns declared via
+ * @YdbPrimaryColumn.
  *
- * Семантика наследования и повторного применения: дедупликация по имени поля
- * (как у @YdbPrimaryColumn) — повторное объявление на наследнике или на том же
- * классе не создаёт дублей в AAD-строке.
+ * Inheritance and re-application semantics: deduplication by field name
+ * (like @YdbPrimaryColumn) — a re-declaration on a subclass or on the same
+ * class does not create duplicates in the AAD string.
+ *
+ * @returns Property decorator function.
  */
 export function YdbSecurityAAD(): PropertyDecorator {
   return (target, propertyKey) => {

--- a/src/decorators/entity.decorator.spec.ts
+++ b/src/decorators/entity.decorator.spec.ts
@@ -4,12 +4,12 @@ import { YdbEntity } from './entity.decorator.js';
 import { getYdbEntityMetadata } from '../metadata/entity-metadata.js';
 import { getRegisteredYdbEntities } from '../metadata/entity-registry.js';
 
-// Валидация имени таблицы в @YdbEntity (#91): невалидное имя должно падать
-// при декорировании (загрузке модуля), а не на первом DescribeTable/DDL,
-// где из него уже собрали путь до первой ошибки квотинга.
+// Table-name validation in @YdbEntity (#91): an invalid name must fail at
+// decoration (module load) time, not on the first DescribeTable/DDL, where
+// the path would already have been built up to the first quoting error.
 
 describe('@YdbEntity table name validation (#91)', () => {
-  /** Декорирует класс именем name — декоратор отрабатывает немедленно. */
+  /** Decorates a class with the given name — the decorator runs immediately. */
   function decorate(name: string): void {
     @YdbEntity(name)
     class DecoratorValidationEntity {}
@@ -21,7 +21,7 @@ describe('@YdbEntity table name validation (#91)', () => {
     (name) => {
       const before = getRegisteredYdbEntities().length;
       expect(() => decorate(name)).not.toThrow();
-      // Валидная сущность попадает в глобальный реестр
+      // A valid entity enters the global registry
       expect(getRegisteredYdbEntities().length).toBe(before + 1);
     },
   );
@@ -37,11 +37,11 @@ describe('@YdbEntity table name validation (#91)', () => {
     ['SQL injection attempt', '`users`; DROP TABLE users'],
   ])('rejects invalid table name (%s)', (_label, name) => {
     const before = getRegisteredYdbEntities().length;
-    // Строки в toThrow сопоставляются с текстом ошибки как подстроки
+    // Strings in toThrow are matched against the error text as substrings
     expect(() => decorate(name)).toThrow('@YdbEntity: invalid table name');
     expect(() => decorate(name)).toThrow(JSON.stringify(name));
     expect(() => decorate(name)).toThrow('/^[a-zA-Z_][a-zA-Z0-9_]*$/');
-    // Невалидная сущность не должна попасть в глобальный реестр
+    // An invalid entity must not enter the global registry
     expect(getRegisteredYdbEntities().length).toBe(before);
   });
 
@@ -65,15 +65,15 @@ describe('@YdbEntity table name validation (#91)', () => {
       thrown = error;
     }
     expect(thrown).toBeInstanceOf(Error);
-    // Декоратор упал до defineMetadata — метаданных сущности нет.
-    // Проверяем через свежий WeakMap-кеш метаданных на классе-обёртке.
+    // The decorator failed before defineMetadata — no entity metadata exists.
+    // Checked via a fresh WeakMap metadata cache on the wrapper class.
     const holder: { target?: new (...args: any[]) => any } = {};
     try {
       @YdbEntity('also bad')
       class AnotherInvalidEntity {}
       holder.target = AnotherInvalidEntity;
     } catch {
-      // ожидаемо
+      // expected
     }
     expect(holder.target).toBeUndefined();
   });

--- a/src/decorators/entity.decorator.ts
+++ b/src/decorators/entity.decorator.ts
@@ -8,12 +8,17 @@ import {
 import { registerYdbEntity } from '../metadata/entity-registry.js';
 
 /**
- * Декоратор класса. Задаёт имя таблицы в YDB.
- * Класс также попадает в глобальный реестр сущностей (см. entity-registry).
+ * Class decorator. Sets the table name in YDB.
+ * The class is also registered in the global entity registry (see
+ * entity-registry).
  *
- * Имя таблицы валидируется сразу при декорировании (#91): из него
- * собирается путь для DescribeTable и DDL, поэтому невалидное имя
- * должно падать при загрузке модуля, а не на первом обращении к БД.
+ * The table name is validated immediately at decoration time (#91): it is
+ * used to build the path for DescribeTable and DDL, so an invalid name must
+ * fail at module load rather than on the first DB access.
+ *
+ * @param tableName - Table name in YDB (must match /^[a-zA-Z_][a-zA-Z0-9_]*$/).
+ * @returns Class decorator function.
+ * @throws If tableName is invalid.
  */
 export function YdbEntity(tableName: string): ClassDecorator {
   return (target) => {

--- a/src/decorators/enum.decorator.ts
+++ b/src/decorators/enum.decorator.ts
@@ -1,21 +1,26 @@
 import 'reflect-metadata';
 
+/** Metadata key for enum columns (`@YdbEnum`). */
 export const YDB_ENUM_KEY = 'ydb:enum';
 
 export interface YdbEnumMeta {
   propertyKey: string;
   values: readonly string[];
-  /** 'Utf8' хранит строковые значения, 'Int32' — порядковый номер. По умолчанию: 'Utf8'. */
+  /** 'Utf8' stores string values, 'Int32' — the ordinal number. Default: 'Utf8'. */
   storage: 'Utf8' | 'Int32';
 }
 
 /**
- * Декоратор enum-колонки: маппинг enum ↔ Utf8 (строковое значение) или Int32 (порядковый номер).
+ * Enum column decorator: maps an enum ↔ Utf8 (string value) or Int32
+ * (ordinal number).
  *
- * Семантика наследования и повторного применения: последняя декларация
- * побеждает (last-write-wins). Переопределение @YdbEnum на свойстве,
- * унаследованном от родителя, заменяет values/storage — а не игнорируется.
- * Для каждого propertyKey в метаданных остаётся ровно одна запись.
+ * Inheritance and re-application semantics: the last declaration wins
+ * (last-write-wins). Overriding @YdbEnum on a property inherited from a
+ * parent replaces values/storage — it is not ignored. Each propertyKey has
+ * exactly one entry in the metadata.
+ *
+ * @param options - Enum options: values array and optional storage type.
+ * @returns Property decorator function.
  * @example
  *   enum Status { ACTIVE = 'active', INACTIVE = 'inactive' }
  *
@@ -44,6 +49,12 @@ export function YdbEnum(options: {
   };
 }
 
+/**
+ * Returns the enum metadata for an entity class.
+ *
+ * @param target - Entity class constructor.
+ * @returns Array of enum metadata entries.
+ */
 export function getYdbEnumMetadata(
   target: new (...args: any[]) => any,
 ): YdbEnumMeta[] {

--- a/src/decorators/index.decorator.ts
+++ b/src/decorators/index.decorator.ts
@@ -1,13 +1,14 @@
 import 'reflect-metadata';
 
+/** Metadata key for secondary indexes (`@YdbIndex`). */
 export const YDB_INDEXES_KEY = 'ydb:indexes';
 
 export interface YdbIndexOptions {
-  /** Колонки индекса (порядок важен). */
+  /** Index columns (order matters). */
   columns: string[];
-  /** Явное имя индекса. По умолчанию: `{table}__{col1}_{col2}`. */
+  /** Explicit index name. Default: `{table}__{col1}_{col2}`. */
   name?: string;
-  /** Уникальный индекс. По умолчанию false. */
+  /** Unique index. Default false. */
   unique?: boolean;
 }
 
@@ -18,17 +19,20 @@ export interface YdbIndexMetadata {
 }
 
 /**
- * Декларативный вторичный индекс (GLOBAL SYNC). Класс-декоратор,
- * можно вешать несколько раз. Попадает в CREATE TABLE при schema sync
- * и в migration:generate.
+ * Declarative secondary index (GLOBAL SYNC). A class decorator that can be
+ * applied multiple times. Lands in CREATE TABLE during schema sync and in
+ * migration:generate.
  *
- * Семантика наследования (#92): индекс привязан к таблице того класса,
- * на котором объявлен, и НЕ наследуется по цепочке прототипов. Класс
- * с собственным @YdbEntity начинает с пустого списка индексов и объявляет
- * свои явно — иначе родительские индексы по чужим колонкам попали бы
- * в CREATE TABLE дочерней таблицы и уронили DDL. Повтор @YdbIndex на
- * наследнике не мутирует список индексов родителя (copy-on-write).
+ * Inheritance semantics (#92): the index is bound to the table of the class
+ * on which it is declared and is NOT inherited along the prototype chain. A
+ * class with its own @YdbEntity starts with an empty index list and declares
+ * its own explicitly — otherwise parent indexes over foreign columns would
+ * leak into the child table's CREATE TABLE and break the DDL. Re-applying
+ * @YdbIndex on a subclass does not mutate the parent's index list
+ * (copy-on-write).
  *
+ * @param options - Index options: columns, optional name, unique flag.
+ * @returns Class decorator function.
  * @example
  *   @YdbEntity('photos')
  *   @YdbIndex({ columns: ['author_email_bi'] })
@@ -37,22 +41,33 @@ export interface YdbIndexMetadata {
  */
 export function YdbIndex(options: YdbIndexOptions): ClassDecorator {
   return (target) => {
-    // Только собственные метаданные класса: иначе при декорировании
-    // наследника сюда затесались бы индексы родителя (#92).
+    // Only the class's own metadata: otherwise the parent's indexes would
+    // leak in when decorating a subclass (#92).
     const existing: YdbIndexMetadata[] =
       Reflect.getOwnMetadata(YDB_INDEXES_KEY, target) || [];
-    // Класс-декораторы применяются снизу вверх — unshift сохраняет порядок объявления.
+    // Class decorators apply bottom-up — unshift preserves declaration order.
     const indexes: YdbIndexMetadata[] = [{ ...options }, ...existing];
     Reflect.defineMetadata(YDB_INDEXES_KEY, indexes, target);
   };
 }
 
-/** Собственные индексы класса (не наследуются от родителя, #92). */
+/**
+ * Returns the class's own indexes (not inherited from the parent, #92).
+ *
+ * @param target - Entity class constructor.
+ * @returns Array of index metadata entries.
+ */
 export function getYdbIndexesMetadata(target: any): YdbIndexMetadata[] {
   return Reflect.getOwnMetadata(YDB_INDEXES_KEY, target) || [];
 }
 
-/** Имя индекса по умолчанию: `{table}__{col1}_{col2}` — группируется сортировкой. */
+/**
+ * Default index name: `{table}__{col1}_{col2}` — grouped by sorting.
+ *
+ * @param tableName - Table name.
+ * @param columns - Index columns.
+ * @returns Default index name.
+ */
 export function resolveIndexName(tableName: string, columns: string[]): string {
   return `${tableName}__${columns.join('_')}`;
 }

--- a/src/decorators/json.decorator.ts
+++ b/src/decorators/json.decorator.ts
@@ -2,8 +2,8 @@ import 'reflect-metadata';
 import { YDB_JSON_COLUMNS_KEY } from '../metadata/entity-metadata.js';
 
 /**
- * Декоратор свойства: колонка хранится как JSON-строка (Utf8 в БД),
- * но автоматически сериализуется/десериализуется при записи/чтении.
+ * Property decorator: the column is stored as a JSON string (Utf8 in the DB)
+ * but automatically serialized/deserialized on write/read.
  *
  * @example
  *   @YdbEntity('users')
@@ -15,7 +15,9 @@ import { YDB_JSON_COLUMNS_KEY } from '../metadata/entity-metadata.js';
  *   const user = new UserEntity();
  *   user.metadata = { role: 'admin', settings: { theme: 'dark' } };
  *   await UserEntity.save(user);
- *   // В БД: '{"role":"admin","settings":{"theme":"dark"}}'
+ *   // In DB: '{"role":"admin","settings":{"theme":"dark"}}'
+ *
+ * @returns Property decorator function.
  */
 export function YdbJson(): PropertyDecorator {
   return (target, propertyKey) => {
@@ -31,7 +33,12 @@ export function YdbJson(): PropertyDecorator {
   };
 }
 
-/** Возвращает список JSON-колонок для класса сущности. */
+/**
+ * Returns the list of JSON columns for an entity class.
+ *
+ * @param target - Entity class constructor.
+ * @returns Array of JSON column property names.
+ */
 export function getJsonColumns(target: any): string[] {
   return Reflect.getMetadata(YDB_JSON_COLUMNS_KEY, target) || [];
 }

--- a/src/decorators/lifecycle.decorator.ts
+++ b/src/decorators/lifecycle.decorator.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 
+/** Metadata keys for lifecycle hooks. */
 export const YDB_BEFORE_INSERT_KEY = 'ydb:lifecycle:beforeInsert';
 export const YDB_AFTER_INSERT_KEY = 'ydb:lifecycle:afterInsert';
 export const YDB_BEFORE_UPDATE_KEY = 'ydb:lifecycle:beforeUpdate';
@@ -20,12 +21,25 @@ function createLifecycleDecorator(metadataKey: string): MethodDecorator {
   };
 }
 
+/**
+ * Registers a method to run before an entity is inserted. If the method
+ * mutates the entity, the changes are carried into the INSERT.
+ *
+ * @returns Method decorator function.
+ */
 export const BeforeInsert = createLifecycleDecorator(YDB_BEFORE_INSERT_KEY);
+/** Registers a method to run after an entity has been inserted. */
 export const AfterInsert = createLifecycleDecorator(YDB_AFTER_INSERT_KEY);
+/** Registers a method to run before an entity is updated. */
 export const BeforeUpdate = createLifecycleDecorator(YDB_BEFORE_UPDATE_KEY);
+/** Registers a method to run after an entity is loaded from the DB. */
 export const AfterFind = createLifecycleDecorator(YDB_AFTER_FIND_KEY);
+/** Registers a method to run before an entity is removed. */
 export const BeforeRemove = createLifecycleDecorator(YDB_BEFORE_REMOVE_KEY);
 
+/**
+ * The collected lifecycle hook method names for an entity.
+ */
 export interface LifecycleHooks {
   beforeInsert: string[];
   afterInsert: string[];
@@ -34,6 +48,12 @@ export interface LifecycleHooks {
   beforeRemove: string[];
 }
 
+/**
+ * Returns the lifecycle hook method names registered on an entity class.
+ *
+ * @param target - Entity class constructor.
+ * @returns Object with arrays of hook method names.
+ */
 export function getLifecycleHooks(target: any): LifecycleHooks {
   return {
     beforeInsert: Reflect.getMetadata(YDB_BEFORE_INSERT_KEY, target) || [],

--- a/src/decorators/relation.decorators.ts
+++ b/src/decorators/relation.decorators.ts
@@ -4,7 +4,9 @@ import { YdbBaseEntity } from '../entity/base-entity.js';
 import { getYdbEntityMetadata } from '../metadata/entity-metadata.js';
 import { getRegisteredYdbEntities } from '../metadata/entity-registry.js';
 
+/** Metadata key for relations (`@OneToMany`/`@ManyToOne`/`@OneToOne`/`@ManyToMany`). */
 export const YDB_RELATIONS_KEY = 'ydb:relations';
+/** Metadata key for join tables (`@JoinTable`). */
 export const YDB_JOIN_TABLES_KEY = 'ydb:joinTables';
 
 export type RelationType =
@@ -14,9 +16,9 @@ export interface RelationMetadata {
   propertyKey: string;
   type: RelationType;
   target: () => typeof YdbBaseEntity;
-  /** Для one-to-many/many-to-one/one-to-one — FK-колонка. Для many-to-many не используется. */
+  /** For one-to-many/many-to-one/one-to-one — the FK column. Not used for many-to-many. */
   joinColumn?: string | ((target: any) => any);
-  /** Для many-to-many — селектор inverse-свойства (для двунаправленных связей). */
+  /** For many-to-many — a selector of the inverse property (bidirectional relations). */
   inverseSide?: (target: any) => string;
 }
 
@@ -24,30 +26,30 @@ export interface JoinTableMetadata {
   propertyKey: string;
   tableName: string;
   /**
-   * Колонка, ссылающаяся на владеющую сущность
-   * (по умолчанию `{ownerTable}_{pkProperty}`, #90).
+   * Column referring to the owning entity
+   * (default `{ownerTable}_{pkProperty}`, #90).
    */
   joinColumn?: string;
   /**
-   * Колонка, ссылающаяся на обратную сущность
-   * (по умолчанию `{inverseTable}_{pkProperty}`, #90).
+   * Column referring to the inverse entity
+   * (default `{inverseTable}_{pkProperty}`, #90).
    */
   inverseJoinColumn?: string;
 }
 
-/** Описание join-таблицы many-to-many, вычисленное по метаданным сущностей. */
+/** Join-table description of a many-to-many relation, computed from entity metadata. */
 export interface ManyToManyJoinTable {
   tableName: string;
   joinColumn: string;
   inverseJoinColumn: string;
   /**
-   * YDB-тип колонки, ссылающейся на владельца (#90/#87): выводится из
-   * фактического PK owner-сущности. Обязателен: резолв всегда выводит тип
-   * из PK или бросает понятную ошибку конфигурации — молчаливого фолбэка
-   * на Uuid не существует (#87).
+   * YDB type of the column referring to the owner (#90/#87): derived from the
+   * owner entity's actual PK. Required: resolution always derives the type
+   * from the PK or throws a clear configuration error — there is no silent
+   * fallback to Uuid (#87).
    */
   joinColumnType: YdbPrimitive;
-  /** YDB-тип колонки, ссылающейся на inverse-сущность (аналогично #87). */
+  /** YDB type of the column referring to the inverse entity (analogous to #87). */
   inverseJoinColumnType: YdbPrimitive;
   ownerEntity: typeof YdbBaseEntity;
   ownerTableName: string;
@@ -57,10 +59,10 @@ export interface ManyToManyJoinTable {
 }
 
 /**
- * Имя join-колонки по умолчанию: `{tableName}_{pkProperty}` (#90).
- * Для PK с именем `uuid` это историческое `{tableName}_uuid` — существующие
- * связи сохраняют имена; для не-uuid PK имя выводится из реального свойства
- * PK вместо молчаливого предположения о `_uuid`.
+ * Default join-column name: `{tableName}_{pkProperty}` (#90).
+ * For a PK named `uuid` this is the historical `{tableName}_uuid` — existing
+ * relations keep their names; for a non-uuid PK the name is derived from the
+ * real PK property instead of silently assuming `_uuid`.
  */
 export function defaultJoinColumnName(
   tableName: string,
@@ -69,29 +71,36 @@ export function defaultJoinColumnName(
   return `${tableName}_${pkProperty}`;
 }
 
-/** Контекст для сообщений об ошибках конфигурации join-колонки (#87). */
+/**
+ * Context for join-column configuration error messages (#87).
+ */
 export interface JoinColumnResolutionContext {
-  /** Имя класса-владельца связи. */
+  /** Name of the entity class owning the relation. */
   entityName: string;
-  /** Свойство связи (@OneToMany/@ManyToOne/@OneToOne). */
+  /** The relation property (@OneToMany/@ManyToOne/@OneToOne). */
   relationPropertyKey: string;
 }
 
 /**
- * Строгий резолв декларации join-колонки связи (#87).
+ * Strict resolution of a relation's join-column declaration (#87).
  *
- * Поддерживается ровно две формы:
- *  - непустая строка — имя колонки;
- *  - селектор свойства: `(target) => target.property` (точка или скобочная
- *    запись с одним чтением свойства).
+ * Exactly two forms are supported:
+ *  - a non-empty string — the column name;
+ *  - a property selector: `(target) => target.property` (dot or bracket
+ *    notation with a single property read).
  *
- * Всё остальное — ошибка конфигурации, а не молчаливая угаданная строка:
- * цепочки свойств (`x.a.b`), вызовы методов (`x.getFk()`), константы
- * (`() => 'col'`) и неиспользованный аргумент отвергаются с ошибкой,
- * называющей сущность и связь.
+ * Everything else is a configuration error, not a silently guessed string:
+ * property chains (`x.a.b`), method calls (`x.getFk()`), constants
+ * (`() => 'col'`) and an unused argument are rejected with an error that
+ * names the entity and the relation.
  *
- * Единственная точка резолва: используется рантаймом relations и
- * validateEntityMetadata — расхождений между путями нет (#87).
+ * The single resolution point: used by the relations runtime and
+ * validateEntityMetadata — no divergence between the paths (#87).
+ *
+ * @param joinColumn - The join column declaration (string or selector).
+ * @param ctx - Resolution context for error messages.
+ * @returns Resolved column name.
+ * @throws If joinColumn is invalid or missing.
  */
 export function resolveRelationJoinColumn(
   joinColumn: string | ((target: any) => any) | undefined | null,
@@ -128,15 +137,21 @@ export function resolveRelationJoinColumn(
 }
 
 /**
- * Строгий резолв селектора `(target) => target.property`: прокси-рекордер читает
- * ровно одно обращение к свойству. Любая другая форма (цепочка, вызов,
- * символ, вычисленное значение) даёт понятную ошибку вместо угаданной
- * строки колонки (#87).
+ * Strict resolution of the `(target) => target.property` selector: a proxy
+ * recorder reads exactly one property access. Any other form (chain, call,
+ * symbol, computed value) yields a clear error instead of a guessed column
+ * string (#87).
  *
- * Единственная точка резолва property-селекторов: используется join-колонками
- * (#87) и селектором inverseSide many-to-many (metadata:dump, #37) —
- * расхождений между путями нет. `what` — название селектора в тексте ошибки
- * ("join column selector", "inverseSide selector").
+ * The single resolution point for property selectors: used by join columns
+ * (#87) and the many-to-many inverseSide selector (metadata:dump, #37) —
+ * no divergence between the paths. `what` is the selector's label in error
+ * text ("join column selector", "inverseSide selector").
+ *
+ * @param selector - Property selector function.
+ * @param what - Selector label for error messages.
+ * @param where - Context for error messages.
+ * @returns Resolved property name.
+ * @throws If selector is not a direct property access.
  */
 export function resolvePropertySelector(
   selector: (target: any) => any,
@@ -146,7 +161,7 @@ export function resolvePropertySelector(
   const accessedProps: string[] = [];
   let lastNode: unknown;
 
-  /** Маркер внутренней ошибки рекордера: отличаем её от ошибок пользователя. */
+  /** Marker of the recorder's internal error: distinguished from user errors. */
   class SelectorRejected extends Error {}
 
   const makeNode = (): unknown =>
@@ -201,6 +216,14 @@ function defineRelation(prototype: object, metadata: RelationMetadata): void {
   Reflect.defineMetadata(YDB_RELATIONS_KEY, relations, constructor);
 }
 
+/**
+ * Declares a one-to-many relation: each row in the target table references
+ * this entity via the FK column (or a property selector resolving to one).
+ *
+ * @param target - Lazy identity of the related entity class.
+ * @param joinColumn - The FK column name or a `(target) => target.property` selector.
+ * @returns Property decorator function.
+ */
 export function OneToMany(
   target: () => typeof YdbBaseEntity,
   joinColumn: string | ((target: any) => any),
@@ -215,6 +238,14 @@ export function OneToMany(
   };
 }
 
+/**
+ * Declares a many-to-one relation: this entity references the target's row
+ * via the FK column (or a property selector resolving to one).
+ *
+ * @param target - Lazy identity of the related entity class.
+ * @param joinColumn - The FK column name or a `(target) => target.property` selector.
+ * @returns Property decorator function.
+ */
 export function ManyToOne(
   target: () => typeof YdbBaseEntity,
   joinColumn: string | ((target: any) => any),
@@ -229,6 +260,14 @@ export function ManyToOne(
   };
 }
 
+/**
+ * Declares a one-to-one relation between this entity and the target via the
+ * FK column (or a property selector resolving to one).
+ *
+ * @param target - Lazy identity of the related entity class.
+ * @param joinColumn - The FK column name or a `(target) => target.property` selector.
+ * @returns Property decorator function.
+ */
 export function OneToOne(
   target: () => typeof YdbBaseEntity,
   joinColumn: string | ((target: any) => any),
@@ -243,6 +282,15 @@ export function OneToOne(
   };
 }
 
+/**
+ * Declares a many-to-many relation backed by a join table. Combine with
+ * @JoinTable on the owning side; the inverse side may provide an
+ * `inverseSide` selector for bidirectional navigation.
+ *
+ * @param target - Lazy identity of the related entity class.
+ * @param inverseSide - Optional selector resolving the inverse relation property.
+ * @returns Property decorator function.
+ */
 export function ManyToMany(
   target: () => typeof YdbBaseEntity,
   inverseSide?: (target: any) => string,
@@ -258,7 +306,12 @@ export function ManyToMany(
 }
 
 /**
- * Задаёт join-таблицу для many-to-many. Вешается на владеющую сторону связи.
+ * Sets the join table for a many-to-many relation. Applied to the owning
+ * side of the relation.
+ *
+ * @param tableName - Join table name.
+ * @param options - Optional join column and inverse join column names.
+ * @returns Property decorator function.
  * @example
  *   @ManyToMany(() => Tag)
  *   @JoinTable('photo_tag')
@@ -284,25 +337,39 @@ export function JoinTable(
   };
 }
 
+/**
+ * Returns the relations metadata declared on an entity class.
+ *
+ * @param target - Entity class constructor.
+ * @returns Array of relation metadata entries.
+ */
 export function getYdbRelationsMetadata(target: any): RelationMetadata[] {
   return Reflect.getMetadata(YDB_RELATIONS_KEY, target) || [];
 }
 
+/**
+ * Returns the join-table metadata declared on an entity class.
+ *
+ * @param target - Entity class constructor.
+ * @returns Array of join table metadata entries.
+ */
 export function getYdbJoinTableMetadata(target: any): JoinTableMetadata[] {
   return Reflect.getMetadata(YDB_JOIN_TABLES_KEY, target) || [];
 }
 
 /**
- * Резолвит ОДНО объявление join-таблицы: владелец + конкретная m2m-связь
- * с @JoinTable. Валидирует PK обеих сторон, выводит имена колонок по
- * умолчанию из фактических PK и их YDB-типы (#90).
+ * Resolves a SINGLE join-table declaration: owner + the specific m2m relation
+ * with @JoinTable. Validates the PKs of both sides, derives default column
+ * names from the actual PKs and their YDB types (#90).
  *
- * Единственная точка резолва объявления: используется и генерацией схемы
- * (getManyToManyJoinTables), и рантайм-резолвом relations (#139) —
- * алгоритм открытия/валидации нигде не дублируется.
+ * The single resolution point for a declaration: used both by schema
+ * generation (getManyToManyJoinTables) and the relations runtime (#139) —
+ * the open/validation algorithm is not duplicated anywhere.
  *
- * undefined — связь не many-to-many, у сущности нет метаданных или
- * у этой связи нет собственной @JoinTable.
+ * @param Entity - Owner entity class.
+ * @param relation - The many-to-many relation metadata.
+ * @returns Resolved join table definition or undefined if not applicable.
+ * @throws If PKs are missing, composite, or types cannot be derived.
  */
 export function resolveRelationJoinTableDefinition(
   Entity: new (...args: any[]) => any,
@@ -327,8 +394,8 @@ export function resolveRelationJoinTableDefinition(
     );
   }
 
-  // Контекст связи для ошибок конфигурации (#87): ошибка всегда называет
-  // сущности, свойство связи и join-таблицу, а не только одну сущность.
+  // Relation context for configuration errors (#87): the error always names
+  // the entities, the relation property and the join table, not just one entity.
   const relationDesc =
     `${Entity.name}.${relation.propertyKey} -> ${InverseEntity.name} ` +
     `(join table "${joinTable.tableName}")`;
@@ -348,12 +415,12 @@ export function resolveRelationJoinTableDefinition(
     );
   }
 
-  // Рантайм-модель many-to-many связывает строки ровно по одному
-  // значению PK с каждой стороны; составной PK породил бы join-таблицу,
-  // не совпадающую с тем, что читает relations-код, — отказываем явно
-  // (#90/#87). Отказ детерминирован: один и тот же резолвер используется
-  // генерацией схемы, валидацией метаданных, eager loading, loadRelations
-  // и рантаймом join-таблицы — частичной поддержки ни в одном пути нет.
+  // The runtime many-to-many model links rows by exactly one PK value on
+  // each side; a composite PK would produce a join table that does not match
+  // what the relations code reads — we refuse explicitly (#90/#87). The
+  // refusal is deterministic: the same resolver is used by schema generation,
+  // metadata validation, eager loading, loadRelations and the join-table
+  // runtime — there is no path with partial support.
   if (meta.primaryKeys.length > 1) {
     throw new Error(
       `Cannot build many-to-many join table for relation "${relationDesc}": ` +
@@ -374,17 +441,17 @@ export function resolveRelationJoinTableDefinition(
   const ownerPk = meta.primaryKeys[0];
   const inversePk = inverseMeta.primaryKeys[0];
 
-  // Имена по умолчанию выводятся из фактических PK-колонок (#90):
-  // для PK "uuid" это прежние `{table}_uuid`, для остальных — `{table}_{pk}`.
+  // Default names are derived from the actual PK columns (#90):
+  // for a "uuid" PK this is the previous `{table}_uuid`, for others — `{table}_{pk}`.
   const resolvedJoinColumn =
     joinTable.joinColumn ?? defaultJoinColumnName(meta.tableName, ownerPk);
   const resolvedInverseJoinColumn =
     joinTable.inverseJoinColumn ??
     defaultJoinColumnName(inverseMeta.tableName, inversePk);
 
-  // Тип join-колонки = точный тип PK-колонки сущности (#90/#87).
-  // Вывести тип невозможно — ошибка конфигурации; молчаливого фолбэка на
-  // Uuid не существует: он породил бы схему, несовместимую с данными.
+  // Join-column type = the entity's exact PK column type (#90/#87).
+  // If the type cannot be derived — a configuration error; there is no silent
+  // fallback to Uuid: it would produce a schema incompatible with the data.
   const ownerPkType = meta.schema[ownerPk];
   if (!ownerPkType) {
     throw new Error(
@@ -421,15 +488,19 @@ export function resolveRelationJoinTableDefinition(
 }
 
 /**
- * Возвращает join-таблицы many-to-many, владельцами которых являются переданные сущности.
- * Обратная сторона (без @JoinTable) не порождает отдельную таблицу.
+ * Returns the many-to-many join tables owned by the given entities.
+ * The inverse side (without @JoinTable) does not produce a separate table.
  *
- * Одно имя join-таблицы может быть объявлено несколько раз (например,
- * зеркально на обеих сторонах связи или при повторе класса во входном
- * списке). Повторные объявления безопасно дедуплицируются только при
- * идентичном физическом описании (#139); расходящиеся — ошибка со списком
- * всех определений: иначе sync/migrations молча построили бы схему по
- * первому объявлению, а relations-код читал бы по другому.
+ * One join-table name may be declared multiple times (e.g. mirrored on both
+ * sides of the relation, or when the class repeats in the input list).
+ * Repeated declarations are safely deduplicated only when they describe an
+ * identical physical table (#139); diverging ones are an error listing all
+ * definitions: otherwise sync/migrations would silently build a schema from
+ * the first declaration while relations code reads by a different one.
+ *
+ * @param entities - Array of entity classes.
+ * @returns Array of resolved join table definitions.
+ * @throws If conflicting declarations for the same table name exist.
  */
 export function getManyToManyJoinTables(
   entities: (new (...args: any[]) => any)[],
@@ -454,8 +525,8 @@ export function getManyToManyJoinTables(
     }
   }
 
-  // Расходящиеся объявления одного имени таблицы — конфликт: физическую
-  // таблицу нельзя построить двумя разными способами (#139).
+  // Diverging declarations of one table name are a conflict: a physical
+  // table cannot be built in two different ways (#139).
   for (const group of groups.values()) {
     if (group.length > 1) {
       throw new Error(formatJoinTableConflict(group));
@@ -466,14 +537,16 @@ export function getManyToManyJoinTables(
 }
 
 /**
- * Глобальная сверка объявления join-таблицы со всеми зарегистрированными
- * сущностями (#139): если то же имя таблицы объявлено другой связью
- * с другим физическим описанием — ошибка с перечислением определений.
+ * Global reconciliation of a join-table declaration against all registered
+ * entities (#139): if the same table name is declared by another relation
+ * with a different physical description — an error enumerating the
+ * definitions.
  *
- * Вызывается рантайм-резолвом relations, чтобы конфликт, который отвергла
- * бы schema sync/verify/миграции, не проходил молча при чтении: локально
- * для пары (owner, inverse) объявление может быть единственным, но имя
- * таблицы уже занято расходящимся объявлением в другом месте модели.
+ * Called by the relations runtime so that a conflict which schema
+ * sync/verify/migrations would reject does not pass silently on read:
+ * locally for the (owner, inverse) pair the declaration may be the only one,
+ * but the table name is already taken by a diverging declaration elsewhere
+ * in the model.
  */
 export function assertNoForeignJoinTableConflicts(
   canonical: ManyToManyJoinTable,
@@ -481,10 +554,10 @@ export function assertNoForeignJoinTableConflicts(
   for (const Entity of getRegisteredYdbEntities()) {
     const relations = getYdbRelationsMetadata(Entity);
     for (const relation of relations) {
-      // Сломанные нерелевантные объявления не должны ронять чтение другой
-      // связи: их отвергнет полное сканирование модели (schema sync/verify/
-      // миграции) с той же ошибкой. Роняет сверку только реальный конфликт
-      // имён таблиц.
+      // Broken irrelevant declarations must not break reading another
+      // relation: a full model scan (schema sync/verify/migrations) will
+      // reject them with the same error. Only a real table-name conflict
+      // fails this check.
       let other: ManyToManyJoinTable | undefined;
       try {
         other = resolveRelationJoinTableDefinition(Entity, relation);
@@ -492,7 +565,7 @@ export function assertNoForeignJoinTableConflicts(
         continue;
       }
       if (!other || other.tableName !== canonical.tableName) continue;
-      // Эквивалентные (например, зеркальные) объявления разрешены.
+      // Equivalent (e.g. mirrored) declarations are allowed.
       if (joinTableDefinitionsEquivalent(canonical, other)) continue;
       throw new Error(
         formatJoinTableConflict([canonical, other]) +
@@ -504,12 +577,15 @@ export function assertNoForeignJoinTableConflicts(
 }
 
 /**
- * Сравнивает два описания join-таблицы как ФИЗИЧЕСКУЮ таблицу (#139):
- * совпадают пары «сущность → имя колонки + тип», направление объявления
- * не важно (зеркальные декларации на обеих сторонах эквивалентны).
- * Типы выводятся из PK конкретных сущностей, поэтому сравнение покрывает
- * и семантику PK; идентичность сущностей гарантирует одинаковый источник
- * имён/типов по умолчанию.
+ * Compares two join-table descriptions as a PHYSICAL table (#139): the
+ * "entity → column name + type" pairs match; the declaration direction does
+ * not matter (mirrored declarations on both sides are equivalent). Types are
+ * derived from the specific entities' PKs, so the comparison also covers PK
+ * semantics; entity identity guarantees the same default name/type source.
+ *
+ * @param a - First join table definition.
+ * @param b - Second join table definition.
+ * @returns True if definitions describe the same physical table.
  */
 export function joinTableDefinitionsEquivalent(
   a: Pick<
@@ -576,7 +652,7 @@ export function joinTableDefinitionsEquivalent(
   );
 }
 
-/** Человекочитаемое описание одного определения join-таблицы (для ошибок). */
+/** Human-readable description of one join-table definition (for errors). */
 function formatJoinTableDefinition(d: ManyToManyJoinTable): string {
   return (
     `- ${d.ownerEntity.name}.${d.ownerProperty} -> ${d.inverseEntity.name} ` +

--- a/src/decorators/timestamp.decorator.ts
+++ b/src/decorators/timestamp.decorator.ts
@@ -3,7 +3,11 @@ import 'reflect-metadata';
 export const YDB_CREATE_DATE_KEY = 'ydb:createDateColumn';
 export const YDB_UPDATE_DATE_KEY = 'ydb:updateDateColumn';
 
-/** Marks a column as auto-populated with creation timestamp. */
+/**
+ * Marks a column as auto-populated with creation timestamp.
+ *
+ * @returns Property decorator function.
+ */
 export function YdbCreateDateColumn(): PropertyDecorator {
   return (target, propertyKey) => {
     Reflect.defineMetadata(
@@ -14,7 +18,11 @@ export function YdbCreateDateColumn(): PropertyDecorator {
   };
 }
 
-/** Marks a column as auto-populated with last-update timestamp. */
+/**
+ * Marks a column as auto-populated with last-update timestamp.
+ *
+ * @returns Property decorator function.
+ */
 export function YdbUpdateDateColumn(): PropertyDecorator {
   return (target, propertyKey) => {
     Reflect.defineMetadata(

--- a/src/decorators/ttl.decorator.ts
+++ b/src/decorators/ttl.decorator.ts
@@ -1,11 +1,12 @@
 import 'reflect-metadata';
 import { YdbPrimitive } from '../core/types.js';
 
+/** Metadata key for table TTL (`@YdbTtl`). */
 export const YDB_TTL_KEY = 'ydb:ttl';
 
 /**
- * Единица измерения числовой TTL-колонки (AS <unit> в YQL).
- * Обязательна для целочисленных колонок, запрещена для Date/Datetime/Timestamp.
+ * Unit of measure for a numeric TTL column (AS <unit> in YQL).
+ * Required for integer columns, forbidden for Date/Datetime/Timestamp.
  */
 export type YdbTtlUnit =
   'seconds' | 'milliseconds' | 'microseconds' | 'nanoseconds';
@@ -17,7 +18,7 @@ const TTL_UNITS: readonly YdbTtlUnit[] = [
   'nanoseconds',
 ];
 
-/** Типы колонок, которые можно использовать как TTL без указания unit. */
+/** Column types usable as TTL without specifying a unit. */
 const DATE_LIKE_TTL_TYPES: readonly YdbPrimitive[] = [
   'Date',
   'Datetime',
@@ -25,20 +26,20 @@ const DATE_LIKE_TTL_TYPES: readonly YdbPrimitive[] = [
 ];
 
 /**
- * Числовые типы TTL-колонок по ограничениям YDB (значение трактуется как
- * Unix-время и требует указания unit). Только беззнаковые: знаковые
- * Int32/Int64 YDB для TTL не принимает.
+ * Numeric TTL column types per YDB constraints (the value is treated as
+ * Unix time and requires a unit). Only unsigned: signed Int32/Int64 are not
+ * accepted by YDB for TTL.
  */
 const NUMERIC_TTL_TYPES: readonly string[] = ['Uint32', 'Uint64', 'DyNumber'];
 
-/** ISO 8601 duration (например, "PT2H", "P30D", "P1DT2H30M"). */
+/** ISO 8601 duration (for example, "PT2H", "P30D", "P1DT2H30M"). */
 const ISO_DURATION_RE =
   /^P(?!$)(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+(\.\d+)?S)?)?$/;
 
-/** Микросекунд в секунде — внутренняя точность типа YDB Interval. */
+/** Microseconds in a second — the internal precision of the YDB Interval type. */
 export const MICROSECONDS_PER_SECOND = 1_000_000;
 
-/** Строгий разбор ISO 8601 duration по компонентам (для сравнения TTL). */
+/** Strict per-component ISO 8601 duration parse (for TTL comparison). */
 const ISO_DURATION_PARSE_RE =
   /^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?=\d)(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$/;
 
@@ -48,19 +49,19 @@ const MICROS_PER = {
   minute: 60 * MICROSECONDS_PER_SECOND,
 };
 
-/** Результат разбора ISO duration. */
+/** Result of parsing an ISO duration. */
 interface IsoDurationParse {
-  /** Длительность в целых микросекундах (без дроби точнее µs). */
+  /** The duration in whole microseconds (no fraction past µs). */
   micros: bigint;
-  /** Есть значимые цифры дробной части за пределами микросекунд. */
+  /** Has significant fractional digits beyond microseconds. */
   subMicroRemainder: boolean;
 }
 
 /**
- * Разбор ISO 8601 duration по компонентам с точной целочисленной
- * арифметикой. Возвращает null для невалидных строк и интервалов
- * с календарными частями (годы/месяцы): они не имеют фиксированной
- * длины и не поддерживаются YDB Interval.
+ * Parses an ISO 8601 duration by component with exact integer arithmetic.
+ * Returns null for invalid strings and for intervals with calendar parts
+ * (years/months): they have no fixed length and are not supported by the YDB
+ * Interval type.
  */
 function parseIsoDuration(iso: string): IsoDurationParse | null {
   const match = ISO_DURATION_PARSE_RE.exec(iso);
@@ -68,8 +69,8 @@ function parseIsoDuration(iso: string): IsoDurationParse | null {
   const [, years, months, weeks, days, hours, minutes, seconds] = match;
   if (years || months) return null;
 
-  // Дробная часть допустима только у секунд; разбираем её по цифрам,
-  // чтобы не терять точность на float ("0.1" * 10 !== 1).
+  // A fractional part is only allowed on seconds; parse it digit by digit so
+  // precision is not lost on float ("0.1" * 10 !== 1).
   const [wholeSeconds = '0', fracSeconds = ''] = (seconds ?? '').split('.');
   let micros =
     BigInt(weeks ?? 0) * 7n * BigInt(MICROS_PER.day) +
@@ -84,12 +85,12 @@ function parseIsoDuration(iso: string): IsoDurationParse | null {
 }
 
 /**
- * Приводит ISO 8601 duration к целому числу микросекунд — внутренней
- * единице типа YDB Interval ("PT2H" → 720000000, "PT0.5S" → 500000).
- * Дробь вычисляется точно (без плавающей точки); знаки после микросекунд
- * отбрасываются детерминированно — YDB Interval хранит максимум 6 знаков.
- * Для сравнения TTL используйте isoDurationToMicrosecondsExact:
- * усечение скрывает расхождения.
+ * Converts an ISO 8601 duration to a whole number of microseconds — the
+ * internal unit of the YDB Interval type ("PT2H" → 720000000, "PT0.5S" → 500000).
+ * The fraction is computed exactly (no floating point); digits after
+ * microseconds are dropped deterministically — YDB Interval stores at most 6
+ * digits. Use isoDurationToMicrosecondsExact for TTL comparison: truncation
+ * hides divergences.
  */
 export function isoDurationToMicroseconds(iso: string): number | null {
   const parsed = parseIsoDuration(iso);
@@ -97,11 +98,11 @@ export function isoDurationToMicroseconds(iso: string): number | null {
 }
 
 /**
- * Строгий вариант isoDurationToMicroseconds: возвращает null для
- * интервалов, непредставимых в YDB Interval точно, — календарные части
- * и дробную часть точнее микросекунд ("PT0.0000001S"). Используется при
- * сравнении TTL, чтобы непредставимый интервал не «совпал» со значением
- * из БД после молчаливого усечения.
+ * The strict variant of isoDurationToMicroseconds: returns null for
+ * intervals not representable exactly in a YDB Interval — calendar parts and
+ * a fractional part finer than microseconds ("PT0.0000001S"). Used when
+ * comparing TTL so that an unrepresentable interval does not "match" a DB
+ * value after silent truncation.
  */
 export function isoDurationToMicrosecondsExact(iso: string): number | null {
   const parsed = parseIsoDuration(iso);
@@ -111,12 +112,12 @@ export function isoDurationToMicrosecondsExact(iso: string): number | null {
 }
 
 /**
- * Обратное преобразование целого числа микросекунд в ISO 8601 duration —
- * точный inverse `isoDurationToMicroseconds` (500000 → "PT0.5S",
- * 720000000 → "PT2H", 90000000000 → "P1DT1H"). Используется для
- * восстановления фактических настроек TTL из БД в down-миграциях
- * и сообщениях о расхождениях; дробная часть рендерится без потери
- * микросекундной точности YDB.
+ * Reverse conversion of a whole number of microseconds into an ISO 8601
+ * duration — the exact inverse of `isoDurationToMicroseconds` (500000 →
+ * "PT0.5S", 720000000 → "PT2H", 90000000000 → "P1DT1H"). Used to restore
+ * the actual TTL settings from the DB in down-migrations and divergence
+ * reports; the fractional part is rendered without losing YDB's
+ * microsecond precision.
  */
 export function microsecondsToIsoDuration(totalMicros: number): string {
   const micros = Math.max(0, Math.trunc(totalMicros));
@@ -146,10 +147,10 @@ export function microsecondsToIsoDuration(totalMicros: number): string {
 }
 
 /**
- * Приводит ISO 8601 duration к секундам ("PT2H" → 7200, "P30D" → 2592000).
- * Возвращает null для интервалов с календарными частями (годы/месяцы).
- * Для дробных секунд результат дробный — сравнение TTL выполняется
- * через isoDurationToMicroseconds, эта функция осталась для удобства.
+ * Converts an ISO 8601 duration to seconds ("PT2H" → 7200, "P30D" → 2592000).
+ * Returns null for intervals with calendar parts (years/months). Fractional
+ * seconds yield a fractional result — TTL comparison is done via
+ * isoDurationToMicroseconds; this function remains for convenience.
  */
 export function isoDurationToSeconds(iso: string): number | null {
   const micros = isoDurationToMicroseconds(iso);
@@ -157,10 +158,10 @@ export function isoDurationToSeconds(iso: string): number | null {
 }
 
 /**
- * Преобразует целое число секунд (формат expire_after_seconds из
- * DescribeTable) в ISO 8601 duration (7200 → "PT2H", 90000 → "P1DT1H").
- * Дробная часть округляется до секунд; для значений с долями секунды
- * используйте microsecondsToIsoDuration.
+ * Converts a whole number of seconds (the expire_after_seconds format from
+ * DescribeTable) into an ISO 8601 duration (7200 → "PT2H", 90000 → "P1DT1H").
+ * The fractional part is rounded to seconds; for values with subsecond parts
+ * use microsecondsToIsoDuration.
  */
 export function secondsToIsoDuration(totalSeconds: number): string {
   return microsecondsToIsoDuration(
@@ -169,19 +170,19 @@ export function secondsToIsoDuration(totalSeconds: number): string {
 }
 
 export interface YdbTtlOptions {
-  /** ISO 8601 duration (например, "PT2H", "P30D", "PT1H"). */
+  /** ISO 8601 duration (e.g., "PT2H", "P30D", "PT1H"). */
   interval: string;
   /**
-   * Колонка для TTL — должна быть объявлена через @YdbColumn.
-   * По ограничениям YDB тип колонки: Date/Datetime/Timestamp либо
-   * числовой Uint32/Uint64/DyNumber (трактуется как Unix-время,
-   * тогда обязателен unit). Знаковые Int32/Int64 YDB не допускает.
-   * Дефолтов нет: колонка указывается явно (см. issue #81).
+   * Column for TTL — must be declared via @YdbColumn.
+   * Per YDB constraints, column type: Date/Datetime/Timestamp or
+   * numeric Uint32/Uint64/DyNumber (treated as Unix time,
+   * then unit is required). Signed Int32/Int64 not accepted by YDB.
+   * No defaults: column must be specified explicitly (see issue #81).
    */
   column: string;
   /**
-   * Единица измерения числовой TTL-колонки (AS <unit>), например 'seconds'.
-   * Обязательна для Uint32/Uint64/DyNumber, запрещена для дат.
+   * Unit for numeric TTL column (AS <unit>), e.g., 'seconds'.
+   * Required for Uint32/Uint64/DyNumber, forbidden for date types.
    */
   unit?: YdbTtlUnit;
 }
@@ -193,32 +194,35 @@ export interface YdbTtlMetadata {
 }
 
 /**
- * Декларативный TTL таблицы (YDB table TTL).
- * Можно применить только один раз на класс.
- * Генерирует секцию WITH (TTL = Interval(...) ON column) после CREATE TABLE (...).
+ * Declarative table TTL (YDB table TTL).
+ * Can be applied only once per class.
+ * Generates WITH (TTL = Interval(...) ON column) section after CREATE TABLE (...).
  *
- * Семантика наследования (#92): TTL привязан к таблице того класса, на котором
- * объявлен, и НЕ наследуется по цепочке прототипов — класс с собственным
- * @YdbEntity объявляет свой TTL явно (или не имеет его), поэтому родительский
- * TTL по чужой колонке не попадает в DDL дочерней таблицы. Повторное
- * применение на наследнике разрешено: guard «один раз» смотрит только
- * собственные метаданные класса и не считает TTL родителя своим.
+ * Inheritance semantics (#92): TTL is bound to the table of the class on which
+ * it is declared and is NOT inherited along the prototype chain — a class with
+ * its own @YdbEntity declares its own TTL explicitly (or has none), so the
+ * parent's TTL on a foreign column does not leak into the child table's DDL.
+ * Re-application on a subclass is allowed: the "once" guard looks only at
+ * the class's own metadata and does not count the parent's TTL as its own.
  *
- * Ошибки формата (interval, column, unit) бросаются сразу при декорировании.
- * Ошибки относительно схемы сущности (неизвестная колонка, несовместимый тип,
- * лишний/недостающий unit) обнаруживаются при инициализации модуля
- * (validateEntityMetadata) и при построении схемы (buildExpectedTableSchema) —
- * до генерации DDL, см. issue #81.
+ * Format errors (interval, column, unit) are thrown immediately at decoration.
+ * Entity schema errors (unknown column, incompatible type,
+ * extra/missing unit) are detected at module initialization
+ * (validateEntityMetadata) and during schema building (buildExpectedTableSchema) —
+ * before DDL generation, see issue #81.
  *
  * @example
  *   @YdbEntity('sessions')
  *   @YdbTtl({ interval: 'PT2H', column: 'expires_at', unit: 'seconds' })
  *   class SessionEntity extends YdbBaseEntity { ... }
+ * @param options - TTL options: interval, column, optional unit.
+ * @returns Class decorator function.
+ * @throws If already applied to the same class.
  */
 export function YdbTtl(options: YdbTtlOptions): ClassDecorator {
   return (target) => {
-    // Только собственные метаданные класса (#92): TTL родителя не должен
-    // блокировать объявление собственного TTL у наследника.
+    // Only the class's own metadata (#92): parent TTL must not
+    // block declaration of own TTL on subclass.
     const existing = Reflect.getOwnMetadata(YDB_TTL_KEY, target);
     if (existing) {
       throw new Error(
@@ -230,14 +234,25 @@ export function YdbTtl(options: YdbTtlOptions): ClassDecorator {
   };
 }
 
-/** Собственный TTL класса (не наследуется от родителя, #92). */
+/**
+ * The class's own TTL (not inherited from parent, #92).
+ *
+ * @param target - Entity class constructor.
+ * @returns TTL metadata or undefined.
+ */
 export function getYdbTtlMetadata(
   target: new (...args: any[]) => any,
 ): YdbTtlMetadata | undefined {
   return Reflect.getOwnMetadata(YDB_TTL_KEY, target);
 }
 
-/** Проверяет опции декоратора без учёта схемы сущности (вызывается из @YdbTtl). */
+/**
+ * Validates decorator options without considering entity schema (called from @YdbTtl).
+ *
+ * @param className - Name of the entity class.
+ * @param options - TTL options to validate.
+ * @throws If options are invalid.
+ */
 function validateYdbTtlOptions(
   className: string,
   options: YdbTtlOptions,
@@ -272,13 +287,18 @@ function validateYdbTtlOptions(
 }
 
 /**
- * Проверяет TTL-метаданные против схемы колонок сущности по ограничениям YDB:
- * колонка должна существовать и иметь тип Date/Datetime/Timestamp (без unit)
- * либо Uint32/Uint64/DyNumber (только с unit). Знаковые Int32/Int64 YDB
- * для TTL не принимает.
+ * Validates TTL metadata against entity column schema per YDB constraints:
+ * column must exist and have type Date/Datetime/Timestamp (without unit)
+ * or Uint32/Uint64/DyNumber (only with unit). Signed Int32/Int64 not accepted
+ * by YDB for TTL.
  *
- * Возвращает список проблем (пустой, если всё в порядке) — чистая функция,
- * используется validateEntityMetadata и buildExpectedTableSchema.
+ * Returns list of issues (empty if all OK) — pure function,
+ * used by validateEntityMetadata and buildExpectedTableSchema.
+ *
+ * @param entityName - Entity name for error messages.
+ * @param ttl - TTL metadata.
+ * @param columns - Entity column schema.
+ * @returns Array of issue strings.
  */
 export function validateYdbTtlAgainstSchema(
   entityName: string,

--- a/src/encryption/aad.spec.ts
+++ b/src/encryption/aad.spec.ts
@@ -11,26 +11,26 @@ function fromRecord(rec: Record<string, unknown>): (name: string) => unknown {
 }
 
 describe('serializeAadV2 (#165)', () => {
-  it('различает tuple из issue: вложенные разделители не создают коллизий', () => {
+  it('distinguishes tuples from the issue: nested separators cause no collisions', () => {
     const t1 = serializeAadV2(['a', 'b'], fromRecord({ a: 'x;b=y', b: '' }));
     const t2 = serializeAadV2(['a', 'b'], fromRecord({ a: 'x', b: 'y;b=' }));
     expect(t1).not.toBe(t2);
   });
 
-  it('prefix v2 маркирует формат и отделяет от legacy', () => {
+  it('prefix v2 marks format and separates from legacy', () => {
     const out = serializeAadV2(['uuid'], fromRecord({ uuid: 'u-1' }));
     expect(out.startsWith('v2:')).toBe(true);
     expect(out).not.toBe('uuid=u-1');
   });
 
-  it('фиксированный порядок полей: перестановка значений даёт другую строку', () => {
+  it('fixed field order: permuting values produces different string', () => {
     const rec = { a: 'x', b: 'y' };
     const ab = serializeAadV2(['a', 'b'], fromRecord(rec));
     const ba = serializeAadV2(['b', 'a'], fromRecord(rec));
     expect(ab).not.toBe(ba);
   });
 
-  it('absent и null кодируются единым маркером отсутствия значения', () => {
+  it('absent and null encoded with single missing-value marker', () => {
     const withNull = serializeAadV2(
       ['a', 'b'],
       fromRecord({ a: 'x', b: null }),
@@ -43,13 +43,13 @@ describe('serializeAadV2 (#165)', () => {
     expect(withNull.endsWith('0')).toBe(true);
   });
 
-  it('поле с пустой строкой отличается от отсутствующего поля', () => {
+  it('field with empty string differs from absent field', () => {
     const empty = serializeAadV2(['a', 'b'], fromRecord({ a: 'x', b: '' }));
     const missing = serializeAadV2(['a', 'b'], fromRecord({ a: 'x' }));
     expect(empty).not.toBe(missing);
   });
 
-  it('Bytes-значения (Uint8Array) нормализуются через base64 детерминированно', () => {
+  it('Bytes values (Uint8Array) normalized via base64 deterministically', () => {
     const bytes = new TextEncoder().encode('abc');
     const same = new TextEncoder().encode('abc');
     const other = new TextEncoder().encode('abd');
@@ -58,15 +58,15 @@ describe('serializeAadV2 (#165)', () => {
     const aad2 = serializeAadV2(['blob'], fromRecord({ blob: same }));
     const aad3 = serializeAadV2(['blob'], fromRecord({ blob: other }));
 
-    // Один и тот же набор байт — одна и та же AAD-строка (в любом инстансе).
+    // The same byte set yields the same AAD string (from any instance).
     expect(aad1).toBe(aad2);
-    // Разные байты — разные строки.
+    // Different bytes yield different strings.
     expect(aad1).not.toBe(aad3);
-    // Значение кодируется base64 ('abc' → 'YWJj').
+    // The value is base64-encoded ('abc' → 'YWJj').
     expect(aad1).toContain('4:YWJj');
   });
 
-  it('Bytes AAD различает разные значения первой же строкой', () => {
+  it('Bytes AAD distinguishes different values at first line', () => {
     const a = serializeAadV2(
       ['a', 'b'],
       fromRecord({ a: 'x', b: new TextEncoder().encode('v') }),
@@ -78,7 +78,7 @@ describe('serializeAadV2 (#165)', () => {
     expect(a).not.toBe(b);
   });
 
-  it('значения, похожие на length-prefix компонента, не ломают кодировку', () => {
+  it('values resembling length-prefix component do not break encoding', () => {
     const t1 = serializeAadV2(['a'], fromRecord({ a: '1:a0' }));
     const t2 = serializeAadV2(['a'], fromRecord({ a: '1:a1' }));
     const t3 = serializeAadV2(['a', 'b'], fromRecord({ a: 'x', b: '0' }));
@@ -86,7 +86,7 @@ describe('serializeAadV2 (#165)', () => {
     expect(t3).not.toBe(t1);
   });
 
-  it('разные пары значений всегда дают разные кодировки', () => {
+  it('different value pairs always produce different encodings', () => {
     const tuples: Record<string, unknown>[] = [
       { a: 'x', b: 'y' },
       { a: 'x', b: 'y;b=' },
@@ -102,7 +102,7 @@ describe('serializeAadV2 (#165)', () => {
     expect(new Set(encodings).size).toBe(encodings.length);
   });
 
-  it('нормализует каждое присутствующее значение ровно один раз (#204)', () => {
+  it('normalizes each present value exactly once (#204)', () => {
     const d1 = new Date('2024-01-01T00:00:00.000Z');
     const d2 = new Date('2025-06-15T12:30:45.000Z');
     const iso1 = jest.spyOn(d1, 'toISOString');
@@ -112,12 +112,12 @@ describe('serializeAadV2 (#165)', () => {
         ['dt1', 'dt2'],
         fromRecord({ dt1: d1, dt2: d2 }),
       );
-      // Байт-в-байт тот же v2-формат: длина + значение для каждого поля.
+      // Byte-for-byte the same v2 format: length + value for each field.
       expect(out).toBe(
         'v2:3:dt1124:2024-01-01T00:00:00.000Z' +
           '3:dt2124:2025-06-15T12:30:45.000Z',
       );
-      // Нормализация (Date → ISO) выполняется один раз на значение.
+      // Normalization (Date → ISO) happens once per value.
       expect(iso1).toHaveBeenCalledTimes(1);
       expect(iso2).toHaveBeenCalledTimes(1);
     } finally {
@@ -128,7 +128,7 @@ describe('serializeAadV2 (#165)', () => {
 });
 
 describe('serializeAadLegacy', () => {
-  it('сохраняет исторический формат name=value;... и пропуск null-полей', () => {
+  it('preserves historical name=value;... format and skips null fields', () => {
     const out = serializeAadLegacy(
       ['uuid', 'tenant_id'],
       fromRecord({ uuid: 'u-1', tenant_id: null }),
@@ -136,7 +136,7 @@ describe('serializeAadLegacy', () => {
     expect(out).toBe('uuid=u-1');
   });
 
-  it('типичные коллизии legacy остаются коллизиями legacy (для теста миграции)', () => {
+  it('typical legacy collisions remain legacy collisions (for migration test)', () => {
     const t1 = serializeAadLegacy(
       ['a', 'b'],
       fromRecord({ a: 'x;b=y', b: '' }),
@@ -150,13 +150,13 @@ describe('serializeAadLegacy', () => {
 });
 
 describe('buildAad', () => {
-  it('по умолчанию использует безопасный v2', () => {
+  it('defaults to safe v2', () => {
     expect(DEFAULT_AAD_FORMAT).toBe('v2');
     const out = buildAad(['uuid'], fromRecord({ uuid: 'u-1' }));
     expect(out.startsWith('v2:')).toBe(true);
   });
 
-  it('явный legacy отдаёт исторический формат', () => {
+  it('explicit legacy returns historical format', () => {
     const out = buildAad(['uuid'], fromRecord({ uuid: 'u-1' }), 'legacy');
     expect(out).toBe('uuid=u-1');
   });

--- a/src/encryption/aad.ts
+++ b/src/encryption/aad.ts
@@ -1,34 +1,41 @@
 /**
- * Сериализация Security AAD (#165).
+ * Security AAD serialization (#165).
  *
- * `legacy` — исторический формат `name=value;name=value` (конкатенация без
- * экранирования): значения с вложенными разделителями создают коллизии.
- * Например, `{ a: 'x;b=y', b: '' }` и `{ a: 'x', b: 'y;b=' }` кодируются
- * одинаково как `a=x;b=y;b=`, поэтому при shared-key AEAD-провайдере
- * ciphertext можно перенести между такими записями, не поймав расхождение
- * аутентифицированных данных. Формат оставлен только как переходный режим
- * для дешифровки существующего ciphertext (см. `YdbModuleOptions.aadFormat`).
+ * `legacy` — the historical `name=value;name=value` format (concatenation
+ * without escaping): values containing nested separators create collisions.
+ * For example, `{ a: 'x;b=y', b: '' }` and `{ a: 'x', b: 'y;b=' }` encode
+ * identically as `a=x;b=y;b=`, so with a shared-key AEAD provider a
+ * ciphertext can be moved between such records without the authenticated
+ * data mismatch being caught. The format is kept only as a transitional
+ * mode for decrypting existing ciphertext (see `YdbModuleOptions.aadFormat`).
  *
- * `v2` (по умолчанию) — версионированная, каноническая, self-delimiting
- * покомпонентная сериализация. Строка начинается с префикса `v2:`, затем для
- * каждого поля в порядке `metadata.aadFields` (фиксированном) идёт блок
- * `len(name):name` + признак присутствия `0|1` + опционально `len(value):value`.
- * Формат однозначен:
- * - порядок полей фиксирован (перестановка значений даёт другую строку);
- * - длина префиксирована — значения с любыми разделителями безопасны;
- * - отсутствующее/null-значение кодируется явным маркером `0`, поэтому
- *   `{ a: 'x' }` и `{ a: 'x', b: null }` не могут совпасть.
- * Значения приводятся к строке через `String(value)` — как в legacy, чтобы
- * для одного и того же поля шифрование и дешифровка давали одинаковый AAD
- * (Uuid, Date и т.п. конвертируются в строку на обоих путях).
+ * `v2` (default) — a versioned, canonical, self-delimiting per-component
+ * serialization. The string starts with the prefix `v2:`, then for each
+ * field in the fixed `metadata.aadFields` order a block of
+ * `len(name):name` + a presence flag `0|1` + optionally `len(value):value`.
+ * The format is unambiguous:
+ * - field order is fixed (permuting values produces a different string);
+ * - length is prefixed, so values containing any delimiters are safe;
+ * - a missing/null value is encoded with an explicit `0` marker, so
+ *   `{ a: 'x' }` and `{ a: 'x', b: null }` cannot coincide.
+ * Values are coerced to strings via `String(value)` — as in legacy, so that
+ * encrypt and decrypt of the same field yield the same AAD (Uuid, Date, etc.
+ * convert to a string on both paths).
  */
 export type AadFormat = 'legacy' | 'v2';
 
+/** The default AAD format: the safe, canonical `v2`. */
 export const DEFAULT_AAD_FORMAT: AadFormat = 'v2';
 
 const AAD_V2_PREFIX = 'v2:';
 
-/** Каноническая v2-сериализация tuple AAD (#165). */
+/**
+ * Canonical v2 serialization of tuple AAD (#165).
+ *
+ * @param names - Ordered field names from metadata (fixed order).
+ * @param valueOf - Function returning the value for a given field name.
+ * @returns Serialized AAD string with `v2:` prefix.
+ */
 export function serializeAadV2(
   names: readonly string[],
   valueOf: (name: string) => unknown,
@@ -46,7 +53,13 @@ export function serializeAadV2(
   return out;
 }
 
-/** Легаси-сериализация `name=value;...` (только для миграции на v2). */
+/**
+ * Legacy serialization `name=value;...` (for migration to v2 only).
+ *
+ * @param names - Ordered field names from metadata.
+ * @param valueOf - Function returning the value for a given field name.
+ * @returns Serialized AAD string in legacy format.
+ */
 export function serializeAadLegacy(
   names: readonly string[],
   valueOf: (name: string) => unknown,
@@ -61,13 +74,18 @@ export function serializeAadLegacy(
 }
 
 /**
- * Значения AAD нормализуются в строку детерминированно (Uuid/Date/Bytes и т.п.
- * конвертируются одинаково при шифровании и дешифровании:
- * - Date/Datetime/Timestamp — ISO-строка;
- * - Bytes — base64 (канонический, обратимый, ASCII-safe);
- * - остальные примитивы — String().
- * Объекты и массивы недопустимы: в PK/AAD-колонках их быть не может, а
- * молчаливый `[object Object]` стёр бы различие между записями.
+ * Value normalization for AAD: values are coerced to a string
+ * deterministically (Uuid/Date/Bytes etc. convert the same way during
+ * encrypt and decrypt):
+ * - Date/Datetime/Timestamp — ISO string;
+ * - Bytes — base64 (canonical, reversible, ASCII-safe);
+ * - other primitives — String().
+ * Objects and arrays are not allowed: they cannot occur in PK/AAD columns,
+ * and a silent `[object Object]` would erase the distinction between records.
+ *
+ * @param value - The value to normalize.
+ * @returns Normalized string representation.
+ * @throws If value is not a supported scalar type.
  */
 export function toAadString(value: unknown): string {
   switch (typeof value) {
@@ -91,8 +109,13 @@ export function toAadString(value: unknown): string {
 }
 
 /**
- * Сборка AAD по выбранному формату. По умолчанию — безопасный `v2`;
- * `legacy` нужен только в переходный период для чтения старых записей.
+ * Builds the AAD according to the selected format. Defaults to the safe `v2`;
+ * `legacy` is only needed during the transition to read old records.
+ *
+ * @param names - Ordered field names from metadata.
+ * @param valueOf - Function returning the value for a given field name.
+ * @param format - AAD format: 'v2' (default) or 'legacy'.
+ * @returns Serialized AAD string.
  */
 export function buildAad(
   names: readonly string[],

--- a/src/encryption/ydb-encryption-provider.interface.ts
+++ b/src/encryption/ydb-encryption-provider.interface.ts
@@ -1,3 +1,7 @@
+/**
+ * Context describing where encryption/decryption is being applied. Helps a
+ * key-management provider derive or select per-field keys.
+ */
 export interface YdbEncryptionContext {
   entityName: string;
   tableName: string;
@@ -8,8 +12,8 @@ export interface YdbEncryptionContext {
 
 export interface YdbEncryptionProvider {
   /**
-   * Шифрует plaintext и возвращает raw ciphertext (Uint8Array).
-   * Значение хранится в YDB-колонке `Bytes` (без base64-кодирования).
+   * Encrypts the plaintext and returns the raw ciphertext (Uint8Array).
+   * The value is stored in a YDB `Bytes` column (no base64 encoding).
    */
   encrypt(
     plaintext: string,
@@ -17,7 +21,8 @@ export interface YdbEncryptionProvider {
     context: YdbEncryptionContext,
   ): Promise<Uint8Array>;
   /**
-   * Дешифрует ciphertext (Uint8Array из колонки `Bytes`) и возвращает plaintext.
+   * Decrypts the ciphertext (Uint8Array read from a `Bytes` column) and
+   * returns the plaintext.
    */
   decrypt(
     ciphertext: Uint8Array,
@@ -26,6 +31,10 @@ export interface YdbEncryptionProvider {
   ): Promise<string>;
 }
 
+/**
+ * Computes a deterministic hash over the plaintext for a blind index,
+ * allowing equality lookups without exposing the value.
+ */
 export interface YdbBlindIndexProvider {
   hash(plaintext: string, context: YdbEncryptionContext): Promise<string>;
 }

--- a/src/entity/base-entity.ts
+++ b/src/entity/base-entity.ts
@@ -20,18 +20,18 @@ import {
 } from '../persistence/entity-persistence.js';
 
 /**
- * Базовый класс Active Record.
+ * Active Record base class.
  *
- * Содержит только публичные статические фасады и instance helpers.
- * Вся реализация CRUD/шифрования/relations живёт в `YdbEntityPersistence`
- * и `YdbEntityRelations`, доступных через `YdbRepository` из entity-runtime.
+ * Contains only public static facades and instance helpers.
+ * All CRUD/encryption/relations implementation lives in `YdbEntityPersistence`
+ * and `YdbEntityRelations`, accessible via `YdbRepository` from entity-runtime.
  */
 export class YdbBaseEntity {
-  // ---- Runtime setters (публичный API для тестов и standalone-конфигурации) ----
+  // ---- Runtime setters (public API for tests and standalone configuration) ----
 
   /**
-   * Устанавливает executor. Передача undefined сбрасывает executor
-   * (нужно при повторном бутстрапе и очистке состояния в тестах).
+   * Sets the executor. Passing undefined resets the executor
+   * (needed for re-bootstrap and state cleanup in tests).
    */
   static setExecutor(this: typeof YdbBaseEntity, db?: YdbExecutor): void {
     getEntityRuntime(this).executor = db;
@@ -39,8 +39,8 @@ export class YdbBaseEntity {
   }
 
   /**
-   * Устанавливает encryption-провайдер. Передача undefined сбрасывает
-   * провайдер (нужно при повторном бутстрапе без шифрования).
+   * Sets the encryption provider. Passing undefined resets
+   * the provider (needed for re-bootstrap without encryption).
    */
   static setEncryptionProvider(
     this: typeof YdbBaseEntity,
@@ -51,8 +51,8 @@ export class YdbBaseEntity {
   }
 
   /**
-   * Устанавливает blind-index-провайдер. Передача undefined сбрасывает
-   * провайдер (нужно при повторном бутстрапе без шифрования).
+   * Sets the blind index provider. Passing undefined resets
+   * the provider (needed for re-bootstrap without encryption).
    */
   static setBlindIndexProvider(
     this: typeof YdbBaseEntity,
@@ -63,8 +63,8 @@ export class YdbBaseEntity {
   }
 
   /**
-   * Устанавливает validation-провайдер. Передача undefined сбрасывает
-   * провайдер (нужно при повторном бутстрапе и очистке состояния в тестах).
+   * Sets the validation provider. Passing undefined resets
+   * the provider (needed for re-bootstrap and state cleanup in tests).
    */
   static setValidationProvider(
     this: typeof YdbBaseEntity,
@@ -75,10 +75,10 @@ export class YdbBaseEntity {
   }
 
   /**
-   * Устанавливает формат сериализации Security AAD (#165): 'v2' (по
-   * умолчанию, безопасный) или 'legacy' — только для переходного периода,
-   * когда в БД ещё есть ciphertext, написанный старым форматом. Передача
-   * undefined возвращает формат по умолчанию.
+   * Sets the Security AAD serialization format (#165): 'v2' (default,
+   * secure) or 'legacy' — only for the transitional period when the
+   * database still has ciphertext written in the old format. Passing
+   * undefined returns the default format.
    */
   static setAadFormat(this: typeof YdbBaseEntity, format?: AadFormat): void {
     getEntityRuntime(this).aadFormat = format;
@@ -86,11 +86,12 @@ export class YdbBaseEntity {
   }
 
   /**
-   * Управляет автоматическим определением формата AAD при дешифровке (#165).
-   * По умолчанию (undefined → true) при сбое основного формата делается
-   * повтор вторым: записи, написанные legacy-форматом, читаемы сразу после
-   * апгрейда на v2-дефолт. После полной перешифровки данных передайте
-   * `false` — строгий режим, ошибка формата не маскируется.
+   * Controls automatic AAD format detection on decryption (#165).
+   * Default (undefined → true): on primary format failure, a second
+   * attempt is made with the other format — records written in legacy
+   * format are readable immediately after upgrading to v2 default.
+   * After full data re-encryption, pass `false` — strict mode, format
+   * error is not masked.
    */
   static setAadReadFallback(
     this: typeof YdbBaseEntity,
@@ -127,6 +128,12 @@ export class YdbBaseEntity {
 
   // ---- CRUD facades ----
 
+  /**
+   * Finds a single entity by the given criteria.
+   * @param where - Filter criteria (column-value pairs).
+   * @param options - Query options (transaction, timeout, limit, offset, signal, idempotent).
+   * @returns The entity instance or null if not found.
+   */
   static async find<T extends YdbBaseEntity>(
     this: { new (): T } & typeof YdbBaseEntity,
     where: Record<string, any>,
@@ -135,6 +142,12 @@ export class YdbBaseEntity {
     return getOrCreateRepository<T>(this).find(where, options);
   }
 
+  /**
+   * Finds all entities matching the criteria.
+   * @param where - Filter criteria (column-value pairs). Defaults to {} (all rows).
+   * @param options - Query options (transaction, timeout, limit, offset, signal, idempotent).
+   * @returns Array of entity instances.
+   */
   static async findAll<T extends YdbBaseEntity>(
     this: { new (): T } & typeof YdbBaseEntity,
     where: Record<string, any> = {},
@@ -143,6 +156,12 @@ export class YdbBaseEntity {
     return getOrCreateRepository<T>(this).findAll(where, options);
   }
 
+  /**
+   * Finds a single entity by the given criteria (alias for `find`).
+   * @param where - Filter criteria (column-value pairs).
+   * @param options - Query options (transaction, timeout, limit, offset, signal, idempotent).
+   * @returns The entity instance or null if not found.
+   */
   static async findOneBy<T extends YdbBaseEntity>(
     this: { new (): T } & typeof YdbBaseEntity,
     where: Record<string, any>,
@@ -151,6 +170,12 @@ export class YdbBaseEntity {
     return getOrCreateRepository<T>(this).findOneBy(where, options);
   }
 
+  /**
+   * Finds all entities matching the criteria (alias for `findAll`).
+   * @param where - Filter criteria (column-value pairs).
+   * @param options - Query options (transaction, timeout, limit, offset, signal, idempotent).
+   * @returns Array of entity instances.
+   */
   static async findBy<T extends YdbBaseEntity>(
     this: { new (): T } & typeof YdbBaseEntity,
     where: Record<string, any>,
@@ -159,6 +184,12 @@ export class YdbBaseEntity {
     return getOrCreateRepository<T>(this).findBy(where, options);
   }
 
+  /**
+   * Counts entities matching the criteria.
+   * @param where - Filter criteria (column-value pairs). Defaults to {} (all rows).
+   * @param options - Query options (transaction, timeout, signal, idempotent).
+   * @returns Number of matching rows.
+   */
   static async count(
     this: typeof YdbBaseEntity,
     where: Record<string, any> = {},
@@ -167,6 +198,12 @@ export class YdbBaseEntity {
     return getOrCreateRepository(this).count(where, options);
   }
 
+  /**
+   * Saves (inserts or updates) an entity instance.
+   * @param entity - Entity instance to save.
+   * @param options - Query options (transaction, timeout, signal, idempotent).
+   * @returns The saved entity instance (with generated PK if applicable).
+   */
   static async save<T extends YdbBaseEntity>(
     this: { new (): T } & typeof YdbBaseEntity,
     entity: T,
@@ -175,6 +212,12 @@ export class YdbBaseEntity {
     return getOrCreateRepository<T>(this).save(entity, options);
   }
 
+  /**
+   * Inserts multiple entities in a single batch (grouped by columns).
+   * @param entities - Array of entity instances to insert.
+   * @param options - Query options (transaction, timeout, signal, idempotent).
+   * @returns Array of saved entity instances.
+   */
   static async insertMany<T extends YdbBaseEntity>(
     this: { new (): T } & typeof YdbBaseEntity,
     entities: T[],
@@ -183,6 +226,13 @@ export class YdbBaseEntity {
     return getOrCreateRepository<T>(this).insertMany(entities, options);
   }
 
+  /**
+   * Updates entities matching the criteria with the given patch.
+   * @param where - Filter criteria (column-value pairs).
+   * @param patch - Partial object with columns to update.
+   * @param options - Query options (transaction, timeout, signal, idempotent).
+   * @returns Number of affected rows.
+   */
   static async updateBy(
     this: typeof YdbBaseEntity,
     where: Record<string, any>,
@@ -192,6 +242,12 @@ export class YdbBaseEntity {
     return getOrCreateRepository(this).updateBy(where, patch, options);
   }
 
+  /**
+   * Deletes an entity by primary key value(s).
+   * @param pkValue - Primary key value (single value for single PK, object for composite PK).
+   * @param options - Query options (transaction, timeout, signal, idempotent).
+   * @returns The deleted entity instance or null if not found.
+   */
   static async delete<T extends YdbBaseEntity>(
     this: { new (): T } & typeof YdbBaseEntity,
     pkValue: string | number | Record<string, any>,
@@ -200,6 +256,12 @@ export class YdbBaseEntity {
     return getOrCreateRepository<T>(this).delete(pkValue, options);
   }
 
+  /**
+   * Deletes all entities matching the criteria.
+   * @param where - Filter criteria (column-value pairs).
+   * @param options - Query options (transaction, timeout, signal, idempotent).
+   * @returns Number of deleted rows.
+   */
   static async deleteBy(
     this: typeof YdbBaseEntity,
     where: Record<string, any>,
@@ -208,16 +270,20 @@ export class YdbBaseEntity {
     return getOrCreateRepository(this).deleteBy(where, options);
   }
 
+  /**
+   * Returns a query builder for the entity.
+   * @returns YdbQueryBuilder instance for fluent query construction.
+   */
   static query<T extends YdbBaseEntity>(
     this: { new (): T } & typeof YdbBaseEntity,
   ): YdbQueryBuilder<T> {
     return getOrCreateRepository<T>(this).query();
   }
 
-  // ---- @internal мосты для YdbQueryBuilder ----
+  // ---- @internal bridges for YdbQueryBuilder ----
 
   /**
-   * @internal Мост для YdbQueryBuilder: собрать WHERE по метаданным сущности.
+   * @internal Bridge for YdbQueryBuilder: build WHERE clause from entity metadata.
    */
   static _buildWhereClause(
     this: typeof YdbBaseEntity,
@@ -232,7 +298,7 @@ export class YdbBaseEntity {
   }
 
   /**
-   * @internal Мост для YdbQueryBuilder: выполнить SELECT и вернуть сущности.
+   * @internal Bridge for YdbQueryBuilder: execute SELECT and return entities.
    */
   static async _executeSelect<T extends YdbBaseEntity>(
     this: { new (): T } & typeof YdbBaseEntity,
@@ -252,7 +318,7 @@ export class YdbBaseEntity {
   }
 
   /**
-   * @internal Мост для YdbQueryBuilder: выполнить COUNT-запрос.
+   * @internal Bridge for YdbQueryBuilder: execute COUNT query.
    */
   static async _executeCount(
     this: typeof YdbBaseEntity,
@@ -274,8 +340,8 @@ export class YdbBaseEntity {
   // ---- Instance helpers ----
 
   /**
-   * Сериализация в JSON: исключает synthetic {field}_bi колонки
-   * и внутренние служебные поля.
+   * Serialization to JSON: excludes synthetic {field}_bi columns
+   * and internal service fields.
    */
   toJSON(): Record<string, any> {
     const meta = getYdbEntityMetadata(this.constructor as typeof YdbBaseEntity);

--- a/src/entity/entity-runtime.ts
+++ b/src/entity/entity-runtime.ts
@@ -11,8 +11,8 @@ import type { YdbBaseEntity } from './base-entity.js';
 import type { YdbRepository } from '../repository/ydb-repository.js';
 
 /**
- * Снапшот зависимостей, использованных при создании repository.
- * Хранится в runtime для пересоздания repository при смене deps.
+ * Snapshot of dependencies used when creating the repository.
+ * Stored in runtime for repository recreation when deps change.
  */
 export interface RepositoryDepsSnapshot {
   executor?: YdbExecutor;
@@ -29,38 +29,42 @@ export interface EntityRuntime {
   encryptionProvider?: YdbEncryptionProvider;
   blindIndexProvider?: YdbBlindIndexProvider;
   validationProvider?: YdbValidationProvider;
-  /** Генератор UUID для PK (по умолчанию v7 — см. base-entity). */
+  /** UUID generator for primary key (default: v7 — see base-entity). */
   uuidGenerator?: () => string;
-  /** Формат Security AAD (#165); undefined = 'v2' по умолчанию. */
+  /** Security AAD format (#165); undefined = 'v2' by default. */
   aadFormat?: AadFormat;
   /**
-   * Автоматическое определение формата AAD при чтении (#165);
-   * undefined = true (безопасный переход legacy → v2).
+   * Automatic AAD format detection on read (#165);
+   * undefined = true (safe legacy → v2 transition).
    */
   aadReadFallback?: boolean;
-  /** Готовый репозиторий сущности (создаётся лениво из deps). */
+  /** Cached entity repository (lazily created from deps). */
   repository?: YdbRepository<YdbBaseEntity>;
-  /** Снапшот deps, использованных для создания repository. */
+  /** Snapshot of deps used to create the repository. */
   repositoryDeps?: RepositoryDepsSnapshot;
   /**
-   * Скоуп ORM-конфигурации, которой принадлежит сущность (#199);
-   * undefined — сущность ещё не сконфигурирована.
+   * ORM configuration scope that owns this entity (#199);
+   * undefined — entity has not been configured yet.
    */
   scope?: YdbOrmScope;
   /**
-   * Настройки транзакций конфигурации-владельца (#199); undefined —
-   * используются процессно-глобальные настройки (прежнее поведение).
+   * Transaction settings of the owning configuration (#199); undefined —
+   * process-global settings are used (legacy behavior).
    */
   transactions?: Required<YdbTransactionsSettings>;
 }
 
 /**
- * Рантайм-зависимости Active Record сущностей.
- * Хранятся отдельно от классов (а не в статических полях с any-кастами),
- * ключ — конкретный класс сущности, поэтому наследники не разделяют состояние.
+ * Runtime dependencies of Active Record entities.
+ * Stored separately from classes (not in static fields with any-casts),
+ * key is the specific entity class, so subclasses don't share state.
  */
 const runtimes = new WeakMap<typeof YdbBaseEntity, EntityRuntime>();
 
+/**
+ * Returns the runtime dependencies for an entity class, creating an
+ * empty record if none exists yet.
+ */
 export function getEntityRuntime(target: typeof YdbBaseEntity): EntityRuntime {
   let runtime = runtimes.get(target);
   if (!runtime) {
@@ -71,21 +75,21 @@ export function getEntityRuntime(target: typeof YdbBaseEntity): EntityRuntime {
 }
 
 /**
- * Снимок runtime-состояния сущности ДО применения конфигурации для
- * атомарного отката (#200). Используется configureEntities() и
- * createActiveRecordEntityProvider(): если конфигурация падает после того,
- * как часть runtime уже изменена, restoreEntityRuntime() возвращает сущность
- * ровно в то состояние, в котором она была до вызова.
+ * Snapshot of entity runtime state BEFORE applying configuration for
+ * atomic rollback (#200). Used by configureEntities() and
+ * createActiveRecordEntityProvider(): if configuration fails after
+ * part of runtime has been changed, restoreEntityRuntime() returns the
+ * entity to exactly the state it was in before the call.
  *
- * Контракт (обязателен для корректности поверхностного снимка):
- * конфигурация заменяет только ВЕРХНЕУРОВНЕВЫЕ поля runtime (executor,
- * провайдеры, uuidGenerator, aadFormat, aadReadFallback, scope, transactions,
- * repository, repositoryDeps), присваивая новые значения по ссылке. Ни одно
- * вложенное значение (scope.transactions, repositoryDeps, repository) внутри
- * не мутируется в месте — поэтому копирования ссылок достаточно для точного
- * восстановления прежних ссылок. Если появится поле, которое мутируется
- * в месте (например, `runtime.transactions.ambient = true`), его снимок
- * нужно делать здесь глубоким, а restoreEntityRuntime() — дополнить.
+ * Contract (required for correctness of shallow snapshot):
+ * configuration replaces only TOP-LEVEL runtime fields (executor,
+ * providers, uuidGenerator, aadFormat, aadReadFallback, scope, transactions,
+ * repository, repositoryDeps), assigning new values by reference. No nested
+ * value (scope.transactions, repositoryDeps, repository) is mutated in place
+ * — so copying references is sufficient for exact restoration of previous
+ * references. If a field that mutates in place appears (e.g.,
+ * `runtime.transactions.ambient = true`), its snapshot must be made deep
+ * here, and restoreEntityRuntime() must be extended.
  */
 export function snapshotEntityRuntime(
   entityClass: typeof YdbBaseEntity,
@@ -94,10 +98,11 @@ export function snapshotEntityRuntime(
 }
 
 /**
- * Восстанавливает runtime-состояние сущности из снимка (см.
- * snapshotEntityRuntime). Помимо присваивания сохранённых ссылок удаляет
- * поля, которых не было в снимке: если конфигурация добавила новое поле
- * (не существовавшее до вызова), оно не должно пережить откат.
+ * Restores entity runtime state from snapshot (see
+ * snapshotEntityRuntime). Besides assigning saved references, removes
+ * fields that were not in the snapshot: if configuration added a new
+ * field (one that didn't exist before the call), it must not survive
+ * the rollback.
  */
 export function restoreEntityRuntime(
   entityClass: typeof YdbBaseEntity,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 /**
- * ydb-orm — TypeORM-like ORM для YDB (Yandex Database).
- * Публичный API библиотеки.
+ * ydb-orm — TypeORM-like ORM for YDB (Yandex Database).
+ * Public API of the library.
  */
 
-// Типы и интерфейсы ядра
+// Core types and interfaces
 export type { YdbPrimitive } from './core/types.js';
 export type {
   YdbModuleOptions,
@@ -30,7 +30,7 @@ export type {
   YdbLoggingOptions,
 } from './core/query-logger.js';
 
-// Декораторы
+// Decorators
 export { YdbEntity } from './decorators/entity.decorator.js';
 export { YdbColumn, YdbPrimaryColumn } from './decorators/column.decorator.js';
 export {
@@ -112,7 +112,7 @@ export {
 } from './core/query-limits.js';
 export { executeYdbQuery } from './core/execute-query.js';
 
-// Retry-политика по типу ошибки (#27)
+// Retry policy by error type (#27)
 export {
   runWithRetry,
   computeRetryDelayMs,
@@ -134,7 +134,7 @@ export type {
   YdbRetryRng,
 } from './core/retry.js';
 
-// Репозитории / EntityManager (DI-вариант поверх Active Record)
+// Repositories / EntityManager (DI variant over Active Record)
 export {
   YdbRepository,
   YdbEntityManager,
@@ -142,13 +142,13 @@ export {
 } from './repository/index.js';
 export type { YdbEntityConstructor } from './repository/index.js';
 
-// Persistence / Relations (новое ядро ORM)
+// Persistence / Relations (new ORM core)
 export { YdbEntityPersistence } from './persistence/index.js';
 export { YdbEntityRelations } from './relations/index.js';
 export type { PersistenceDeps } from './persistence/index.js';
 export type { RelationsDeps } from './relations/index.js';
 
-// Шифрование
+// Encryption
 export type {
   YdbEncryptionProvider,
   YdbBlindIndexProvider,
@@ -161,11 +161,11 @@ export {
   DEFAULT_AAD_FORMAT,
 } from './encryption/aad.js';
 export type { AadFormat } from './encryption/aad.js';
-// Тестовая заглушка шифрования вынесена в отдельный пакет
-// @ycforge/js-dev-tools (см. README). Готовые KMS/HMAC-провайдеры —
-// в @ycforge/orm-security-providers.
+// Test encryption stub moved to a separate package
+// @ycforge/js-dev-tools (see README). Ready-to-use KMS/HMAC providers —
+// in @ycforge/orm-security-providers.
 
-// Валидация
+// Validation
 export type {
   YdbValidationProvider,
   YdbValidationOptions,
@@ -178,7 +178,7 @@ export {
   normalizeValidationIssues,
 } from './validation/validation-error.js';
 
-// Метаданные и реестр сущностей
+// Metadata and entity registry
 export { getYdbEntityMetadata } from './metadata/entity-metadata.js';
 export {
   validateEntityMetadata,
@@ -227,7 +227,7 @@ export type {
   YdbSchemaIssue,
 } from './schema/schema-sync.js';
 
-// Транзакции
+// Transactions
 export { YdbTransactionManager } from './transaction/transaction.manager.js';
 export type { RunInTransactionOptions } from './transaction/transaction.manager.js';
 export {
@@ -236,7 +236,7 @@ export {
 } from './transaction/transaction-context.js';
 export type { ActiveTransactionContext } from './transaction/transaction-context.js';
 
-// Миграции
+// Migrations
 export type {
   YdbMigration,
   YdbMigrationClass,
@@ -273,7 +273,7 @@ export {
 } from './migrations/migration-generator.js';
 export type { PlannedMigration } from './migrations/migration-generator.js';
 
-// Подключение без NestJS (CLI, скрипты)
+// Connection without NestJS (CLI, scripts)
 export {
   resolveCredentialsProvider,
   createDriver,
@@ -281,7 +281,7 @@ export {
   validateYdbModuleOptions,
 } from './core/driver.js';
 export { configureEntities } from './core/standalone.js';
-// Независимые ORM-конфигурации в одном процессе (#199).
+// Independent ORM configurations in one process (#199).
 export {
   createOrmScope,
   getDefaultOrmScope,
@@ -292,7 +292,7 @@ export {
 } from './core/orm-scope.js';
 export type { YdbOrmScope } from './core/orm-scope.js';
 export type { YdbCliConfig } from './cli/config.js';
-// Генерация сущности без CLI (#24): программный вход для скриптов/инструментов.
+// Entity generation without CLI (#24): programmatic entry for scripts/tools.
 export type {
   YdbEntitySpec,
   YdbEntityColumnSpec,
@@ -319,7 +319,7 @@ export type {
   EntityCreateWizardOptions,
 } from './cli/entity-wizard.js';
 export { PromptCancelledError } from './cli/prompt.js';
-// Дамп метаданных (#37): программный вход для внешних инструментов (#36 и др.).
+// Metadata dump (#37): programmatic entry for external tools (#36 etc.).
 export {
   buildMetadataDump,
   METADATA_DUMP_FORMAT,
@@ -338,10 +338,10 @@ export type {
   DumpedJoinTable,
   DumpedJoinTableRef,
 } from './cli/metadata-dump.js';
-// Mermaid ER-диаграмма (#36): рендер поверх канонического дампа метаданных.
+// Mermaid ER diagram (#36): render on top of canonical metadata dump.
 export { buildEntityDiagram, writeDiagramFile } from './cli/entity-diagram.js';
 
-// Базовый класс провайдера учётных данных из SDK (#96): тип реэкспортируется,
-// чтобы пользователи могли типизировать свои реализации без прямой
-// зависимости от @ydbjs/auth.
+// Base credentials provider class from SDK (#96): type is re-exported
+// so users can type their implementations without a direct
+// dependency on @ydbjs/auth.
 export type { CredentialsProvider } from '@ydbjs/auth';

--- a/src/metadata/entity-metadata.ts
+++ b/src/metadata/entity-metadata.ts
@@ -1,52 +1,63 @@
 import 'reflect-metadata';
 import { YdbPrimitive } from '../core/types.js';
 
+/** Reflect metadata key for the entity table name. */
 export const YDB_ENTITY_KEY = 'ydb:entity';
+/** Reflect metadata key for the column map (property → YDB type). */
 export const YDB_COLUMNS_KEY = 'ydb:columns';
+/** Reflect metadata key for the primary key column list. */
 export const YDB_PRIMARY_KEYS_KEY = 'ydb:primaryKeys';
+/** Reflect metadata key for encrypted field descriptors. */
 export const YDB_ENCRYPTED_KEY = 'ydb:encrypted';
+/** Reflect metadata key for Security AAD field names. */
 export const YDB_SECURITY_AAD_KEY = 'ydb:security:aad';
+/** Reflect metadata key for JSON-serialized column names. */
 export const YDB_JSON_COLUMNS_KEY = 'ydb:jsonColumns';
 
+/**
+ * Metadata for a single encrypted field (from `@YdbEncrypted`).
+ */
 export interface EncryptedFieldMeta {
   propertyKey: string;
   blindIndex: boolean;
   aadOverride?: string;
-  /**
-   * Ленивая дешифровка: поле не дешифруется при чтении из БД,
-   * а только по явному вызову decryptField()/decryptLazyFields().
-   */
+  /** Lazy decryption: field is not decrypted when reading from DB,
+   * only on explicit call to decryptField()/decryptLazyFields(). */
   lazy?: boolean;
 }
 
+/**
+ * Canonical metadata of an `@YdbEntity`-decorated class, built once per
+ * class and cached for the lifetime of the process.
+ */
 export interface YdbEntityMetadata<T = any> {
   tableName: string;
   schema: Record<string, YdbPrimitive>;
   primaryKeys: string[];
   encryptedFields: EncryptedFieldMeta[];
   aadFields: string[];
-  /** Колонки с автоматической JSON-сериализацией (хранятся как Utf8). */
+  /** Columns with automatic JSON serialization (stored as Utf8). */
   jsonColumns: string[];
   target: new (...args: any[]) => T;
 }
 
 /**
- * Метаданные собираются из Reflect один раз на класс: декораторы
- * отрабатывают при определении класса, до первого запроса.
+ * Metadata is collected from Reflect once per class: decorators
+ * run at class definition time, before the first query.
  */
 const metadataCache = new WeakMap<object, YdbEntityMetadata<any>>();
 
 /**
- * Извлекает метаданные, собранные декораторами @YdbEntity / @YdbColumn.
+ * Extracts metadata collected by @YdbEntity / @YdbColumn decorators.
  *
- * Имя таблицы читается только из СОБСТВЕННЫХ метаданных класса
- * (Reflect.getOwnMetadata, #92): сущностью является только класс,
- * непосредственно декорированный @YdbEntity. Подкласс без собственного
- * @YdbEntity — не сущность: он не наследует tableName родителя и потому
- * не регистрируется вторым классом на его таблицу (иначе buildExpectedSchemas
- * вернул бы дубликаты, а sync патчил одну таблицу дважды). Колонки, PK,
- * шифрование, AAD, JSON и enum при этом продолжают наследоваться по цепочке
- * прототипов с copy-on-write (см. декораторы свойств).
+ * Table name is read only from the class's OWN metadata
+ * (Reflect.getOwnMetadata, #92): an entity is only the class
+ * directly decorated with @YdbEntity. A subclass without its own
+ * @YdbEntity is not an entity: it does not inherit the parent's tableName
+ * and therefore is not registered as a second class on its table (otherwise
+ * buildExpectedSchemas would return duplicates, and sync would patch one
+ * table twice). Columns, PK, encryption, AAD, JSON, and enum still inherit
+ * through the prototype chain with copy-on-write (see property decorators).
  */
 export function getYdbEntityMetadata<T>(
   target: new (...args: any[]) => T,
@@ -83,8 +94,8 @@ export function getYdbEntityMetadata<T>(
     });
   }
 
-  // Шифруемые поля всегда хранятся как Bytes (raw ciphertext) — формат
-  // объявленный в @YdbColumn игнорируется (раньше был base64 в Utf8).
+  // Encrypted fields are always stored as Bytes (raw ciphertext) — format
+  // declared in @YdbColumn is ignored (previously was base64 in Utf8).
   for (const ef of encryptedFields) {
     schema[ef.propertyKey] = 'Bytes';
   }

--- a/src/metadata/entity-registry.ts
+++ b/src/metadata/entity-registry.ts
@@ -1,54 +1,55 @@
 /**
- * Реестр сущностей: декоратор @YdbEntity регистрирует класс в момент
- * загрузки модуля. Нужен schema sync (опция `sync` в forRoot), чтобы
- * находить все сущности без явного списка entities в опциях модуля.
+ * Entity registry: @YdbEntity decorator registers the class at module
+ * load time. Needed for schema sync (`sync` option in forRoot) to find
+ * all entities without an explicit entities list in module options.
  *
- * Важно: класс попадает в реестр только если его файл был импортирован
- * (обычно это происходит через YdbOrmModule.forFeature / импорты модулей NestJS).
+ * Important: a class enters the registry only if its file was imported
+ * (typically via YdbOrmModule.forFeature / NestJS module imports).
  *
- * Владение сущностями (#142): у каждого экземпляра YdbCoreModule (то есть
- * у каждого Nest-приложения) есть собственный скоуп — createEntityScope()
- * вызывается на статической стороне forRootAsync, а провайдеры forFeature
- * привязывают сущности к скоупу СВОЕГО приложения через DI-токен
- * YDB_CORE_SCOPE. Порядок резолва провайдеров роли не играет: сущность
- * физически не может попасть в чужое приложение. Приложение, упавшее
- * с Duplicate YDB module initialization, уносит свои привязки с собой.
+ * Entity ownership (#142): each YdbCoreModule instance (i.e., each
+ * NestJS application) has its own scope — createEntityScope() is called
+ * on the static side of forRootAsync, and forFeature providers bind
+ * entities to THEIR application's scope via the YDB_CORE_SCOPE DI token.
+ * Provider resolution order doesn't matter: an entity physically cannot
+ * end up in a foreign application. An application that fails with
+ * Duplicate YDB module initialization takes its bindings with it.
  *
- * Вне активного приложения (CLI, standalone, unit-тесты)
- * getRegisteredYdbEntities() без аргумента возвращает весь глобальный
- * реестр — прежнее поведение; повторная регистрация идемпотентна (Set).
+ * Outside an active application (CLI, standalone, unit tests),
+ * getRegisteredYdbEntities() without an argument returns the entire
+ * global registry — previous behavior; re-registration is idempotent (Set).
  */
 type EntityCtor = new (...args: any[]) => any;
 
-/** Все задекорированные классы за жизнь процесса (никогда не чистится). */
+/** All decorated classes for the lifetime of the process (never cleared). */
 const registry = new Set<EntityCtor>();
 
-/** Скоуп сущностей одного приложения: обычный Set, им владеет его ядро. */
+/** Scope of entities for one application: a plain Set, owned by its core. */
 export type YdbEntityAppScope = Set<EntityCtor>;
 
-/** Создаёт пустой скоуп для нового экземпляра ядра (вызов из forRootAsync). */
+/** Creates an empty scope for a new core instance (called from forRootAsync). */
 export function createEntityScope(): YdbEntityAppScope {
   return new Set<EntityCtor>();
 }
 
+/** Registers an `@YdbEntity`-decorated class in the process-global registry. */
 export function registerYdbEntity(target: EntityCtor): void {
-  // Декоратор выполняется при загрузке модуля и не знает ни про одно
-  // приложение — регистрация только процессно-глобальная. Привязку к
-  // конкретному приложению делает YdbOrmModule.forFeature (#142).
+  // The decorator runs at module load time and knows about no application —
+  // registration is process-global only. Binding to a specific application
+  // is done by YdbOrmModule.forFeature (#142).
   registry.add(target);
 }
 
 /**
- * Явно привязывает сущности к скоупу конкретного приложения (#142).
+ * Explicitly binds entities to a specific application's scope (#142).
  *
- * Вызывается из фабрики AR-провайдера (YdbOrmModule.forFeature): декоратор
- * @YdbEntity выполняется один раз за жизнь процесса (кеш ESM-модулей),
- * поэтому повторное приложение в том же процессе не «перерегистрирует»
- * свои сущности само — без явной привязки schema sync увидел бы пустой
- * набор. Скоуп приходит через DI-токен YDB_CORE_SCOPE и гарантированно
- * принадлежит контейнеру того приложения, в котором создан провайдер,
- * поэтому привязка корректна и ДО claim ядра (сущность просто ждёт в
- * скоупе будущего приложения), и после него.
+ * Called from the AR provider factory (YdbOrmModule.forFeature): the
+ * @YdbEntity decorator runs once per process lifetime (ESM module cache),
+ * so a re-application in the same process won't "re-register" its entities
+ * on its own — without explicit binding, schema sync would see an empty
+ * set. The scope comes via the YDB_CORE_SCOPE DI token and is guaranteed
+ * to belong to the container of the application where the provider was
+ * created, so the binding is correct both BEFORE the core claim (entity
+ * just waits in the future application's scope) and after it.
  */
 export function requestEntitiesForApp(
   scope: YdbEntityAppScope,
@@ -61,8 +62,9 @@ export function requestEntitiesForApp(
 }
 
 /**
- * Сущности для schema sync/verify. С аргументом — набор конкретного
- * приложения; без аргумента (CLI, standalone) — весь глобальный реестр.
+ * Entities for schema sync/verify. With argument — the set of a specific
+ * application; without argument (CLI, standalone) — the entire global
+ * registry.
  */
 export function getRegisteredYdbEntities(
   scope?: YdbEntityAppScope,

--- a/src/metadata/validate-entity.spec.ts
+++ b/src/metadata/validate-entity.spec.ts
@@ -90,7 +90,7 @@ class EncryptedPk extends YdbBaseEntity {
   uuid: string;
 }
 
-/** AAD-поле Json: объектное значение не имеет детерминированного AAD (#165). */
+/** AAD field of Json type: object value has no deterministic AAD (#165). */
 @YdbEntity('v_aad_json')
 class AadJsonPk extends YdbBaseEntity {
   @YdbSecurityAAD()
@@ -98,7 +98,7 @@ class AadJsonPk extends YdbBaseEntity {
   attributes: unknown;
 }
 
-/** AAD-поле Bytes: допустимый скаляр (base64-нормализация в AAD, #165). */
+/** AAD field of Bytes: valid scalar (base64 normalization in AAD, #165). */
 @YdbEntity('v_aad_bytes')
 class AadBytesPk extends YdbBaseEntity {
   @YdbSecurityAAD()

--- a/src/metadata/validate-entity.ts
+++ b/src/metadata/validate-entity.ts
@@ -14,25 +14,25 @@ import {
 import { getYdbEntityMetadata } from './entity-metadata.js';
 import type { YdbBaseEntity } from '../entity/base-entity.js';
 
-/** Контекст валидации: какие провайдеры настроены в модуле. */
+/** Validation context: which providers are configured in the module. */
 export interface EntityValidationContext {
   encryptionProviderConfigured: boolean;
   blindIndexProviderConfigured: boolean;
 }
 
-/** Строгость диагностики. Модель валидации сейчас различает только 'error'. */
+/** Diagnostic severity. The validation model currently distinguishes only 'error'. */
 export type EntityValidationSeverity = 'error' | 'warning';
 
 /**
- * Структурированная диагностика проблемы в метаданных сущности (#213).
+ * Structured diagnostic of an issue in entity metadata (#213).
  *
- * - `code` — стабильный машинно-читаемый код правила (не менять и не
- *   выводить из текста; новые правила добавляют новые коды, а не парсят строки).
- * - `path` — локус проблемы в метаданных (сущность/поле/отношение), когда
- *   применимо; формат точечный, например `entity.User.email`.
- * - `message` — человекочитаемое описание (прежний текст).
- * - `severity` — строгость; сейчас все проблемы блокируют инициализацию,
- *   но тип оставляет место для будущих предупреждений.
+ * - `code` — stable machine-readable rule code (don't change or derive
+ *   from text; new rules add new codes, not parse strings).
+ * - `path` — locus of the issue in metadata (entity/field/relation),
+ *   when applicable; dot format, e.g., `entity.User.email`.
+ * - `message` — human-readable description (legacy text).
+ * - `severity` — severity; currently all issues block initialization,
+ *   but the type leaves room for future warnings.
  */
 export interface EntityValidationIssue {
   code: string;
@@ -41,12 +41,18 @@ export interface EntityValidationIssue {
   severity: EntityValidationSeverity;
 }
 
-/** Возвращает прежнее человекочитаемое представление диагностики. */
+/**
+ * Returns the legacy human-readable string representation of a
+ * structured validation diagnostic.
+ */
 export function validationIssueToMessage(issue: EntityValidationIssue): string {
   return issue.message;
 }
 
-/** Собирает список диагностик в прежний плоский список человекочитаемых строк. */
+/**
+ * Collects a list of structured diagnostics into the legacy flat list
+ * of human-readable strings.
+ */
 export function validationIssuesToMessages(
   issues: readonly EntityValidationIssue[],
 ): string[] {
@@ -85,19 +91,19 @@ function relationIssue(
 }
 
 /**
- * Типы YDB-колонок, которые нельзя использовать как Security AAD (#165):
- * значения этих колонок — объекты (JSON), и toAadString не имеет для них
- * детерминированного строкового представления.
+ * YDB column types that cannot be used as Security AAD (#165):
+ * values of these columns are objects (JSON), and toAadString has no
+ * deterministic string representation for them.
  */
 const AAD_UNSAFE_TYPES = new Set(['Json', 'JsonDocument']);
 
 /**
- * Валидация метаданных сущности при инициализации модуля.
- * Возвращает прежний плоский список человекочитаемых строк (пустой, если всё
- * в порядке) — обратная совместимость с прежним API.
+ * Validates entity metadata on module initialization.
+ * Returns the legacy flat list of human-readable strings (empty if all
+ * is well) — backward compatibility with the old API.
  *
- * Структурированный вариант с кодами/путями/severity — `validateEntityMetadataIssues`.
- * Чистая функция, без сети.
+ * Structured variant with codes/paths/severity — `validateEntityMetadataIssues`.
+ * Pure function, no network.
  */
 export function validateEntityMetadata(
   entity: typeof YdbBaseEntity,
@@ -107,9 +113,9 @@ export function validateEntityMetadata(
 }
 
 /**
- * Валидация метаданных сущности при инициализации модуля.
- * Возвращает список структурированных диагностик (пустой, если всё в порядке) —
- * вызывающий код решает, как бросать ошибку. Чистая функция, без сети.
+ * Validates entity metadata on module initialization.
+ * Returns a list of structured diagnostics (empty if all is well) —
+ * caller decides how to throw. Pure function, no network.
  */
 export function validateEntityMetadataIssues(
   entity: typeof YdbBaseEntity,
@@ -167,10 +173,10 @@ export function validateEntityMetadataIssues(
       );
     }
 
-    // Гарантия сериализуемости в AAD (#165): AAD-значение обязано быть
-    // скаляром, который toAadString переводит в строку детерминированно.
-    // Json/JsonDocument — объекты, для них шифрование упало бы в рантайме
-    // каждый раз; такое определяем на инициализации, а не в первом save().
+    // AAD serializability guarantee (#165): AAD value must be a scalar
+    // that toAadString converts to a string deterministically.
+    // Json/JsonDocument are objects; encryption would fail at runtime every
+    // time; we catch this at initialization, not on first save().
     const aadType = meta.schema[aadField];
     if (aadType && AAD_UNSAFE_TYPES.has(aadType)) {
       issues.push(
@@ -309,9 +315,9 @@ function validateRelation(
     return issues;
   }
 
-  // Строгий резолв join-колонки (#87): тот же резолвер, что и в рантайме
-  // relations. Невалидный селектор или отсутствие join-колонки — issue с
-  // понятным описанием, а не молчаливо угаданная строка.
+  // Strict join column resolution (#87): same resolver as in runtime
+  // relations. Invalid selector or missing join column — issue with
+  // clear description, not a silently guessed string.
   let joinColumn: string | undefined;
   if (rel.type !== 'many-to-many') {
     try {
@@ -391,10 +397,10 @@ function validateRelation(
         ),
       );
     } else {
-      // Ошибки конфигурации m2m (нет PK, составной PK, невыводимый тип
-      // join-колонки и т.п.) обнаруживаются тем же резолвером, который
-      // строит схему и читает рантайм (#87): module init падает с той же
-      // ошибкой, что позже дали бы schema sync/verify/relations.
+      // m2m configuration errors (no PK, composite PK, non-inferrable
+      // join column type, etc.) are caught by the same resolver that
+      // builds the schema and reads runtime (#87): module init fails with
+      // the same error that schema sync/verify/relations would give later.
       try {
         resolveRelationJoinTableDefinition(
           ownJoin ? entity : Target,

--- a/src/migrations/migration-bookkeeping.spec.ts
+++ b/src/migrations/migration-bookkeeping.spec.ts
@@ -6,7 +6,7 @@ import {
 } from './migration-bookkeeping.js';
 import { MIGRATIONS_TABLE } from './migration-runner.js';
 
-/** Мок executor-а: записывает SQL, отдаёт строки для SELECT. */
+/** Executor mock: records SQL, returns rows for SELECT. */
 function makeExecutor(rows: Record<string, unknown>[] = []) {
   const executedSql: string[] = [];
   const executor: any = jest.fn((strings: TemplateStringsArray) => {
@@ -60,7 +60,7 @@ describe('readBookkeepingSnapshot (#152, read-only)', () => {
 
     expect(snapshot).toEqual({ exists: false, legacy: false, records: [] });
     expect(describeTable).toHaveBeenCalledWith(MIGRATIONS_TABLE);
-    // Ни одного запроса: таблицы нет — читать нечего, создавать нельзя.
+    // No queries at all: no table — nothing to read, nothing to create.
     expect(mock.executedSql).toEqual([]);
   });
 
@@ -92,7 +92,7 @@ describe('readBookkeepingSnapshot (#152, read-only)', () => {
     expect(snapshot.legacy).toBe(false);
     expect(snapshot.records.map((r) => r.name)).toEqual(['1-A', '2-B']);
 
-    // Ровно один голый SELECT, без CREATE/ALTER/probe.
+    // Exactly one bare SELECT, no CREATE/ALTER/probe.
     expect(mock.executedSql).toHaveLength(1);
     const sql = mock.executedSql[0];
     expect(sql).toMatch(
@@ -105,7 +105,7 @@ describe('readBookkeepingSnapshot (#152, read-only)', () => {
     const mock = makeExecutor(rows);
     const describeTable = jest.fn((): Promise<any> =>
       Promise.resolve({
-        // Легаси-таблица до #101: только базовые колонки.
+        // Legacy table before #101: only the base columns.
         columns: new Map([
           ['id', 3 as never],
           ['timestamp', 3 as never],
@@ -133,7 +133,7 @@ describe('readBookkeepingSnapshot (#152, read-only)', () => {
     ]);
 
     const sql = mock.executedSql[0];
-    // Колонки hash/state НЕ запрашиваются и НИЧЕГО не добавляется.
+    // The hash/state columns are NOT requested and NOTHING is added.
     expect(sql).toBe('SELECT `id`, `timestamp`, `name` FROM `ydb_migrations`');
     expect(mock.executedSql.every((s) => !/ALTER/i.test(s))).toBe(true);
   });

--- a/src/migrations/migration-bookkeeping.ts
+++ b/src/migrations/migration-bookkeeping.ts
@@ -1,18 +1,18 @@
 /**
- * Read-only доступ к таблице учёта миграций (#152).
+ * Read-only access to the migration bookkeeping table (#152).
  *
- * Проверка готовности (migration:check/status/show) обязана не менять БД,
- * поэтому путь YdbMigrationRunner.status → ensureMigrationsTable()
- * (CREATE TABLE IF NOT EXISTS + возможный ALTER для легаси-таблиц)
- * ей недоступен. Вместо этого:
- *  1. существование `ydb_migrations` определяется метаданными —
- *     DescribeTable через Table service (`YdbSchemaSyncer.describeTable`,
- *     #91: null только если таблицы действительно нет; остальные ошибки
- *     пробрасываются, ничего не «глотается»);
- *  2. записи читаются голым SELECT только тех колонок, что реально есть:
- *     у легаси-таблиц (созданных до #101) колонок `hash`/`state` может не
- *     быть — вместо ALTER их отсутствие просто учитывается при чтении;
- *  3. никакого DDL и записей здесь нет в принципе.
+ * The readiness check (migration:check/status/show) must not modify the DB,
+ * so the YdbMigrationRunner.status path (ensureMigrationsTable ->
+ * CREATE TABLE IF NOT EXISTS + possible ALTER for legacy tables) is off
+ * limits. Instead:
+ *  1. the existence of `ydb_migrations` is determined via metadata —
+ *     DescribeTable through the Table service (`YdbSchemaSyncer.describeTable`,
+ *     #91: null only when the table is truly absent; any other error
+ *     propagates, nothing is swallowed);
+ *  2. records are read via a bare SELECT of only the columns that actually
+ *     exist: legacy tables (created before #101) may lack `hash`/`state` —
+ *     instead of ALTER, their absence is merely accounted for on read;
+ *  3. no DDL or writes happen here at all.
  */
 import type { Driver } from '@ydbjs/core';
 import { quoteIdentifier } from '../core/sql-utils.js';
@@ -27,34 +27,34 @@ import {
   type AppliedMigration,
 } from './migration-runner.js';
 
-/** Снимок таблицы учёта миграций без каких-либо изменений схемы. */
+/** Snapshot of the migration bookkeeping table without any schema change. */
 export interface MigrationBookkeepingSnapshot {
-  /** Таблица учёта существует. */
+  /** The bookkeeping table exists. */
   exists: boolean;
   /**
-   * Легаси-формат (до #101): колонок `hash`/`state` нет — сопоставление
-   * по имени, все записи подразумеваются применёнными.
+   * Legacy format (pre-#101): the `hash`/`state` columns are absent —
+   * matching is by name and every record is implied applied.
    */
   legacy: boolean;
-  /** Записи учёта в порядке применения. */
+  /** Bookkeeping records in application order. */
   records: AppliedMigration[];
 }
 
-/** Зависимости чтения снимка: драйвер (метаданные) + executor (SELECT). */
+/** Snapshot-read dependencies: driver (metadata) + executor (SELECT). */
 export interface MigrationBookkeepingDeps {
   driver: Driver;
   executor: YdbExecutor;
 }
 
 /**
- * Считывает состояние таблицы учёта БЕЗ создания/изменения.
- * Отсутствие таблицы — нормальный результат ({ exists: false }), а не
- * ошибка: свежая база ещё не инициализирована миграциями.
+ * Reads the state of the bookkeeping table WITHOUT creating or modifying
+ * anything. A missing table is a normal result ({ exists: false }), not an
+ * error: a fresh database has not been initialized with migrations yet.
  */
 export async function readBookkeepingSnapshot(
   deps: MigrationBookkeepingDeps,
   options?: {
-    /** Шов для тестов (по умолчанию DescribeTable через YdbSchemaSyncer). */
+    /** Test seam (defaults to DescribeTable via YdbSchemaSyncer). */
     describeTable?: (tableName: string) => Promise<YdbTableDescription | null>;
   },
 ): Promise<MigrationBookkeepingSnapshot> {

--- a/src/migrations/migration-check.spec.ts
+++ b/src/migrations/migration-check.spec.ts
@@ -61,7 +61,7 @@ describe('evaluateMigrationCheck (#152)', () => {
       status({ name: 'a', applied: true, interrupted: true }),
     ]);
 
-    // Прерванная миграция НЕ считается успешно применённой.
+    // An interrupted migration is NOT considered successfully applied.
     expect(verdict.pending).toEqual([]);
     expect(verdict.interrupted).toEqual(['a']);
     expect(verdict.appliedCount).toBe(0);
@@ -71,7 +71,7 @@ describe('evaluateMigrationCheck (#152)', () => {
   });
 
   it('modified after apply (#101) is its own state', () => {
-    // #212: producer даёт applied=false для изменённой миграции.
+    // #212: the producer gives applied=false for a changed migration.
     const verdict = evaluateMigrationCheck([
       status({ name: 'a', contentChanged: true }),
     ]);
@@ -86,8 +86,9 @@ describe('evaluateMigrationCheck (#152)', () => {
   });
 
   it('#212: a content-changed migration can never satisfy the healthy-applied condition', () => {
-    // Обе формы входа (новая from producer и legacy/ручная с applied=true)
-    // дают один вердикт: не готово, state=modified, appliedCount=0.
+    // Both input forms (new, from the producer, and legacy/manual with
+    // applied=true) yield the same verdict: not ready, state=modified,
+    // appliedCount=0.
     const inputs: YdbMigrationStatus[][] = [
       [status({ name: 'm', contentChanged: true })],
       [status({ name: 'm', applied: true, contentChanged: true })],

--- a/src/migrations/migration-check.ts
+++ b/src/migrations/migration-check.ts
@@ -1,65 +1,66 @@
 /**
- * Ядро проверки готовности схемы БД (#152): чистая функция над статусами
- * миграций (`YdbMigrationRunner.status`) и, опционально, расхождениями
- * схемы (`YdbSchemaSyncer.verify`). Никакого I/O — CLI лишь рендерит
- * результат и выбирает exit-код.
+ * Core of the database schema readiness check (#152): a pure function over
+ * migration statuses (`YdbMigrationRunner.status`) and, optionally, schema
+ * drift (`YdbSchemaSyncer.verify`). No I/O — the CLI merely renders the
+ * result and chooses the exit code.
  *
- * Различимые состояния:
- *  - `ok`           — всё применено (и схема совпадает, если проверялась);
- *  - `pending`      — есть неприменённые миграции;
- *  - `interrupted`  — есть записи `state='started'` (#101): прошлый запуск
- *    оборвался посреди миграции, БД может быть частично изменена;
- *  - `modified`     — содержимое применённой миграции изменилось (#101);
- *  - `schema-drift` — схема БД расходится с метаданными сущностей
- *    (проверяется только если в конфиге CLI заданы entities).
+ * Distinguishable states:
+ *  - `ok`           — everything is applied (and the schema matches, if checked);
+ *  - `pending`      — there are unapplied migrations;
+ *  - `interrupted`  — there are `state='started'` records (#101): a previous
+ *    run broke off mid-migration, the DB may be partially changed;
+ *  - `modified`     — the content of an applied migration changed (#101);
+ *  - `schema-drift` — the DB schema diverges from the entity metadata
+ *    (checked only when entities are configured in the CLI config).
  *
- * Прерванные и изменённые миграции НЕ считаются успешно применёнными —
- * у таких статусов `applied=false` (флаг «причина» сохранён, #212).
- * Orphan-записи (файл удалён после применения) — информационные: сами по
- * себе готовность не ломают, но всегда выводятся в отчёте.
+ * Interrupted and modified migrations are NOT considered successfully
+ * applied — such statuses have `applied=false` (the "reason" flag is kept,
+ * #212). Orphan records (file deleted after application) are informational:
+ * on their own they do not break readiness, but are always shown in the report.
  */
 import type { YdbSchemaIssue } from '../schema/schema-sync.js';
 import type { YdbMigrationStatus } from './migration-runner.js';
 
-/** Состояние готовности схемы БД для migration:check / migration:status. */
+/** Database schema readiness state for migration:check / migration:status. */
 export type MigrationCheckState =
   'ok' | 'pending' | 'interrupted' | 'modified' | 'schema-drift';
 
-/** Состояния, означающие «не готово», в порядке приоритета. */
+/** The "not ready" states, in priority order. */
 export const MIGRATION_CHECK_STATES: readonly Exclude<
   MigrationCheckState,
   'ok'
 >[] = ['interrupted', 'modified', 'pending', 'schema-drift'];
 
+/** Verdict of a readiness evaluation combining migration statuses and optional schema drift. */
 export interface MigrationCheckVerdict {
-  /** true — только когда нет ни одного состояния «не готово». */
+  /** true — only when there is no "not ready" state at all. */
   ready: boolean;
   /**
-   * Определяющее состояние: первое по приоритету из обнаруженных
-   * (или 'ok'). По нему выбирается exit-код команды.
+   * The decisive state: the first by priority among the detected ones
+   * (or 'ok'). The command's exit code is selected from it.
    */
   state: MigrationCheckState;
-  /** Все обнаруженные состояния «не готово» в порядке приоритета. */
+  /** All detected "not ready" states in priority order. */
   states: Array<Exclude<MigrationCheckState, 'ok'>>;
-  /** Всего миграций в директории (без orphan-записей). */
+  /** Total migrations in the directory (excluding orphan records). */
   totalMigrations: number;
   /**
-   * Успешно применённых (без interrupted/modified/orphan) — для отчётов;
-   * готовность определяется полем ready, а не этим числом.
+   * Successfully applied (excluding interrupted/modified/orphan) — for
+   * reports; readiness is determined by the `ready` field, not this number.
    */
   appliedCount: number;
   pending: string[];
   interrupted: string[];
   modified: string[];
-  /** Информационные записи без файла миграции (на exit-код не влияют). */
+  /** Informational records without a migration file (do not affect the exit code). */
   orphaned: string[];
 }
 
 /**
- * Exit-коды `migration:check` / `migration:status` (#152).
- * Детерминированы состоянием; help/успех — 0. Ошибка выполнения
- * команды (подключение, I/O, неожиданное исключение) — отдельный код 5,
- * чтобы CI не путал её с ожидаемым «не готово».
+ * Exit codes for `migration:check` / `migration:status` (#152).
+ * Determined by the state; help/success — 0. A command execution error
+ * (connection, I/O, unexpected exception) is a separate code 5, so CI does
+ * not confuse it with the expected "not ready".
  */
 export const MIGRATION_STATE_EXIT_CODES: Record<MigrationCheckState, number> =
   Object.freeze({
@@ -70,26 +71,26 @@ export const MIGRATION_STATE_EXIT_CODES: Record<MigrationCheckState, number> =
     modified: 4,
   });
 
-/** Exit-код по определяющему состоянию вердикта. */
+/** Exit code for the verdict's decisive state. */
 export function migrationStateExitCode(state: MigrationCheckState): number {
   return MIGRATION_STATE_EXIT_CODES[state];
 }
 
 /**
- * Здоровая «применённая» миграция (#212): единственная точка истины для
- * «applied=true не означает проблему». Изменённая после применения и
- * прерванная миграции сюда не проходят в любой форме входных данных —
- * и новые (applied=false + флаг), и legacy/ручные (applied=true + флаг).
+ * A healthy "applied" migration (#212): the single source of truth that
+ * "applied=true does not mean a problem". Migrations modified after being
+ * applied and interrupted migrations never pass here in any input shape —
+ * neither new (applied=false + flag) nor legacy/manual (applied=true + flag).
  */
 function isHealthilyApplied(status: YdbMigrationStatus): boolean {
   return status.applied && !status.interrupted && !status.contentChanged;
 }
 
 /**
- * Сводит статусы миграций (+ опциональные issues схемы) к вердикту.
- * Приоритет при нескольких состояниях: interrupted > modified >
- * pending > schema-drift — сначала то, что блокирует повторный запуск
- * миграций, потом обычное «не применено», затем информационный drift.
+ * Reduces migration statuses (+ optional schema issues) to a verdict.
+ * Priority with multiple states: interrupted > modified > pending >
+ * schema-drift — first what blocks re-running migrations, then the plain
+ * "not applied", then the informational drift.
  */
 export function evaluateMigrationCheck(
   statuses: YdbMigrationStatus[],
@@ -104,9 +105,9 @@ export function evaluateMigrationCheck(
   for (const status of statuses) {
     if (status.orphan) {
       orphaned.push(status.name);
-      // Orphan-запись в состоянии `started`/с изменённым хешем всё равно
-      // блокирует: она попадает и в соответствующий список проблем.
-      // Чистый applied-orphan — только информационный.
+      // An orphan record in the `started` state or with a changed hash still
+      // blocks: it lands in the corresponding problem list too.
+      // A clean applied orphan is informational only.
       if (!status.interrupted && !status.contentChanged) continue;
     }
     if (status.interrupted) interrupted.push(status.name);

--- a/src/migrations/migration-generator.spec.ts
+++ b/src/migrations/migration-generator.spec.ts
@@ -131,7 +131,7 @@ describe('planMigration', () => {
       'ALTER TABLE `photos` ADD INDEX `photos__title` GLOBAL SYNC ON (`title`)',
       'ALTER TABLE `photos` ADD INDEX `photos__title_width` GLOBAL SYNC ON (`title`, `width`)',
     ]);
-    // down в обратном порядке: индексы удаляются до прочих откатов
+    // down in reverse order: indexes are dropped before other rollbacks
     expect(plan.down).toEqual([
       'ALTER TABLE `photos` DROP INDEX `photos__title_width`',
       'ALTER TABLE `photos` DROP INDEX `photos__title`',
@@ -290,7 +290,7 @@ describe('planMigration', () => {
     expect(plan.up).toEqual([
       'ALTER TABLE `photos` SET (TTL = Interval("P1D") ON `title`)',
     ]);
-    // down восстанавливает прежние настройки TTL из DescribeTable
+    // down restores the previous TTL settings from DescribeTable
     expect(plan.down).toEqual([
       'ALTER TABLE `photos` SET (TTL = Interval("PT2H") ON `width_col` AS SECONDS)',
     ]);
@@ -319,9 +319,9 @@ describe('planMigration', () => {
     expect(plan.up).toEqual([
       'ALTER TABLE `photos` SET (TTL = Interval("P1D") ON `title`)',
     ]);
-    // Регрессия микросекундной точности YDB Interval: прежняя конверсия
-    // через secondsToIsoDuration округляла 1.5s до "PT2S" и ломала откат.
-    // down обязан восстановить дробный TTL ровно ("PT1.5S").
+    // Regression of YDB Interval microsecond precision: the previous
+    // conversion via secondsToIsoDuration rounded 1.5s to "PT2S" and broke
+    // rollback. down must restore the fractional TTL exactly ("PT1.5S").
     expect(plan.down).toEqual([
       'ALTER TABLE `photos` SET (TTL = Interval("PT1.5S") ON `width_col`)',
     ]);
@@ -387,7 +387,7 @@ describe('planMigration composite primary key order (#89)', () => {
 
     expect(plan.up).toEqual([]);
     expect(plan.down).toEqual([]);
-    // Ручная миграция вместо опасного автогенерируемого DDL
+    // A manual migration instead of dangerous auto-generated DDL
     expect(plan.warnings).toEqual([
       'Table "tenant_objects": primary key column order mismatch: ' +
         'expected [tenant_id, id], actual [id, tenant_id] — ' +
@@ -449,10 +449,10 @@ describe('planMigration input validation (#102)', () => {
 });
 
 /**
- * #23: вероятные переименования колонок в migration:generate.
+ * #23: probable column renames in migration:generate.
  */
 describe('planMigration: rename suggestions (#23)', () => {
-  // Сущность переименовала label -> title (тип сохранён)
+  // The entity renamed label -> title (type preserved)
   const renameExpected: ExpectedTableSchema = {
     tableName: 'photos',
     columns: { uuid: 'Uuid', title: 'Utf8' },
@@ -470,13 +470,13 @@ describe('planMigration: rename suggestions (#23)', () => {
     expect(plan.suggestions).toEqual([
       'ALTER TABLE `photos` RENAME COLUMN `label` TO `title`',
     ]);
-    // ADD для переименованной колонки не генерируется
+    // No ADD is generated for the renamed column
     expect(plan.up).toEqual([]);
     expect(plan.down).toEqual([]);
     expect(
       plan.warnings.some((w) => w.includes('may have been renamed to "title"')),
     ).toBe(true);
-    // Лишняя колонка по-прежнему честно числится лишней и не удаляется
+    // The extra column is still honestly listed as extra and not dropped
     expect(plan.warnings.some((w) => w.includes('extra column "label"'))).toBe(
       true,
     );
@@ -541,8 +541,8 @@ describe('planMigration: rename suggestions (#23)', () => {
     );
 
     expect(plan.suggestions).toEqual([]);
-    // Подсказки нет — расхождение PK обрабатывается прежним путём:
-    // колонка добавляется обычным ADD, PK требует ручной миграции.
+    // No hint — the PK mismatch is handled the previous way:
+    // the column is added with a plain ADD, the PK requires a manual migration.
     expect(plan.up).toEqual(['ALTER TABLE `photos` ADD COLUMN `title` Utf8']);
     expect(plan.down).toEqual(['ALTER TABLE `photos` DROP COLUMN `title`']);
     expect(plan.warnings.some((w) => w.includes('primary key mismatch'))).toBe(
@@ -563,7 +563,7 @@ describe('planMigration: rename suggestions (#23)', () => {
     );
 
     expect(plan.suggestions).toEqual([]);
-    // Обычный путь: ADD колонки + установка TTL из метаданных
+    // The normal path: ADD column + set TTL from metadata
     expect(plan.up).toEqual([
       'ALTER TABLE `photos` ADD COLUMN `title` Utf8',
       'ALTER TABLE `photos` SET (TTL = Interval("PT1H") ON `title`)',
@@ -639,7 +639,7 @@ describe('renderMigrationFile', () => {
       suggestions: ['ALTER TABLE `photos` RENAME COLUMN `label` TO `title`'],
     });
 
-    // Подсказка видна в обоих направлениях и явно помечена как неприменённая
+    // The hint is visible in both directions and explicitly marked as not applied
     expect(content).toContain(
       '// SUGGESTION (not applied automatically): possible column rename detected.',
     );
@@ -648,9 +648,9 @@ describe('renderMigrationFile', () => {
         /\/\/ {3}ALTER TABLE `photos` RENAME COLUMN `label` TO `title`;/g,
       ),
     ).toHaveLength(2);
-    // RENAME не исполняется автоматически
+    // RENAME is not executed automatically
     expect(content.match(/await executeSql/g) ?? []).toHaveLength(0);
-    // Плейсхолдер «no statements» не нужен — тело занято подсказкой
+    // The "no statements" placeholder is not needed — the body is taken by the hint
     expect(content).not.toContain('no statements');
   });
 
@@ -670,7 +670,7 @@ describe('renderMigrationFile', () => {
     expect(content).toContain(
       'await executeSql(executor, "ALTER TABLE `photos` DROP INDEX',
     );
-    // Ни один executeSql не содержит RENAME COLUMN
+    // No executeSql contains RENAME COLUMN
     for (const line of content.split('\n')) {
       if (line.includes('await executeSql')) {
         expect(line.includes('RENAME COLUMN')).toBe(false);

--- a/src/migrations/migration-generator.ts
+++ b/src/migrations/migration-generator.ts
@@ -18,25 +18,25 @@ import {
   YdbTtlMetadata,
 } from '../decorators/ttl.decorator.js';
 
-/** План миграции: DDL для up/down и предупреждения о ручных правках. */
+/** Migration plan: DDL for up/down plus warnings about manual edits. */
 export interface PlannedMigration {
   up: string[];
   down: string[];
   warnings: string[];
   /**
-   * Предположения о переименовании колонок (#23): НЕ выполняются и не
-   * применяются автоматически — рендерятся комментариями внутри up()/down()
-   * сгенерированного файла. Для каждой пары соответствующие ADD/DROP
-   * в up/down подавляются: применение переименования — явное решение.
+   * Likely column renames (#23): NOT executed and not applied automatically —
+   * they are rendered as comments inside up()/down() of the generated file.
+   * For each pair the corresponding ADD/DROP in up/down is suppressed:
+   * applying the rename is an explicit decision.
    */
   suggestions?: string[];
 }
 
-/** Восстанавливает YdbTtlMetadata из фактических настроек TTL в БД. */
+/** Reconstructs YdbTtlMetadata from the actual TTL settings in the DB. */
 function ttlMetaFromActual(actual: YdbTableTtl): YdbTtlMetadata {
   return {
-    // expire_after_seconds — целые секунды; конвертация через микросекунды
-    // (точность YDB Interval) без потерь
+    // expire_after_seconds is whole seconds; conversion via microseconds
+    // (the precision of the YDB Interval) is lossless
     interval: microsecondsToIsoDuration(
       actual.expireAfterSeconds * MICROSECONDS_PER_SECOND,
     ),
@@ -46,10 +46,10 @@ function ttlMetaFromActual(actual: YdbTableTtl): YdbTtlMetadata {
 }
 
 /**
- * Валидирует входы planMigration (#102). Массивы сопоставляются строго
- * по индексу (expected[i] ↔ existing[i]) — это часть публичного контракта,
- * поэтому расхождение длин должно падать с понятной ошибкой, а не молча
- * порождать неверный DDL.
+ * Validates planMigration inputs (#102). Arrays are matched strictly by
+ * index (expected[i] <-> existing[i]) — that is part of the public contract,
+ * so a length mismatch must fail with a clear error rather than silently
+ * producing wrong DDL.
  */
 function validatePlanInputs(
   expected: ExpectedTableSchema[],
@@ -80,24 +80,24 @@ function validatePlanInputs(
 }
 
 /**
- * Чистая функция: строит план миграции по ожидаемым схемам сущностей
- * и текущему состоянию БД (null — таблицы нет).
- * Используется `migration:generate`.
+ * Pure function: builds a migration plan from expected entity schemas and the
+ * current DB state (null — the table does not exist).
+ * Used by `migration:generate`.
  *
- * Политика безопасности (#88):
- *  - отсутствующие индексы и TTL создаются в up и откатываются в down;
- *  - лишние индексы и TTL не удаляются — только предупреждение;
- *  - расхождение существующего индекса (unique/колонки) только
- *    диагностируется — пересоздание индекса небезопасно делать молча;
- *  - PK, типы колонок и лишние колонки не меняются (как раньше).
+ * Safety policy (#88):
+ *  - missing indexes and TTL are created in up and rolled back in down;
+ *  - extra indexes and TTL are not removed — only a warning;
+ *  - a divergence of an existing index (unique/columns) is only diagnosed —
+ *    recreating an index silently is unsafe;
+ *  - PK, column types and extra columns are not changed (as before).
  *
- * Вероятные переименования (#23): если ровно одна лишняя колонка БД и одна
- * новая колонка сущности совпадают по типу и не затрагивают PK/индексы/TTL/
- * blind-index, план НЕ генерирует для этой пары ADD/DROP, а кладёт
- * `ALTER TABLE ... RENAME COLUMN ... TO ...` в suggestions (комментарий
- * в файле миграции). YQL пока не поддерживает RENAME COLUMN — применение
- * всегда ручное. При малейшей неоднозначности (несколько кандидатов,
- * участие ключевых колонок и т.п.) поведение прежнее: ADD/DROP + warning.
+ * Likely renames (#23): if exactly one extra DB column and one new entity
+ * column match by type and do not touch PK/indexes/TTL/blind-index, the plan
+ * does NOT generate ADD/DROP for that pair, and instead puts
+ * `ALTER TABLE ... RENAME COLUMN ... TO ...` into suggestions (a comment in
+ * the migration file). YQL does not support RENAME COLUMN yet — applying is
+ * always manual. At the slightest ambiguity (several candidates, key columns
+ * involved, etc.) the previous behavior applies: ADD/DROP + warning.
  */
 export function planMigration(
   expected: ExpectedTableSchema[],
@@ -123,8 +123,9 @@ export function planMigration(
     const check = checkTableSchema(schema, current);
 
     if (!check.primaryKeyMatches) {
-      // #89: перестановка PK-колонок — тоже расхождение (порядок значим),
-      // но DDL не генерируем: PK в YDB не меняется, только ручная миграция.
+      // #89: a reordering of PK columns is also a divergence (order matters),
+      // but no DDL is generated: a PK cannot be altered in YDB, manual
+      // migration required.
       warnings.push(
         `Table "${schema.tableName}": ${describePrimaryKeyMismatch(check)} — ` +
           `YDB cannot alter a primary key, manual migration required`,
@@ -143,8 +144,8 @@ export function planMigration(
       );
     }
 
-    // #23: вероятное переименование — только подсказка, ADD/DROP для пары
-    // подавляются. Лишняя колонка по-прежнему не удаляется автоматически.
+    // #23: likely rename — only a hint, ADD/DROP for the pair is suppressed.
+    // The extra column is still not dropped automatically.
     const renamedTargets = new Set(
       check.likelyRenames.map((rename) => rename.to),
     );
@@ -166,7 +167,7 @@ export function planMigration(
       );
       if (autoAdd.length) {
         up.push(generateAddColumnsYql(schema.tableName, autoAdd));
-        // down — в обратном порядке через unshift, чтобы up/down были симметричны
+        // down — in reverse order via unshift, so that up/down stay symmetric
         for (const [column] of autoAdd) {
           down.unshift(
             `ALTER TABLE ${quoteIdentifier(schema.tableName)} DROP COLUMN ${quoteIdentifier(column)}`,
@@ -175,13 +176,13 @@ export function planMigration(
       }
     }
 
-    // Отсутствующие индексы: создаём в up, удаляем в down (#88).
+    // Missing indexes: create in up, drop in down (#88).
     for (const idx of check.missingIndexes) {
       up.push(generateAddIndexYql(schema.tableName, idx));
       down.unshift(generateDropIndexYql(schema.tableName, idx.name));
     }
 
-    // Существующий индекс расходится с метаданными — только диагностируем.
+    // Existing index diverges from metadata — diagnose only.
     for (const mismatch of check.uniqueMismatches) {
       warnings.push(
         `Table "${schema.tableName}" index "${mismatch.name}": ` +
@@ -197,15 +198,15 @@ export function planMigration(
           `recreate the index manually if needed`,
       );
     }
-    // Лишние индексы никогда не удаляем автоматически.
+    // Extra indexes are never dropped automatically.
     for (const extra of check.extraIndexes) {
       warnings.push(
         `Table "${schema.tableName}" has extra index "${extra.name}" — not dropped automatically`,
       );
     }
 
-    // TTL: отсутствующий ставим, изменённый заменяем; down восстанавливает
-    // прежнее состояние БД (сброс или старые настройки).
+    // TTL: a missing one is set, a changed one is replaced; down restores the
+    // previous DB state (reset or the old settings).
     if (check.missingTtl.length && check.missingTtl[0].expected) {
       up.push(
         generateSetTtlYql(schema.tableName, check.missingTtl[0].expected),
@@ -223,7 +224,7 @@ export function planMigration(
         ),
       );
     }
-    // TTL без метаданных в сущности не сбрасываем автоматически.
+    // TTL that has no metadata in the entity is not reset automatically.
     for (const extra of check.extraTtl) {
       warnings.push(
         `Table "${schema.tableName}" has extra TTL on column "${extra.actual.column}" ` +
@@ -236,9 +237,9 @@ export function planMigration(
 }
 
 /**
- * Рендерит блок комментариев с подсказками о переименовании (#23).
- * Подсказки никогда не попадают в исполняемые statements: YQL не
- * поддерживает RENAME COLUMN, применение — только вручную после проверки.
+ * Renders a comment block with rename hints (#23).
+ * Hints never end up as executable statements: YQL has no RENAME COLUMN,
+ * applying is done manually only after verification.
  */
 function renderSuggestionsBlock(
   suggestions: string[] | undefined,
@@ -253,9 +254,9 @@ function renderSuggestionsBlock(
 }
 
 /**
- * Рендерит файл миграции по плану. Если план пуст — up/down остаются
- * пустыми с комментарием. Подсказки о переименовании рендерятся
- * комментариями внутри up()/down(), а не исполняемыми statements (#23).
+ * Renders a migration file from a plan. If the plan is empty, up/down stay
+ * empty with a comment. Rename hints are rendered as comments inside
+ * up()/down(), not as executable statements (#23).
  */
 export function renderMigrationFile(
   className: string,

--- a/src/migrations/migration-loader.spec.ts
+++ b/src/migrations/migration-loader.spec.ts
@@ -66,8 +66,8 @@ describe('loadMigrationsFromDir', () => {
   });
 
   it('fails clearly for missing directory (#103)', async () => {
-    // Раньше возвращался [] — опечатка в --dir выглядела как
-    // «No pending migrations».
+    // Previously [] was returned — a typo in --dir looked just like
+    // "No pending migrations".
     await expect(
       loadMigrationsFromDir(path.join(dir, 'not-exists')),
     ).rejects.toThrow(/Migration directory does not exist/);
@@ -83,7 +83,7 @@ describe('loadMigrationsFromDir', () => {
 
   describe('#100 regression: deterministic discovery', () => {
     it('ignores *.spec.* and *.test.* files even when they export no migration', async () => {
-      // Раньше такой файл жёстко ронял migration:run/show/check
+      // Previously such a file hard-crashed migration:run/show/check
       writeMigration(
         '1000-Ok.mjs',
         `export default class Ok {
@@ -117,7 +117,7 @@ describe('loadMigrationsFromDir', () => {
     });
 
     it('throws a clear error when a file exports several migration classes', async () => {
-      // Раньше молча брался только первый подошедший класс
+      // Previously only the first matching class was taken silently
       writeMigration(
         '1000-Multi.mjs',
         `${upDownClass('CreateUsers')}
@@ -142,7 +142,7 @@ describe('loadMigrationsFromDir', () => {
     });
 
     it('throws when a helper class with up/down sits next to a real migration', async () => {
-      // Раньше эвристика могла взять helper вместо миграции или наоборот
+      // Previously the heuristic could pick a helper instead of a migration or vice versa
       writeMigration(
         '1000-Mixed.mjs',
         `${upDownClass('SomeHelper')}
@@ -155,7 +155,7 @@ describe('loadMigrationsFromDir', () => {
     });
 
     it('throws on duplicate names from a .ts source and its compiled .js copy', async () => {
-      // Раньше второй файл с тем же именем молча skip-ался в раннере
+      // Previously the second file with the same name was silently skipped in the runner
       fs.writeFileSync(
         path.join(dir, 'package.json'),
         JSON.stringify({ type: 'module' }),
@@ -212,7 +212,7 @@ describe('loadMigrationsFromDir', () => {
     });
 
     it('keeps the hash stable across file renames', async () => {
-      // Переименование файла не должно менять идентичность миграции
+      // Renaming the file must not change the migration identity
       const body = `export default class Stable {
         async up() {}
         async down() {}
@@ -231,8 +231,8 @@ describe('loadMigrationsFromDir', () => {
     });
 
     it('throws when two files have identical content', async () => {
-      // Обе «миграции» применились бы, но вторая упала бы на уже
-      // выполненном DDL — раньше это всплывало только в рантайме БД
+      // Both "migrations" would have applied, but the second would have failed
+      // on already-executed DDL — previously this only surfaced at DB runtime
       const body = `export default class Dup2 {
         async up() {}
         async down() {}
@@ -292,11 +292,11 @@ describe('loadMigrationsFromDir', () => {
     });
 
     it('rejects a declared hash diverging from the file content (tamper/legacy path)', async () => {
-      // #189 upgrade path: у настоящего файла объявленный hash входит в его же
-      // содержимое, поэтому не может совпасть с contentHash — любое объявление
-      // означает подделку либо устаревший шаблон с «записанным» hash. Отказ —
-      // намеренный breaking change: идентичность всегда контентная, середина
-      // «записанный hash = файл» недостижима.
+      // #189 upgrade path: in a real file the declared hash is part of its own
+      // content, so it cannot match the contentHash — any declaration means a
+      // forgery or an outdated template with a hardcoded hash. The rejection is
+      // an intentional breaking change: identity is always content-based, the
+      // middle ground of "declared hash = file" is unreachable.
       const declared = 'b'.repeat(64);
       const body = `export default class EqualHash {
         hash = '${declared}';
@@ -318,8 +318,8 @@ describe('loadMigrationsFromDir', () => {
       writeMigration('1000-Mutable.mjs', body);
       const before = await loadMigrationsFromDir(dir);
 
-      // Повторная загрузка уже выдала бы файл из кеша Node import;
-      // переименование + изменение содержимого имитируют модификацию.
+      // A reload would already return the file from the Node import cache;
+      // renaming + changing the content mimics a modification.
       fs.writeFileSync(
         path.join(dir, '2000-Mutable.mjs'),
         body.concat('\n// touched\n'),
@@ -334,8 +334,9 @@ describe('loadMigrationsFromDir', () => {
 
   describe('missing directory (#103)', () => {
     it('fails clearly instead of returning []', async () => {
-      // Раньше несуществующая директория выглядела как «No pending
-      // migrations» — опечатка в --dir была неотличима от пустой директории.
+      // Previously a nonexistent directory looked like "No pending
+      // migrations" — a typo in --dir was indistinguishable from an empty
+      // directory.
       const missing = path.join(dir, 'no-such-dir');
 
       await expect(loadMigrationsFromDir(missing)).rejects.toThrow(

--- a/src/migrations/migration-loader.ts
+++ b/src/migrations/migration-loader.ts
@@ -6,13 +6,12 @@ import { YdbMigration } from './migration.interface.js';
 
 const MIGRATION_FILE_RE = /\.(ts|mts|js|mjs)$/;
 
-/** Декларации и source map не содержат исполняемого кода миграций. */
+/** Declaration files and source maps contain no executable migration code. */
 const NON_CODE_FILE_RE = /(?:\.d\.ts|\.map)$/;
 
 /**
- * Тестовые файлы никогда не являются миграциями (#100):
- * случайно попавший `*.spec.ts`/`*.test.ts` не должен ронять
- * migration:run/show/check.
+ * Test files are never migrations (#100): a stray `*.spec.ts`/`*.test.ts`
+ * must not break migration:run/show/check.
  */
 const TEST_FILE_RE = /\.(spec|test)\.[^./]+$/;
 
@@ -23,7 +22,7 @@ function isMigrationFileName(file: string): boolean {
   return true;
 }
 
-/** Проверяет, что значение похоже на миграцию: класс или объект с up/down. */
+/** Checks whether a value looks like a migration: a class or object with up/down. */
 function isMigrationLike(candidate: unknown): boolean {
   if (typeof candidate === 'function') {
     const proto = (candidate as { prototype?: unknown }).prototype as
@@ -42,15 +41,15 @@ function isMigrationLike(candidate: unknown): boolean {
 }
 
 interface MigrationCandidate {
-  /** Имена экспортов, указывающих на этот класс/объект (для сообщений об ошибках). */
+  /** Names of the exports pointing at this class/object (for error messages). */
   names: string[];
   create: () => YdbMigration;
 }
 
 /**
- * Собирает все экспорты модуля, похожие на миграцию.
- * Экспорт `default` и именованный экспорт одного и того же класса —
- * один кандидат (дедупликация по значению).
+ * Collects all migration-like exports of a module.
+ * A `default` export and a named export of the same class are a single
+ * candidate (deduplicated by value).
  */
 function collectCandidates(mod: Record<string, any>): MigrationCandidate[] {
   const byValue = new Map<unknown, MigrationCandidate>();
@@ -74,25 +73,25 @@ function collectCandidates(mod: Record<string, any>): MigrationCandidate[] {
 }
 
 /**
- * Загружает миграции из директории: каждый файл `.ts`/`.js`/`.mts`/`.mjs`
- * должен экспортировать ровно одну миграцию (default или именованную).
- * Тестовые (`*.spec.*`, `*.test.*`) и декларационные файлы игнорируются (#100).
- * Node ≥ 22.18 импортирует .ts напрямую (type stripping).
+ * Loads migrations from a directory: every `.ts`/`.js`/`.mts`/`.mjs` file
+ * must export exactly one migration (default or named).
+ * Test (`*.spec.*`, `*.test.*`) and declaration files are ignored (#100).
+ * Node >= 22.18 imports .ts directly (type stripping).
  *
- * Имя миграции = имя файла без расширения (`<timestamp>-<Name>`);
- * сортировка — по имени файла. Файлы с одинаковым именем миграции
- * (например, исходник `.ts` рядом со скомпилированной копией `.js`)
- * приводят к ошибке, а не к молчаливому пропуску.
+ * The migration name is the file name without the extension
+ * (`<timestamp>-<Name>`); ordering is by file name. Files with the same
+ * migration name (e.g., a `.ts` source next to its compiled `.js` copy)
+ * produce an error rather than a silent skip.
  *
- * Каждой миграции присваивается стабильная идентичность (#101): SHA-256
- * содержимого файла (`migration.hash`). Переименование файла идентичность
- * не меняет, поэтому применённая миграция не выполнится повторно.
+ * Each migration gets a stable identity (#101): SHA-256 of the file content
+ * (`migration.hash`). Renaming the file does not change the identity, so an
+ * applied migration is not run again.
  */
 export async function loadMigrationsFromDir(
   dir: string,
 ): Promise<YdbMigration[]> {
-  // Несуществующая директория — ошибка, а не «No pending migrations» (#103):
-  // опечатка в --dir не должна выглядеть как отсутствие миграций.
+  // A nonexistent directory is an error, not "No pending migrations" (#103):
+  // a typo in --dir must not look like an absence of migrations.
   if (!fs.existsSync(dir)) {
     throw new Error(
       `Migration directory does not exist: ${path.resolve(dir)} ` +
@@ -119,9 +118,9 @@ export async function loadMigrationsFromDir(
       .update(fs.readFileSync(filePath))
       .digest('hex');
 
-    // Два файла с одинаковым содержимым — почти наверняка копия (#101):
-    // обе миграции применятся «успешно», но вторая упадёт на уже
-    // выполненном DDL. Раньше это всплывало только в рантайме БД.
+    // Two files with identical content are almost certainly copies (#101):
+    // both would apply "successfully", but the second would fail on
+    // already-executed DDL. Previously this surfaced only at DB runtime.
     const duplicateHashFile = fileByHash.get(contentHash);
     if (duplicateHashFile) {
       throw new Error(
@@ -143,8 +142,8 @@ export async function loadMigrationsFromDir(
           `(expected default or named export of a class or object with up()/down() methods)`,
       );
     }
-    // Несколько миграций в одном файле — неоднозначность (#100):
-    // раньше молча брался первый подошедший экспорт.
+    // Several migrations in one file are ambiguous (#100): previously the first
+    // matching export was silently taken.
     if (candidates.length > 1) {
       const names = candidates
         .flatMap((c) => c.names)
@@ -158,15 +157,15 @@ export async function loadMigrationsFromDir(
 
     const migration = candidates[0].create();
     migration.name ??= file.replace(MIGRATION_FILE_RE, '');
-    // Стабильная идентичность (#101): hash всегда берётся из содержимого
-    // файла. Явный hash в коде миграции не может ни перекрыть её (он никогда
-    // не используется как идентичность — всегда стирается на contentHash),
-    // ни «поручиться» за содержимое: у настоящего файла объявленный hash
-    // входит в его же содержимое, поэтому совпасть с contentHash не может
-    // в принципе, а расхождение = признак подделки/устаревшего шаблона (#169).
-    // Совпадение (теоретически возможное, если хешируемый контент когда-нибудь
-    // перестанет включать литерал объявления) принимается без вреда для
-    // безопасности — идентичность всё равно контентная.
+    // Stable identity (#101): the hash always comes from the file content. A
+    // hash declared in the migration code can neither override it (it is never
+    // used as the identity — always overwritten with contentHash), nor vouch
+    // for the content: in a real file the declared hash is part of its own
+    // content, so it cannot match contentHash in principle, and a mismatch is
+    // a sign of forgery/an outdated template (#169). A match (theoretically
+    // possible if the hashed content ever stops including the declaration
+    // literal) is accepted without harm to security — the identity is
+    // content-based anyway.
     if (migration.hash !== undefined && migration.hash !== contentHash) {
       throw new Error(
         `File ${file} declares its own migration hash ("${migration.hash}") ` +
@@ -179,8 +178,8 @@ export async function loadMigrationsFromDir(
     }
     migration.hash = contentHash;
 
-    // Дубли имени (в т.ч. `.ts` + скомпилированный `.js` рядом) —
-    // раньше второй файл молча skip-ался или дважды применялся в раннере (#100).
+    // Duplicate names (incl. `.ts` + a compiled `.js` next to it) — previously
+    // the second file was silently skipped or applied twice in the runner (#100).
     const duplicateFile = fileByName.get(migration.name);
     if (duplicateFile) {
       throw new Error(

--- a/src/migrations/migration-runner.spec.ts
+++ b/src/migrations/migration-runner.spec.ts
@@ -31,7 +31,7 @@ interface StatefulExecutor {
   rows: Map<string, StoreRow>;
 }
 
-/** Колоночное состояние таблицы учёта для реалистичной модели ALTER (#186). */
+/** Column state of the bookkeeping table for a realistic ALTER model (#186). */
 interface BookkeepingSchema {
   hash: boolean;
   state: boolean;
@@ -48,7 +48,7 @@ const paramString = (param: unknown, fallback = ''): string => {
   return typeof value === 'string' ? value : fallback;
 };
 
-/** Ключ строки (id): Int64 приходит как bigint. */
+/** Row key (id): Int64 arrives as a bigint. */
 const paramKey = (param: unknown): string => {
   const value = paramValue(param);
   if (typeof value === 'bigint' || typeof value === 'number') {
@@ -58,23 +58,23 @@ const paramKey = (param: unknown): string => {
 };
 
 /**
- * Stateful мок executor с PK-уникальностью: имитирует таблицу учёта
- * миграций и атомарность PRIMARY KEY на INSERT (для теста гонок).
+ * Stateful mock executor with PK uniqueness: simulates the migrations
+ * bookkeeping table and PRIMARY KEY atomicity on INSERT (for the race test).
  */
 function createStatefulExecutor(
   options: {
-    /** Начальные строки таблицы учёта. */
+    /** Initial bookkeeping table rows. */
     rows?: (Partial<AppliedMigration> & { timestamp: number })[];
-    /** SELECT-проба legacy-колонок падает (таблица старого формата). */
+    /** The SELECT probe for legacy columns fails (legacy-format table). */
     failProbe?: boolean;
-    /** Внедрить сбой на конкретный SQL. */
+    /** Inject a failure on a specific SQL. */
     failOn?: (sql: string) => Error | undefined;
-    /** Общее хранилище для нескольких раннеров (тест гонок). */
+    /** Shared storage for several runners (race test). */
     store?: Map<string, StoreRow>;
     /**
-     * Общее колоночное состояние таблицы учёта (#186). При заданном schema
-     * мок моделирует реальный ALTER: колонка добавляется ровно один раз,
-     * повторная попытка падает на дубликате (как в YDB).
+     * Shared column state of the bookkeeping table (#186). With a given schema
+     * the mock models a real ALTER: a column is added exactly once, and a
+     * repeated attempt fails on the duplicate (like in YDB).
      */
     schema?: BookkeepingSchema;
   } = {},
@@ -101,8 +101,8 @@ function createStatefulExecutor(
     if (sql.startsWith('CREATE TABLE')) return [];
     if (sql.startsWith('SELECT `hash`')) {
       if (schema) {
-        // Реалистичная модель: проба читает hash/state и валится, пока
-        // хотя бы одной колонки нет.
+        // Realistic model: the probe reads hash/state and fails until
+        // at least one of the columns is missing.
         if (!schema.hash || !schema.state) {
           throw new Error('column `hash` was not found');
         }
@@ -211,8 +211,8 @@ const insertQueries = (mock: StatefulExecutor) =>
   mock.queries.filter((q) => q.sql.startsWith('INSERT INTO'));
 
 /**
- * Барьер на N участников (#186): каждый вызвавший arrive() ждёт, пока
- * не подойдут все — детерминированная точка встречи для теста гонки.
+ * Barrier over N participants (#186): every caller of arrive() waits until
+ * all reach it — a deterministic meeting point for the race test.
  */
 const makeBarrier = (count: number): (() => Promise<void>) => {
   let arrived = 0;
@@ -244,8 +244,9 @@ describe('YdbMigrationRunner (#101)', () => {
     });
 
     it('#186 no-driver runner propagates probe failure without any ALTER', async () => {
-      // Раннер без driver не может подтвердить «колонки нет» по DescribeTable,
-      // поэтому ALTER после произвольного падения SELECT запрещён (#186).
+      // A runner without a driver cannot confirm via DescribeTable that the
+      // column is missing, so ALTER after an arbitrary SELECT failure is
+      // forbidden (#186).
       const mock = createStatefulExecutor({ failProbe: true });
       const runner = new YdbMigrationRunner(mock.executor);
 
@@ -291,7 +292,7 @@ describe('YdbMigrationRunner (#101)', () => {
       ).toHaveLength(0);
     });
 
-    /** Колонки таблицы учёта для DescribeTable-шва (#176). */
+    /** Bookkeeping columns for the DescribeTable seam (#176). */
     const bookkeepingColumns = (hasHash: boolean, hasState: boolean) =>
       new Map<string, unknown>([
         ['id', 3],
@@ -356,7 +357,7 @@ describe('YdbMigrationRunner (#101)', () => {
         mock1.queries.filter((q) => q.sql.startsWith('ALTER TABLE')),
       ).toHaveLength(1);
 
-      // Первый ALTER (`hash`) прошёл; повторный запуск добавляет только `state`.
+      // The first ALTER (`hash`) passed; the rerun adds only `state`.
       hasHash = true;
       const mock2 = createStatefulExecutor({ store });
       const second = new YdbMigrationRunner(
@@ -517,7 +518,7 @@ describe('YdbMigrationRunner (#101)', () => {
     });
 
     it('ensures the table only once per runner instance (#101)', async () => {
-      // Раньше ensureMigrationsTable выполнялся перед каждым чтением
+      // Previously ensureMigrationsTable ran before every read
       const mock = createStatefulExecutor({
         rows: [{ timestamp: 1000, name: '1-First' }],
       });
@@ -535,8 +536,8 @@ describe('YdbMigrationRunner (#101)', () => {
 
   describe('stable identity', () => {
     it('skips an applied migration even after its file was renamed', async () => {
-      // Раньше сопоставление шло только по имени: переименование файла
-      // приводило к повторному применению up()
+      // Previously matching was done only by name: renaming a file
+      // caused up() to be re-applied
       const hash = sha256('create users');
       const mock = createStatefulExecutor({
         rows: [{ timestamp: 1000, name: '100-OldName', hash }],
@@ -552,7 +553,7 @@ describe('YdbMigrationRunner (#101)', () => {
 
     it('matches legacy records without hash by name (backwards compat)', async () => {
       const mock = createStatefulExecutor({
-        rows: [{ timestamp: 1000, name: '1-First' }], // запись старого формата
+        rows: [{ timestamp: 1000, name: '1-First' }], // legacy-format record
       });
       const runner = new YdbMigrationRunner(mock.executor);
       const m1 = migrationFactory('1-First', { hash: sha256('first') });
@@ -584,8 +585,8 @@ describe('YdbMigrationRunner (#101)', () => {
       const idOf = (hash: string) =>
         deriveMigrationRowId(migrationIdentity({ hash } as YdbMigration));
 
-      // Одинаковая идентичность → одинаковый id у любых процессов:
-      // на этом строится атомарный claim через PRIMARY KEY
+      // Same identity → the same id in any process:
+      // this underpins the atomic claim via the PRIMARY KEY
       expect(idOf('h1')).toBe(idOf('h1'));
       expect(idOf('h1')).not.toBe(idOf('h2'));
       expect(Number.isSafeInteger(idOf('h1'))).toBe(true);
@@ -656,7 +657,7 @@ describe('YdbMigrationRunner (#101)', () => {
       const claimIdx = mock.queries.indexOf(inserts[0]);
       expect(upIdx).toBeGreaterThan(claimIdx);
 
-      // claim пишет маркер started и стабильную идентичность до up()
+      // The claim writes the started marker and stable identity before up()
       expect(String(inserts[0].params.state.value)).toBe('started');
       expect(String(inserts[0].params.name.value)).toBe('1-First');
       const updateAfterUp = mock.queries.find((q) =>
@@ -677,11 +678,11 @@ describe('YdbMigrationRunner (#101)', () => {
       ).rejects.toThrow(/failed mid-way and was left in "started" state/);
       expect(failing.up).toHaveBeenCalledTimes(1);
 
-      // Маркер частичного применения остался в таблице
+      // The partial-application marker remains in the table
       const [marker] = [...first.rows.values()];
       expect(marker.state).toBe('started');
 
-      // Повторный запуск отказывается выполнять миграцию заново вслепую
+      // A rerun refuses to re-execute the migration blindly
       const retry = migrationFactory('1-Broken');
       const second = createStatefulExecutor({ store: first.rows });
       await expect(
@@ -701,7 +702,7 @@ describe('YdbMigrationRunner (#101)', () => {
         () => null,
         (error: Error) => error,
       );
-      // Исходная ошибка не потеряна: доступна как cause обёртки
+      // The original error is not lost: available as the wrapper's cause
       expect(failure).toBeInstanceOf(Error);
       expect(failure!.message).toMatch(/failed mid-way/);
       expect((failure as any).cause).toBe(boom);
@@ -709,7 +710,7 @@ describe('YdbMigrationRunner (#101)', () => {
       await runner.markMigrationApplied('1-Broken');
       expect([...mock.rows.values()][0].state).toBe('applied');
 
-      // Следующий run больше не пытается её выполнить
+      // The next run no longer tries to execute it
       const again = migrationFactory('1-Broken');
       const executed = await new YdbMigrationRunner(mock.executor).run([
         again.migration,
@@ -731,7 +732,8 @@ describe('YdbMigrationRunner (#101)', () => {
       await runner.removeMigrationRecord('1-Broken');
       expect(mock.rows.size).toBe(0);
 
-      // Пользователь явно решил откатить схему — миграция применится заново
+      // The user explicitly decided to roll the schema back — the migration
+      // will be applied again
       const fixed = migrationFactory('1-Broken');
       const executed = await new YdbMigrationRunner(mock.executor).run([
         fixed.migration,
@@ -770,9 +772,9 @@ describe('YdbMigrationRunner (#101)', () => {
 
   describe('concurrent runners', () => {
     it('applies a contested migration exactly once (DB-level atomicity)', async () => {
-      // Общее хранилище = одна БД; два независимых процесса-раннера.
-      // id строки детерминирован идентичностью миграции, поэтому оба
-      // процесса претендуют на одну строку и сталкиваются на PK.
+      // Shared storage = one DB; two independent runner processes.
+      // The row id is deterministic from the migration identity, so both
+      // processes claim the same row and collide on the PK.
       const store = new Map<string, StoreRow>();
       const mkExecutor = () => createStatefulExecutor({ store }).executor;
       const runnerA = new YdbMigrationRunner(mkExecutor());
@@ -803,7 +805,7 @@ describe('YdbMigrationRunner (#101)', () => {
         (r): r is PromiseRejectedResult => r.status === 'rejected',
       );
 
-      // Победитель применил миграцию, проигравший упал на своём claim
+      // The winner applied the migration, the loser failed on its own claim
       expect(fulfilled).toHaveLength(1);
       expect(fulfilled[0].value).toEqual(['1-Contested']);
       expect(rejected).toHaveLength(1);
@@ -811,7 +813,7 @@ describe('YdbMigrationRunner (#101)', () => {
         /another migration process is likely running concurrently/,
       );
 
-      // up() выполнился ровно один раз — двойного применения нет
+      // up() ran exactly once — no double application
       expect(mA.up.mock.calls.length + mB.up.mock.calls.length).toBe(1);
 
       const records = [...store.values()];
@@ -822,8 +824,8 @@ describe('YdbMigrationRunner (#101)', () => {
 
   describe('revert consistency', () => {
     it('refuses to revert a record left "started" by an interrupted up()', async () => {
-      // Сбой посреди up() оставил маркер started; revert() не должен
-      // вслепую выполнять down() по частично применённой схеме
+      // A failure mid-up() left a started marker; revert() must not
+      // blindly run down() against a partially applied schema
       const mock = createStatefulExecutor();
       const runner = new YdbMigrationRunner(mock.executor);
       const broken = migrationFactory('1-Broken', {
@@ -840,12 +842,12 @@ describe('YdbMigrationRunner (#101)', () => {
       );
       expect(m.down).not.toHaveBeenCalled();
 
-      // Запись не изменена: состояние разрешается только явно
+      // The record is unchanged: the state is resolved only explicitly
       expect([...mock.rows.values()][0].state).toBe('started');
     });
 
     it('refuses to re-revert after a failed down() left "started"', async () => {
-      // Первая попытка отката упала посреди down(): запись осталась started
+      // The first rollback attempt failed mid-down(): the record stayed started
       const mock = createStatefulExecutor({
         rows: [{ timestamp: 1000, name: '1-First' }],
       });
@@ -857,14 +859,14 @@ describe('YdbMigrationRunner (#101)', () => {
         /Revert of "1-First" failed mid-way/,
       );
 
-      // Повторный revert() отказывается вызывать down() ещё раз
+      // A repeated revert() refuses to call down() again
       const retry = migrationFactory('1-First');
       await expect(
         new YdbMigrationRunner(mock.executor).revert([retry.migration]),
       ).rejects.toThrow(/Cannot revert "1-First"[\s\S]*"started" state/);
       expect(retry.down).not.toHaveBeenCalled();
 
-      // После явного восстановления revert работает как обычно
+      // After an explicit repair, revert works as usual
       await runner.markMigrationApplied('1-First');
       const afterRepair = migrationFactory('1-First');
       const reverted = await new YdbMigrationRunner(mock.executor).revert([
@@ -892,7 +894,7 @@ describe('YdbMigrationRunner (#101)', () => {
       expect(m2.down).toHaveBeenCalled();
       expect(m1.down).not.toHaveBeenCalled();
 
-      // Порядок: маркер намерения → down() → удаление записи
+      // Order: intent marker → down() → record deletion
       const startIdx = mock.queries.findIndex((q) =>
         q.sql.startsWith('UPDATE'),
       );
@@ -902,7 +904,7 @@ describe('YdbMigrationRunner (#101)', () => {
       expect(
         mock.queries.find((q) => q.sql.startsWith('DELETE')),
       ).toBeDefined();
-      expect(mock.rows.size).toBe(1); // осталась только 1-First
+      expect(mock.rows.size).toBe(1); // only 1-First remains
     });
 
     it('keeps the record when down() fails mid-way', async () => {
@@ -919,15 +921,15 @@ describe('YdbMigrationRunner (#101)', () => {
       );
       expect(broken.down).toHaveBeenCalledTimes(1);
 
-      // Запись не молча осталась «применённой»: состояние started
+      // The record did not silently remain "applied": state is started
       const [row] = [...mock.rows.values()];
       expect(row.name).toBe('1-Broken');
       expect(row.state).toBe('started');
     });
 
     it('keeps the record when the delete after down() fails', async () => {
-      // Раньше: down() прошёл, DELETE записи упал — миграция оставалась
-      // recorded как применённая, хотя схема уже откачена.
+      // Previously: down() passed, the record DELETE failed — the migration
+      // stayed recorded as applied even though the schema was already reverted.
       const mock = createStatefulExecutor({
         rows: [{ timestamp: 1000, name: '1-Reverted' }],
         failOn: (sql) =>
@@ -991,7 +993,7 @@ describe('YdbMigrationRunner (#101)', () => {
         },
         {
           name: '2-Interrupted',
-          // #212: прерванная миграция не считается применённой.
+          // #212: an interrupted migration is not considered applied.
           applied: false,
           appliedAt: new Date(2000),
           interrupted: true,
@@ -1023,8 +1025,8 @@ describe('YdbMigrationRunner (#101)', () => {
     });
 
     it('marks a record whose content changed after apply (#152)', async () => {
-      // Запись учёта осталась от старого содержимого; файл миграции
-      // теперь с другим хешем — сопоставление по имени даёт 'changed'.
+      // The record is left from the old content; the migration file
+      // now has a different hash — name-based matching yields 'changed'.
       const mock = createStatefulExecutor({
         rows: [
           {
@@ -1043,7 +1045,7 @@ describe('YdbMigrationRunner (#101)', () => {
       expect(statuses).toEqual([
         {
           name: '1-Edited',
-          // #212: содержимое изменилось — это не «здорово применённая».
+          // #212: the content changed — this is not a "healthy applied".
           applied: false,
           appliedAt: new Date(5000),
           interrupted: false,
@@ -1123,7 +1125,7 @@ describe('YdbMigrationRunner (#101)', () => {
 
       expect(status.contentChanged).toBe(true);
       expect(status.interrupted).toBe(false);
-      // Нормальное «здорово применено» такому статусу не подходит.
+      // A normal "healthy applied" does not match such a status.
       expect(
         status.applied && !status.contentChanged && !status.interrupted,
       ).toBe(false);
@@ -1146,7 +1148,7 @@ describe('YdbMigrationRunner (#101)', () => {
 
     const inserts = insertQueries(mock);
     expect(inserts).toHaveLength(2);
-    // id детерминирован хешем содержимого
+    // The id is deterministic from the content hash
     expect(String(inserts[0].params.id.value)).toBe(
       String(deriveMigrationRowId(hashA)),
     );

--- a/src/migrations/migration-runner.ts
+++ b/src/migrations/migration-runner.ts
@@ -9,54 +9,58 @@ import {
 } from '../schema/schema-sync.js';
 import { YdbMigration, executeSql } from './migration.interface.js';
 
-/** Таблица учёта применённых миграций. */
+/** Bookkeeping table recording applied migrations. */
 export const MIGRATIONS_TABLE = 'ydb_migrations';
 
-/** Состояние записи учёта миграции (#101). */
+/** State of a migration's bookkeeping record (#101). */
 export type MigrationRecordState = 'applied' | 'started';
 
+/** One bookkeeping record of an applied migration. */
 export interface AppliedMigration {
   id: number;
   timestamp: number;
   name: string;
   /**
-   * Стабильный идентификатор содержимого (SHA-256, #101).
-   * Отсутствует у записей старого формата (до появления колонки `hash`).
+   * Stable content-based identity (SHA-256, #101).
+   * Absent for old-format records (created before the `hash` column existed).
    */
   hash?: string;
   /**
-   * `started` — миграция начата, но не завершена: маркер частичного
-   * применения после сбоя (DDL в YDB не транзакционен).
-   * У записей старого формата подразумевается `applied`.
+   * `started` — the migration was begun but not finished: a marker of a
+   * partially applied migration after a failure (DDL in YDB is
+   * non-transactional). For old-format records `applied` is implied.
    */
   state: MigrationRecordState;
 }
 
+/** Status of one migration relative to the bookkeeping table. */
 export interface YdbMigrationStatus {
   name: string;
   /**
-   * Только «здорово применённая» миграция (#212): запись учёта есть,
-   * состояние не `started` и содержимое не менялось. Изменённая после
-   * применения (`contentChanged`) и прерванная (`interrupted`) миграции
-   * НЕ считаются applied — флаг несёт истинную причину, чтобы
-   * консьюмеры, проверяющие только `applied`, не приняли их за здоровые.
+   * True only for a "healthily applied" migration (#212): a bookkeeping
+   * record exists, the state is not `started`, and the content is unchanged.
+   * Migrations modified after being applied (`contentChanged`) and
+   * interrupted (`interrupted`) ones are NOT counted as applied — the flag
+   * carries the true reason so consumers that check only `applied` do not
+   * mistake them for healthy ones.
    */
   applied: boolean;
   appliedAt?: Date;
-  /** Запись есть в БД, но среди переданных миграций её нет (файл удалён). */
+  /** A record exists in the DB, but no matching migration was passed (file deleted). */
   orphan?: boolean;
-  /** Миграция помечена начатой (`state = 'started'`), но не завершена. */
+  /** The migration was marked started (`state = 'started'`) but never finished. */
   interrupted?: boolean;
   /**
-   * Содержимое файла изменилось после применения (#101): запись учёта
-   * сопоставлена по имени, но хеш различается. Для проверок готовности
-   * это «не успешно применённая» миграция (applied=false) — нужен явный
-   * reconcile (восстановить содержимое или removeMigrationRecord).
+   * The file content changed after the migration was applied (#101): the
+   * bookkeeping record was matched by name, but the hashes differ. For
+   * readiness checks this is NOT a successfully applied migration
+   * (applied=false) — an explicit reconcile is required (restore the
+   * content or call removeMigrationRecord).
    */
   contentChanged?: boolean;
 }
 
-/** Имя миграции или понятная ошибка. */
+/** Returns the migration name, or a descriptive error if it has none. */
 export function migrationName(migration: YdbMigration): string {
   if (!migration.name) {
     throw new Error(
@@ -68,30 +72,29 @@ export function migrationName(migration: YdbMigration): string {
 }
 
 /**
- * Стабильная идентичность миграции (#101): хеш содержимого, а при его
- * отсутствии — имя. Переименование файла идентичность не меняет, поэтому
- * применённая миграция не выполняется повторно под новым именем.
+ * Stable migration identity (#101): the content hash, or the name if no
+ * hash is set. Renaming a file does not change the identity, so an applied
+ * migration is not re-run under a new name.
  */
 export function migrationIdentity(migration: YdbMigration): string {
   return migration.hash ?? migrationName(migration);
 }
 
 /**
- * Детерминированный id строки учёта из идентичности миграции (#101):
- * первые 13 hex-символов SHA-256 (52 бита — диапазон безопасных целых,
- * значение не искажается при переводе в number).
+ * Deterministic bookkeeping row id derived from the migration identity (#101):
+ * the first 13 hex characters of the SHA-256 (52 bits — within the
+ * safe-integer range, so the value survives conversion to number).
  *
- * Два параллельных процесса претендуют на одну и ту же миграцию →
- * вычисляют один и тот же id → конфликт PRIMARY KEY на INSERT-claim.
- * Так защита от гонки обеспечивается атомарно на уровне БД, а не
- * внутрипроцессным локом.
+ * Two concurrent processes claiming the same migration compute the same id ->
+ * PRIMARY KEY conflict on the INSERT claim. The race guard is thus enforced
+ * atomically at the DB level rather than by an in-process lock.
  */
 export function deriveMigrationRowId(identity: string): number {
   const hex = createHash('sha256').update(identity, 'utf8').digest('hex');
   return Number.parseInt(hex.slice(0, 13), 16);
 }
 
-/** Порядок применения: по timestamp, затем по id (id больше не хронологичен). */
+/** Application order: by timestamp, then by id (ids are no longer chronological). */
 function byChronology(a: AppliedMigration, b: AppliedMigration): number {
   return a.timestamp - b.timestamp || a.id - b.id;
 }
@@ -107,15 +110,15 @@ function appliedFromRow(row: Record<string, any>): AppliedMigration {
 }
 
 /**
- * Маппинг строки таблицы учёта в запись; экспортируется для read-only
- * снимка (migration-bookkeeping.ts). Отсутствующие hash/state — легаси-
- * формат до #101: подразумевается applied, сопоставление по имени.
+ * Maps a bookkeeping table row into a record; exported for the read-only
+ * snapshot (migration-bookkeeping.ts). Missing hash/state is the legacy
+ * pre-#101 format: `applied` is implied and matching is by name.
  */
 export const appliedRecordFromRow = appliedFromRow;
 
 /**
- * Дубликаты во входном массиве — ошибка (#101): раньше второй дубликат
- * молча skip-ался (или применялся повторно).
+ * Duplicates in the input array are an error (#101): previously the second
+ * duplicate was silently skipped (or applied again).
  */
 function assertNoDuplicates(migrations: YdbMigration[]): void {
   const byName = new Map<string, YdbMigration>();
@@ -165,11 +168,12 @@ type MatchResult =
   | { kind: 'pending' };
 
 /**
- * Сопоставляет миграцию с записью учёта (#101):
- *  1. по стабильному хешу содержимого — переименование файла не страшно;
- *  2. по имени, если у записи нет хеша (legacy-записи старого формата);
- *  3. имя совпадает, а хеши различаются → содержимое изменили после
- *     применения — выполнение такой миграции опасно, нужен явный reconcile.
+ * Matches a migration against a bookkeeping record (#101):
+ *  1. by the stable content hash — file renames are harmless;
+ *  2. by name, when the record has no hash (legacy old-format records);
+ *  3. names match but hashes differ -> content was modified after being
+ *     applied — running such a migration is unsafe, an explicit reconcile
+ *     is required.
  */
 function matchAppliedRecord(
   index: AppliedIndex,
@@ -191,7 +195,7 @@ function matchAppliedRecord(
   return { kind: 'pending' };
 }
 
-/** Ищет класс миграции для записи учёта (приоритет — точное совпадение хеша). */
+/** Finds the migration class for a bookkeeping record (prefers an exact hash match). */
 function findMigrationForRecord(
   migrations: YdbMigration[],
   record: AppliedMigration,
@@ -199,11 +203,11 @@ function findMigrationForRecord(
   if (record.hash) {
     return migrations.find((m) => m.hash === record.hash);
   }
-  // Legacy-записи без хеша сопоставляем только по имени.
+  // Legacy records without a hash are matched by name only.
   return migrations.find((m) => migrationName(m) === record.name);
 }
 
-/** Есть ли у записи учёта соответствие среди переданных миграций. */
+/** Whether the record has a matching migration among the passed ones. */
 function recordMatchesMigration(
   record: AppliedMigration,
   migrations: YdbMigration[],
@@ -216,9 +220,10 @@ function recordMatchesMigration(
 }
 
 /**
- * Чистое сопоставление «файлы миграций ↔ записи учёта» без обращения к БД:
- * используется и YdbMigrationRunner.status (обслуживающий путь с ensure),
- * и read-only проверка готовности (#152, снимок из readBookkeepingSnapshot).
+ * Pure matching of "migration files <-> bookkeeping records" without touching
+ * the DB: used both by YdbMigrationRunner.status (the serving path with
+ * ensure) and by the read-only readiness check (#152, snapshot from
+ * readBookkeepingSnapshot).
  */
 export function computeMigrationStatuses(
   migrations: YdbMigration[],
@@ -235,21 +240,21 @@ export function computeMigrationStatuses(
     }
     return {
       name,
-      // `applied` — только здорово применённая (#212): изменённая после
-      // применения или прерванная миграция applied не считается.
+      // `applied` — only healthily applied (#212): a modified-after-application
+      // or interrupted migration is not considered applied.
       applied: match.kind === 'matched' && match.record.state !== 'started',
       appliedAt: new Date(match.record.timestamp),
       interrupted: match.record.state === 'started',
-      // Имя совпадает, а хеш содержимого различается (#101): файл меняли
-      // после применения. Для проверки готовности это не «успешно
-      // применённая» миграция — состояние фиксируется явно.
+      // The name matches but the content hash differs (#101): the file was
+      // modified after being applied. For the readiness check this is not a
+      // successfully applied migration — the state is flagged explicitly.
       contentChanged: match.kind === 'changed' || undefined,
     };
   });
 
-  // Orphan-записи (#101): применены, но файла миграции уже нет.
-  // Чистый orphan — информационный (applied=true); orphan в состоянии
-  // `started` — прерванный, applied=false (#212).
+  // Orphan records (#101): applied, but the migration file no longer exists.
+  // A clean orphan is informational (applied=true); an orphan in the
+  // `started` state is interrupted, applied=false (#212).
   for (const record of applied) {
     if (recordMatchesMigration(record, migrations)) continue;
     statuses.push({
@@ -270,41 +275,43 @@ const RECOVERY_HINT =
   `markMigrationApplied(...) or removeMigrationRecord(...).`;
 
 /**
- * Исполнитель миграций: ведёт таблицу `ydb_migrations`,
- * применяет новые миграции по порядку и откатывает последнюю.
+ * Migration executor: maintains the `ydb_migrations` bookkeeping table,
+ * applies new migrations in order, and reverts the latest one.
  *
- * DDL в YDB не транзакционен, поэтому миграции выполняются последовательно
- * без обёртки в транзакцию (#101):
- *  - перед `up()`/`down()` в таблицу учёта пишется маркер `state='started'`;
- *  - сбой посреди миграции оставляет этот маркер — повторный `run()` не
- *    начнёт миграцию заново вслепую, пока состояние не разрешат явно через
- *    `markMigrationApplied()` / `removeMigrationRecord()`;
- *  - claim на применение — INSERT с детерминированным id (из хеша
- *    содержимого): параллельные процессы сталкиваются на PRIMARY KEY,
- *    двойное применение невозможно.
+ * DDL in YDB is non-transactional, so migrations run sequentially without a
+ * wrapping transaction (#101):
+ *  - a `state='started'` marker is written to the bookkeeping table before
+ *    `up()`/`down()`;
+ *  - a failure mid-migration leaves that marker — a subsequent `run()` will
+ *    not blindly re-start the migration until the state is explicitly resolved
+ *    via `markMigrationApplied()` / `removeMigrationRecord()`;
+ *  - claiming an application is an INSERT with a deterministic id (derived
+ *    from the content hash): concurrent processes collide on PRIMARY KEY,
+ *    so double application is impossible.
  */
 export class YdbMigrationRunner {
-  /** Кеш ensure: один round-trip на инстанс вместо каждого чтения (#101). */
+  /** Ensure cache: one round-trip per instance instead of per read (#101). */
   private ensurePromise?: Promise<void>;
 
   constructor(
     private readonly executor: YdbExecutor,
     /**
-     * Драйвер нужен для гарантированного апгрейда легаси-таблицы учёта
-     * (#176): DescribeTable через Table service отличает «колонки нет»
-     * от транзиентной ошибки, SELECT-проба этого не умела.
+     * The driver is required for a guaranteed upgrade of the legacy
+     * bookkeeping table (#176): DescribeTable through the Table service
+     * distinguishes "column missing" from a transient error, which a
+     * SELECT probe could not.
      */
     private readonly driver?: Driver,
     /**
-     * Шов для тестов поверх пути DescribeTable.
-     * Возвращает null, если таблицы не существует (или схему читать нельзя).
+     * Test seam over the DescribeTable path.
+     * Returns null when the table does not exist (or the schema is unreadable).
      */
     private readonly describeTable?: (
       tableName: string,
     ) => Promise<YdbTableDescription | null>,
   ) {}
 
-  /** Создаёт таблицу учёта миграций, если её ещё нет (один раз на инстанс). */
+  /** Creates the migration bookkeeping table if it is missing (once per instance). */
   async ensureMigrationsTable(): Promise<void> {
     this.ensurePromise ??= this.doEnsureMigrationsTable().catch((error) => {
       this.ensurePromise = undefined;
@@ -322,13 +329,13 @@ export class YdbMigrationRunner {
         ')',
     );
 
-    // Апгрейд таблицы старого формата (созданной до #101): колонок
-    // `hash`/`state` может не быть. Колонки добавляются ТОЛЬКО по реальным
-    // метаданным DescribeTable (#176): Select-проба не отличала отсутствие
-    // колонки от транзиентной/авторизационной ошибки, а безусловная пара
-    // ALTER не переживала частичного апгрейда (сбой между ALTER оставлял
-    // таблицу в состоянии, при котором повторный запуск падал на
-    // дубликате колонки и никогда не доходил до второй).
+    // Upgrade of an old-format table (created before #101): the `hash`/`state`
+    // columns may be absent. Columns are added ONLY based on real DescribeTable
+    // metadata (#176): a SELECT probe could not tell a missing column from a
+    // transient/authorization error, and an unconditional ALTER pair could not
+    // survive a partial upgrade (a failure between the ALTERs left the table so
+    // that a re-run crashed on the duplicate column and never reached the
+    // second one).
     let description: YdbTableDescription | null = null;
     if (this.driver || this.describeTable) {
       description = await this.describeMigrationsTable();
@@ -343,13 +350,13 @@ export class YdbMigrationRunner {
       return;
     }
 
-    // Легаси-путь для раннеров, созданных без driver (программный вызов):
-    // DescribeTable недоступен, поэтому SELECT-проба не отличает «колонки
-    // нет» от транзиентной/авторизационной ошибки. Делать ALTER после
-    // произвольного падения пробы небезопасно (#186): без надёжно
-    // подтверждённого отсутствия колонки ошибка пробрасывается без DDL.
-    // В CLI и NestJS-путях всегда передаётся driver — там апгрейд
-    // выполняется по реальным метаданным DescribeTable.
+    // Legacy path for runners created without a driver (programmatic use):
+    // DescribeTable is unavailable, so a SELECT probe cannot tell a missing
+    // column from a transient/authorization error. Running ALTER after an
+    // arbitrary probe failure is unsafe (#186): without a reliably confirmed
+    // absence of the column, the error is rethrown without any DDL.
+    // The CLI and NestJS paths always pass a driver — there the upgrade runs
+    // on real DescribeTable metadata.
     try {
       await executeSql(
         this.executor,
@@ -369,12 +376,12 @@ export class YdbMigrationRunner {
   }
 
   /**
-   * Добавляет отсутствующую колонку с идемпотентным исходом при гонке (#186):
-   * если ALTER упал, но колонка по факту уже есть (её добавил конкурентный
-   * процесс или предыдущий заход), результат читается из реальных метаданных
-   * DescribeTable, а не из текста ошибки. Любая иная ошибка (нет прав,
-   * транзиентная) пробрасывается без изменений — таблица остаётся в исходном
-   * состоянии, повторный запуск восстановит апгрейд.
+   * Adds a missing column with an idempotent outcome under a race (#186):
+   * if the ALTER failed but the column actually exists already (added by a
+   * concurrent process or a previous attempt), the result is read from the
+   * real DescribeTable metadata rather than from the error text. Any other
+   * error (missing privileges, transient) is rethrown unchanged — the table
+   * stays in its original state and a re-run restores the upgrade.
    */
   private async addColumnIfMissing(column: string): Promise<void> {
     try {
@@ -386,16 +393,16 @@ export class YdbMigrationRunner {
     } catch (error) {
       const now = await this.describeMigrationsTable().catch(() => null);
       if (now && now.columns.has(column)) {
-        return; // конкурент уже привёл таблицу к цели
+        return; // a concurrent process already brought the table to the target state
       }
       throw error;
     }
   }
 
   /**
-   * Метаданные таблицы учёта через существующий путь DescribeTable.
-   * Ошибки DescribeTable (нет прав, транзиентные) пробрасываются наверх
-   * без ALTER — только явное отсутствие колонки ведёт к ALTER (#176).
+   * Metadata of the bookkeeping table via the existing DescribeTable path.
+   * DescribeTable errors (missing privileges, transient) propagate without
+   * any ALTER — only a clearly missing column leads to ALTER (#176).
    */
   private async describeMigrationsTable(): Promise<YdbTableDescription | null> {
     if (this.describeTable) {
@@ -409,7 +416,7 @@ export class YdbMigrationRunner {
     return null;
   }
 
-  /** Список применённых миграций в порядке применения. */
+  /** Applied migrations in application order. */
   async getAppliedMigrations(): Promise<AppliedMigration[]> {
     await this.ensureMigrationsTable();
     const sets = (await this.executor([
@@ -420,8 +427,8 @@ export class YdbMigrationRunner {
   }
 
   /**
-   * Применяет все неприменённые миграции по порядку.
-   * Возвращает имена выполненных миграций.
+   * Applies all unapplied migrations in order.
+   * Returns the names of the executed migrations.
    */
   async run(migrations: YdbMigration[]): Promise<string[]> {
     assertNoDuplicates(migrations);
@@ -459,8 +466,8 @@ export class YdbMigrationRunner {
       try {
         await migration.up(this.executor);
       } catch (error) {
-        // Маркер `started` остаётся: следующему запуску запрещено
-        // выполнять up() заново вслепую (#101).
+        // The `started` marker remains: the next run is forbidden from
+        // executing up() again blindly (#101).
         throw new Error(
           `Migration "${name}" failed mid-way and was left in "started" state — ` +
             `the database may be partially migrated. ${RECOVERY_HINT}`,
@@ -474,10 +481,10 @@ export class YdbMigrationRunner {
   }
 
   /**
-   * Откатывает последнюю применённую миграцию.
-   * Возвращает её имя или null, если откатывать нечего.
-   * Отказывается работать, если последняя запись в состоянии `started`
-   * (прерванный up()/упавший down()) — сначала разрешите её явно через
+   * Reverts the most recently applied migration.
+   * Returns its name, or null when there is nothing to revert.
+   * Refuses to run if the latest record is in the `started` state
+   * (an interrupted up()/a failed down()) — resolve it explicitly first via
    * markMigrationApplied()/removeMigrationRecord().
    */
   async revert(migrations: YdbMigration[]): Promise<string | null> {
@@ -487,8 +494,8 @@ export class YdbMigrationRunner {
 
     const last = applied[applied.length - 1];
     if (last.state === 'started') {
-      // Прерванный up()/упавший down(): схема в неизвестном состоянии,
-      // слепой повторный down() запрещён (#101).
+      // Interrupted up()/failed down(): the schema is in an unknown state,
+      // a blind re-run of down() is forbidden (#101).
       throw new Error(
         `Cannot revert "${last.name}": its bookkeeping record is in "started" state — ` +
           `a previous run was interrupted mid-way, so the database state is unknown. ` +
@@ -504,8 +511,9 @@ export class YdbMigrationRunner {
       );
     }
 
-    // Маркер намерения до down(): падение между down() и DELETE записи
-    // оставит запись в "started" — состояние придётся разрешить явно (#101).
+    // Intent marker before down(): a failure between down() and the record
+    // DELETE leaves the record in "started" — the state then has to be
+    // resolved explicitly (#101).
     await this.startRecord(last.id);
     try {
       await migration.down(this.executor);
@@ -522,12 +530,12 @@ export class YdbMigrationRunner {
   }
 
   /**
-   * Статус по всем переданным миграциям (+ orphan/interrupted записи).
+   * Status across all passed migrations (plus orphan/interrupted records).
    *
-   * ВНИМАНИЕ: это «обслуживающий» путь — он создаёт таблицу учёта, если её
-   * нет (ensureMigrationsTable). Read-only потребители (проверка готовности
-   * #152) должны использовать computeMigrationStatuses поверх снимка из
-   * readBookkeepingSnapshot — без DDL.
+   * NOTE: this is a "serving" path — it creates the bookkeeping table if it
+   * is missing (ensureMigrationsTable). Read-only consumers (readiness check
+   * #152) should use computeMigrationStatuses over a snapshot from
+   * readBookkeepingSnapshot — without DDL.
    */
   async status(migrations: YdbMigration[]): Promise<YdbMigrationStatus[]> {
     const applied = await this.getAppliedMigrations();
@@ -535,10 +543,10 @@ export class YdbMigrationRunner {
   }
 
   /**
-   * Механизм восстановления (#101): явно помечает миграцию применённой.
-   * Вызывается, когда схема БД приведена в целевое состояние вручную
-   * после прерванного запуска.
-   * Принимает объект миграции или строку (хеш либо имя).
+   * Recovery mechanism (#101): explicitly marks a migration as applied.
+   * Use it when the database schema has been brought to the target state
+   * manually after an interrupted run.
+   * Accepts a migration object or a string (hash or name).
    */
   async markMigrationApplied(target: YdbMigration | string): Promise<void> {
     const record = await this.resolveRecord(target);
@@ -546,17 +554,17 @@ export class YdbMigrationRunner {
   }
 
   /**
-   * Механизм восстановления (#101): удаляет запись учёта — миграция
-   * считается полностью откаченной вручную. Осторожно: удаление записи
-   * применённой миграции приведёт к повторному выполнению up().
-   * Принимает объект миграции или строку (хеш либо имя).
+   * Recovery mechanism (#101): deletes a bookkeeping record — the migration
+   * is considered fully rolled back manually. Caution: deleting the record
+   * of an applied migration will cause up() to run again.
+   * Accepts a migration object or a string (hash or name).
    */
   async removeMigrationRecord(target: YdbMigration | string): Promise<void> {
     const record = await this.resolveRecord(target);
     await this.deleteRecord(record.id);
   }
 
-  /** Резервирует применение миграции: INSERT с state='started'. */
+  /** Claims the migration for application: INSERT with state='started'. */
   private async claim(id: number, migration: YdbMigration): Promise<void> {
     const name = migrationName(migration);
     try {
@@ -620,7 +628,7 @@ export class YdbMigrationRunner {
     await query;
   }
 
-  /** Находит запись учёта по объекту миграции или строке (хеш либо имя). */
+  /** Finds a bookkeeping record by a migration object or a string (hash or name). */
   private async resolveRecord(
     target: YdbMigration | string,
   ): Promise<AppliedMigration> {

--- a/src/migrations/migration.interface.ts
+++ b/src/migrations/migration.interface.ts
@@ -1,34 +1,34 @@
 import { YdbExecutor } from '../core/interfaces.js';
 
 /**
- * Миграция БД (аналог MigrationInterface в TypeORM).
- * Имя миграции — из имени файла: `<timestamp>-<Name>` (например,
- * `1755000000000-CreateUsers`). Порядок выполнения — по имени файла.
+ * A database migration (analogous to TypeORM's MigrationInterface).
+ * The migration name comes from the file name: `<timestamp>-<Name>` (e.g.,
+ * `1755000000000-CreateUsers`). Migrations run in file-name order.
  */
 export interface YdbMigration {
-  /** Имя миграции. Если не задано, runner возьмёт имя файла. */
+  /** Migration name. If not set, the runner falls back to the file name. */
   name?: string;
 
   /**
-   * Стабильный идентификатор содержимого (#101). Заполняется загрузчиком
-   * (SHA-256 содержимого файла), поэтому переименование файла не приводит
-   * к повторному применению миграции.
+   * Stable content-based identity (#101). Populated by the loader as the
+   * SHA-256 of the file content, so renaming the file does not re-apply
+   * an applied migration.
    */
   hash?: string;
 
-  /** Применить миграцию. */
+  /** Apply the migration. */
   up(executor: YdbExecutor): Promise<void>;
 
-  /** Откатить миграцию. */
+  /** Roll the migration back. */
   down(executor: YdbExecutor): Promise<void>;
 }
 
-/** Класс миграции (то, что экспортируется из файла миграции). */
+/** A migration class (what a migration file exports). */
 export type YdbMigrationClass = new () => YdbMigration;
 
 /**
- * Выполняет произвольный YQL (DDL/DML) через executor.
- * Вспомогательная функция для миграций.
+ * Runs arbitrary YQL (DDL/DML) through the executor.
+ * Helper function for migrations.
  */
 export async function executeSql(
   executor: YdbExecutor,

--- a/src/nest/constants.ts
+++ b/src/nest/constants.ts
@@ -1,41 +1,49 @@
 import { YdbTransactionManager } from '../transaction/transaction.manager.js';
 
+/** DI token of the YDB driver. */
 export const YDB_DRIVER = Symbol('YDB_DRIVER');
+/** DI token of the YDB executor (query interface). */
 export const YDB_QUERY = Symbol('YDB_QUERY');
+/** DI token of the resolved YdbModuleOptions. */
 export const YDB_OPTIONS = Symbol('YDB_OPTIONS');
+/** DI token of the resolved credentials provider (#96). */
 export const YDB_CREDENTIALS_PROVIDER = Symbol('YDB_CREDENTIALS_PROVIDER');
+/** DI token of the optional encryption provider. */
 export const YDB_ENCRYPTION_PROVIDER = Symbol('YDB_ENCRYPTION_PROVIDER');
+/** DI token of the optional blind index provider. */
 export const YDB_BLIND_INDEX_PROVIDER = Symbol('YDB_BLIND_INDEX_PROVIDER');
+/** DI token of the optional validation provider. */
 export const YDB_VALIDATION_PROVIDER = Symbol('YDB_VALIDATION_PROVIDER');
+/** DI token of the DB schema synchronizer. */
 export const YDB_SCHEMA_SYNC = Symbol('YDB_SCHEMA_SYNC');
-/** Скоуп сущностей конкретного экземпляра ядра (#142): значение уникально
- * для каждого вызова YdbCoreModule.forRootAsync(), поэтому провайдеры
- * forFeature привязывают сущности к СВОЕМУ приложению независимо от
- * порядка резолва провайдеров. */
+/** Entity scope of a specific core instance (#142): the value is unique per
+ * YdbCoreModule.forRootAsync() call, so forFeature providers bind entities
+ * to THEIR application regardless of provider resolution order. */
 export const YDB_CORE_SCOPE = Symbol('YDB_CORE_SCOPE');
-/** Скоуп ORM-конфигурации (#199): владение сущностями и per-scope настройки
- * транзакций. Значение уникально для каждого вызова forRootAsync. */
+/** ORM configuration scope (#199): entity ownership and per-scope
+ * transaction settings. The value is unique per forRootAsync call. */
 export const YDB_ORM_SCOPE = Symbol('YDB_ORM_SCOPE');
-/** Имя конфигурации (#199): useValue-строка в провайдерах ядра — заодно
- * делает module token динамического модуля уникальным для каждого имени
- * (иначе NestJS дедуплицирует два forRootAsync одного класса). */
+/** Configuration name (#199): the useValue string in core providers also
+ * makes the dynamic module's module token unique per name (otherwise
+ * NestJS deduplicates two forRootAsync calls of the same class). */
 export const YDB_CONNECTION_NAME = Symbol('YDB_CONNECTION_NAME');
 /**
- * Внутренний lifecycle-провайдер YdbCoreModule (schema sync на bootstrap,
- * закрытие драйвера и снятие с учёта при shutdown). Наружу не экспортируется.
+ * Internal YdbCoreModule lifecycle provider (schema sync on bootstrap,
+ * closing the driver and unregistering on shutdown). Not exported publicly.
  */
 export const YDB_CORE_LIFECYCLE = Symbol('YDB_CORE_LIFECYCLE');
 
-/** Имя конфигурации по умолчанию (#199). */
+/** Default configuration name (#199). */
 export const DEFAULT_CONNECTION_NAME = 'default';
 
 /**
- * DI-токен конкретной конфигурации (#199). Для конфигурации по умолчанию
- * возвращается исходный символ (обратная совместимость одиночной
- * конфигурации); именованные конфигурации получают собственные токены,
- * поэтому несколько YdbCoreModule с разными именами не конфликтуют в DI.
- * Токены мемоизированы: повторный вызов с теми же base+name возвращает
- * ТОТ ЖЕ символ (Symbol(description) не равен другому такому же символу).
+ * DI token of a specific configuration (#199). For the default
+ * configuration the original symbol is returned (single-configuration
+ * backward compatibility); named configurations get their own tokens, so
+ * several YdbCoreModule instances with different names don't collide in
+ * DI. Tokens are memoized: a repeated call with the same base+name returns
+ * THE SAME symbol (Symbol(description) is not equal to another such
+ * symbol).
  */
 const scopedTokens = new Map<string, symbol>();
 
@@ -50,8 +58,9 @@ export function getScopedToken(base: symbol, name: string): symbol {
   return token;
 }
 
-/** Токен YdbTransactionManager конкретной конфигурации (#199): для
- * дефолтной — исторический класс-токен, для именованных — свой символ. */
+/** YdbTransactionManager token of a specific configuration (#199): for
+ * the default one — the historic class token, for named ones — its own
+ * symbol. */
 export function getTransactionManagerToken(
   name: string,
 ): symbol | typeof YdbTransactionManager {

--- a/src/nest/core-module-registry.ts
+++ b/src/nest/core-module-registry.ts
@@ -4,49 +4,51 @@ import type { YdbEntityAppScope } from '../metadata/entity-registry.js';
 import type { YdbOrmScope } from '../core/orm-scope.js';
 
 /**
- * Состояние одного экземпляра YdbCoreModule (создаётся в forRootAsync и
- * живёт в замыкании его провайдеров). Хранит опции, ссылку на драйвер,
- * созданный самим модулем — его модуль закрывает при graceful shutdown —
- * и скоуп сущностей этого приложения (#142).
+ * State of a single YdbCoreModule instance (created in forRootAsync and
+ * living in the closure of its providers). Holds the options, the driver
+ * created by the module itself — which the module closes on graceful
+ * shutdown — and the entity scope of this application (#142).
  */
 export interface CoreModuleState {
   options?: YdbModuleOptions;
-  /** Драйвер, созданный самим модулем. Если драйвер подменён снаружи
-   * (overrideProvider/useValue), поле остаётся undefined и не закрывается. */
+  /** Driver created by the module itself. If the driver is replaced from
+   * outside (overrideProvider/useValue), the field stays undefined and is
+   * not closed. */
   ownedDriver?: Driver;
-  /** Сущности ЭТОГО приложения: их привязывают провайдеры forFeature через
-   * DI-токен YDB_CORE_SCOPE, поэтому чужие приложения сюда не попадают. */
+  /** Entities of THIS application: forFeature providers bind them through
+   * the YDB_CORE_SCOPE DI token, so foreign applications never get here. */
   readonly entityScope: YdbEntityAppScope;
-  /** Имя конфигурации (#199): 'default' или пользовательское. */
+  /** Configuration name (#199): 'default' or a custom one. */
   readonly name: string;
-  /** Скоуп ORM-конфигурации (#199): владение сущностями и per-scope
-   * настройки транзакций. Освобождается при shutdown приложения. */
+  /** ORM configuration scope (#199): entity ownership and per-scope
+   * transaction settings. Released on application shutdown. */
   readonly ormScope: YdbOrmScope;
 }
 
 /**
- * Защита от двойного forRootAsync (#93) и учёт независимых конфигураций
- * (#199): повторный импорт с ТЕМ ЖЕ именем молча создавал бы второй
- * Driver/executor/credentials-провайдер, а из-за per-class runtime
- * Active Record («последний wins») сущности могли разъехаться по разным
- * executor-ам. Конфигурации с РАЗНЫМИ именами допустимы и изолированы.
+ * Protection against a double forRootAsync (#93) and tracking of
+ * independent configurations (#199): a repeated import with THE SAME name
+ * would silently create a second Driver/executor/credentials provider, and
+ * because of the per-class Active Record runtime ("last wins") entities
+ * could end up spread across different executors. Configurations with
+ * DIFFERENT names are allowed and isolated.
  *
- * Учёт экземпляров lifecycle-aware, а не «навсегда»: экземпляр регистрируется,
- * когда DI резолвит YDB_OPTIONS (момент компиляции модуля — раньше любого хука),
- * и снимается с учёта в onApplicationShutdown. Поэтому последовательные
- * бутстрапы (тесты, hot-restart) разрешены, а два живых одновременно
- * с одним именем — нет.
+ * Instance tracking is lifecycle-aware, not "forever": an instance is
+ * registered when DI resolves YDB_OPTIONS (module compilation time —
+ * before any hook) and unregistered in onApplicationShutdown. Sequential
+ * bootstraps (tests, hot-restart) are therefore allowed, but two live
+ * instances under the same name at once are not.
  *
- * Это детекция именно in-process дубликатов: гонки DDL между репликами
- * решаются безопасным поведением самого schema sync (DescribeTable перед DDL),
- * здесь они не эмулируются.
+ * This detects only in-process duplicates: DDL races between replicas are
+ * resolved by the safe behavior of schema sync itself (DescribeTable
+ * before DDL); they are not emulated here.
  */
 const activeCoreModules = new Set<CoreModuleState>();
 
 /**
- * Регистрирует инициализацию ядра. Если в процессе уже живёт другой
- * экземпляр с тем же именем конфигурации — бросает понятную ошибку
- * вместо тихого создания второго драйвера.
+ * Registers a core initialization. If another instance with the same
+ * configuration name is already live in this process, throws a clear error
+ * instead of silently creating a second driver.
  */
 export function claimCoreModuleInit(state: CoreModuleState): void {
   for (const existing of activeCoreModules) {
@@ -66,9 +68,9 @@ export function claimCoreModuleInit(state: CoreModuleState): void {
   activeCoreModules.add(state);
 }
 
-/** Снимает экземпляр с учёта (идемпотентно). Скоуп сущностей живёт в
- * состоянии экземпляра и уходит в GC вместе с ним — глобально чистить
- * нечего (#142). */
+/** Unregisters an instance (idempotent). The entity scope lives in the
+ * instance's state and is GC'd together with it — there is nothing to
+ * clean globally (#142). */
 export function releaseCoreModuleInit(state: CoreModuleState): void {
   activeCoreModules.delete(state);
 }

--- a/src/nest/index.ts
+++ b/src/nest/index.ts
@@ -1,15 +1,15 @@
 /**
- * @ycforge/ydb-orm/nest — NestJS-интеграция пакета.
+ * @ycforge/ydb-orm/nest — NestJS integration for the package.
  *
- * Подпакет существует, чтобы основной пакет @ycforge/ydb-orm оставался
- * каркасно-нейтральным (работает без NestJS). Здесь собраны:
- * - модули NestJS: YdbOrmModule / YdbCoreModule (+ внутренние провайдеры);
- * - DI-токены и помощники репозиториев: YDB_*, getRepositoryToken,
+ * The subpackage exists so the main @ycforge/ydb-orm package remains
+ * framework-neutral (works without NestJS). It contains:
+ * - NestJS modules: YdbOrmModule / YdbCoreModule (+ internal providers);
+ * - DI tokens and repository helpers: YDB_*, getRepositoryToken,
  *   getActiveRecordInitToken, InjectRepository;
- * - типы async-опций (YdbModuleAsyncOptions / YdbOptionsFactory).
+ * - async option types (YdbModuleAsyncOptions / YdbOptionsFactory).
  *
- * Для удобства NestJS-приложений реэкспортируется и весь публичный API
- * основного пакета — достаточно одного импорта.
+ * For convenience, the entire public API of the main package is also
+ * re-exported — a single import is sufficient for NestJS applications.
  */
 export * from '../index.js';
 export { YdbOrmModule } from './ydb-orm.module.js';

--- a/src/nest/interfaces.ts
+++ b/src/nest/interfaces.ts
@@ -2,24 +2,24 @@ import { ModuleMetadata, Type } from '@nestjs/common';
 import type { YdbModuleOptions } from '../core/interfaces.js';
 
 /**
- * Фабрика опций для forRootAsync() (паттерн async-модуля NestJS).
+ * Options factory for forRootAsync() (NestJS async-module pattern).
  */
 export interface YdbOptionsFactory {
   createYdbOptions(): Promise<YdbModuleOptions> | YdbModuleOptions;
 }
 
 /**
- * Опции YdbOrmModule.forRootAsync() / YdbCoreModule.forRootAsync().
- * Тип специфичен для NestJS-интеграции (imports/useClass/useExisting) —
- * живёт в подпакете `@ycforge/ydb-orm/nest`.
+ * Options for YdbOrmModule.forRootAsync() / YdbCoreModule.forRootAsync().
+ * The type is specific to the NestJS integration (imports/useClass/
+ * useExisting) — it lives in the `@ycforge/ydb-orm/nest` subpackage.
  */
 export interface YdbModuleAsyncOptions extends Pick<ModuleMetadata, 'imports'> {
   /**
-   * Имя конфигурации (#199): позволяет поднять несколько независимых
-   * YDB-конфигураций в одном процессе (по одному экземпляру на имя).
-   * По умолчанию 'default' — прежнее поведение одиночной конфигурации.
-   * Именованные конфигурации получают собственные DI-токены, а их сущности
-   * подключаются через YdbOrmModule.forFeature(entities, name).
+   * Configuration name (#199): allows several independent YDB
+   * configurations in one process (one instance per name). Defaults to
+   * 'default' — the previous single-configuration behavior. Named
+   * configurations get their own DI tokens, their entities are attached
+   * via YdbOrmModule.forFeature(entities, name).
    */
   name?: string;
   useFactory?: (...args: any[]) => Promise<YdbModuleOptions> | YdbModuleOptions;

--- a/src/nest/repository-factory.ts
+++ b/src/nest/repository-factory.ts
@@ -40,14 +40,15 @@ import {
 import { getOrCreateRepository } from '../repository/repository-resolver.js';
 
 /**
- * Провайдер, который при инициализации модуля подключает executor и
- * опциональные encryption/blind-index провайдеры СВОЕЙ конфигурации (#199)
- * к Active Record сущности (см. YdbBaseEntity.setExecutor / setEncryptionProvider).
- * Перед подключением валидирует метаданные сущности (validateEntityMetadataIssues).
- * Также создаёт `YdbRepository` для сущности и сохраняет его в entity-runtime.
+ * Provider that, on module initialization, wires the executor and the
+ * optional encryption/blind-index providers of ITS OWN configuration (#199)
+ * to the Active Record entity (see YdbBaseEntity.setExecutor /
+ * setEncryptionProvider). Validates the entity metadata beforehand
+ * (validateEntityMetadataIssues). Also creates the `YdbRepository` for the
+ * entity and stores it in the entity runtime.
  *
- * connectionName выбирает конфигурацию (#199): 'default' — прежние
- * глобальные DI-токены, именованная конфигурация — собственные токены.
+ * connectionName selects the configuration (#199): 'default' — the previous
+ * global DI tokens, a named configuration — its own tokens.
  */
 export function createActiveRecordEntityProvider(
   entityClass: typeof YdbBaseEntity,
@@ -64,17 +65,18 @@ export function createActiveRecordEntityProvider(
       entityScope?: YdbEntityAppScope,
       ormScope?: YdbOrmScope,
     ) => {
-      // forFeature явно объявляет сущности ЭТОГО приложения (#142): декоратор
-      // @YdbEntity уже отработал при первом импорте класса и больше
-      // не выполнится (кеш модулей). Скоуп приходит через DI-токен YDB_CORE_SCOPE
-      // из контейнера своего приложения, поэтому привязка корректна при любом
-      // порядке резолва провайдеров и не затрагивает чужие приложения.
+      // forFeature explicitly declares the entities of THIS application (#142):
+      // the @YdbEntity decorator already ran on the first import of the
+      // class and won't run again (module cache). The scope arrives through
+      // the YDB_CORE_SCOPE DI token from this application's container, so
+      // the binding stays correct regardless of provider resolution order
+      // and never touches foreign applications.
       if (entityScope) {
         requestEntitiesForApp(entityScope, [entityClass]);
       }
 
-      // Валидируем ДО привязки к скоупу: невалидная сущность не получает
-      // executor/провайдеры и не оставляет владения (#199 + атомарность).
+      // Validate BEFORE binding to the scope: an invalid entity gets no
+      // executor/providers and leaves no ownership behind (#199 + atomicity).
       const issues = validateEntityMetadataIssues(entityClass, {
         encryptionProviderConfigured: Boolean(encryptionProvider),
         blindIndexProviderConfigured: Boolean(blindIndexProvider),
@@ -88,9 +90,10 @@ export function createActiveRecordEntityProvider(
         );
       }
 
-      // Владение сущностью (#199): один класс — одна активная конфигурация.
-      // Регистрация в чужой конфигурации — детерминированная ошибка.
-      // Запоминаем ново заявленные сущности для отката при ошибке конфигурации.
+      // Entity ownership (#199): one class — one active configuration.
+      // Registering in a foreign configuration is a deterministic error.
+      // Remember newly claimed entities for a rollback on configuration
+      // failure.
       let newlyClaimed: (new (...args: any[]) => any)[] = [];
       if (ormScope) {
         newlyClaimed = claimEntitiesForScopeWithTracking(ormScope, [
@@ -98,22 +101,23 @@ export function createActiveRecordEntityProvider(
         ]);
       }
 
-      // Снимок runtime-конфигурации для атомарного отката при ошибке.
+      // Snapshot of the runtime configuration for atomic rollback on error.
       const runtimeSnapshot = snapshotEntityRuntime(entityClass);
 
       try {
         const runtime = getEntityRuntime(entityClass);
         runtime.uuidGenerator = opts.uuidVersion === 'v4' ? uuidv4 : uuidv7;
-        // Привязка к конфигурации (#199): per-scope настройки транзакций.
+        // Binding to the configuration (#199): per-scope transaction settings.
         if (ormScope) {
           runtime.scope = ormScope;
           runtime.transactions = ormScope.transactions;
         }
 
         entityClass.setExecutor(db);
-        // Провайдеры перезаписываются безусловно: повторный бутстрап без них
-        // (тесты, hot-restart) не должен оставлять провайдеры прошлой
-        // конфигурации — undefined сбрасывает предыдущее значение.
+        // Providers are overwritten unconditionally: a repeated bootstrap without
+        // them (tests, hot-restart) must not leave the previous
+        // configuration's providers behind — undefined resets the previous
+        // value.
         entityClass.setEncryptionProvider(encryptionProvider);
         entityClass.setBlindIndexProvider(blindIndexProvider);
         entityClass.setValidationProvider(validationProvider);
@@ -122,7 +126,7 @@ export function createActiveRecordEntityProvider(
 
         getOrCreateRepository(entityClass as any);
       } catch (e) {
-        // Откат runtime-конфигурации сущности к снимку перед изменением.
+        // Roll the entity's runtime configuration back to the pre-change snapshot.
         restoreEntityRuntime(entityClass, runtimeSnapshot);
         if (ormScope && newlyClaimed.length > 0) {
           releaseEntitiesFromScope(ormScope, newlyClaimed);
@@ -147,8 +151,9 @@ export function createActiveRecordEntityProvider(
         token: getScopedToken(YDB_VALIDATION_PROVIDER, connectionName),
         optional: true,
       },
-      // Скоуп опционален для устойчивости к экзотическим контейнерам без
-      // ядра: без него привязка невозможна, но executor всё равно отсутствует
+      // The scope is optional for robustness against exotic containers without
+      // a core: without it binding is impossible, but the executor is
+      // absent anyway
       { token: getScopedToken(YDB_CORE_SCOPE, connectionName), optional: true },
       { token: getScopedToken(YDB_ORM_SCOPE, connectionName), optional: true },
     ],

--- a/src/nest/repository-token.spec.ts
+++ b/src/nest/repository-token.spec.ts
@@ -8,8 +8,8 @@ import {
 let uniqueNameCounter = 0;
 
 /**
- * Создаёт класс сущности с гарантированно уникальным именем, чтобы тесты
- * не зависели от глобального состояния реестра токенов между собой.
+ * Creates an entity class with a guaranteed unique name so the tests don't
+ * depend on the global token registry state across each other.
  */
 function makeNamedEntityClass(nameSuffix?: string): typeof YdbBaseEntity {
   const name = `TokenSpec_${nameSuffix ?? ++uniqueNameCounter}`;
@@ -23,7 +23,7 @@ function makeNamedEntityClass(nameSuffix?: string): typeof YdbBaseEntity {
 }
 
 describe('getRepositoryToken / getActiveRecordInitToken (issue #94)', () => {
-  it('один класс всегда даёт один и тот же токен (идемпотентность)', () => {
+  it('same class always yields the same token (idempotency)', () => {
     const Entity = makeNamedEntityClass();
 
     for (let i = 0; i < 3; i++) {
@@ -33,7 +33,7 @@ describe('getRepositoryToken / getActiveRecordInitToken (issue #94)', () => {
       expect(arToken).toBe(getActiveRecordInitToken(Entity as any));
     }
 
-    // Исторический формат для первого класса с данным именем
+    // Historical format for the first class with a given name
     expect(getRepositoryToken(Entity as any)).toBe(
       `YDB_REPOSITORY_${Entity.name}`,
     );
@@ -42,7 +42,7 @@ describe('getRepositoryToken / getActiveRecordInitToken (issue #94)', () => {
     );
   });
 
-  it('одноимённые классы получают разные токены без перезаписи', () => {
+  it('same-named classes get different tokens without overwriting', () => {
     const first = makeNamedEntityClass('Collision');
     const second = makeNamedEntityClass('Collision');
 
@@ -58,13 +58,13 @@ describe('getRepositoryToken / getActiveRecordInitToken (issue #94)', () => {
     expect(firstAr).not.toBe(secondAr);
   });
 
-  it('порядок регистрации не влияет на стабильность токенов класса', () => {
+  it('registration order does not affect token stability for a class', () => {
     const a1 = makeNamedEntityClass('Order');
     const b1 = makeNamedEntityClass('Order');
     const a2 = makeNamedEntityClass('Order');
     const b2 = makeNamedEntityClass('Order');
 
-    // Токены не меняются после регистрации новых одноимённых классов
+    // Tokens don't change after registering new same-named classes
     expect(getRepositoryToken(a1 as any)).toBe(getRepositoryToken(a1 as any));
     expect(getRepositoryToken(a1 as any)).not.toBe(
       getRepositoryToken(b1 as any),
@@ -80,15 +80,15 @@ describe('getRepositoryToken / getActiveRecordInitToken (issue #94)', () => {
     expect(tokens.size).toBe(4);
   });
 
-  it('AR_INIT-токен согласован между фабрикой провайдера и inject модуля', () => {
-    // Обе стороны обязаны строить токен одной функцией — иначе рассинхрон строк.
+  it('AR_INIT token is consistent between provider factory and module inject', () => {
+    // Both sides must build the token using the same function — otherwise string mismatch.
     const Entity = makeNamedEntityClass();
     const arToken = getActiveRecordInitToken(Entity as any);
     expect(arToken).toContain('_AR_INIT');
     expect(getActiveRecordInitToken(Entity as any)).toBe(arToken);
   });
 
-  it('класс без имени получает валидный и уникальный токен', () => {
+  it('unnamed class gets a valid and unique token', () => {
     @YdbEntity('token_spec_anonymous')
     class Anonymous extends YdbBaseEntity {
       @YdbPrimaryColumn('Uuid')

--- a/src/nest/repository-token.ts
+++ b/src/nest/repository-token.ts
@@ -7,7 +7,8 @@ const REPOSITORY_TOKEN_PREFIX = 'YDB_REPOSITORY_' as const;
 const AR_INIT_TOKEN_SUFFIX = '_AR_INIT' as const;
 
 /**
- * DI-токены сущности: репозиторий и провайдер инициализации Active Record.
+ * The entity's DI tokens: the repository and the Active Record init
+ * provider.
  */
 interface EntityDiTokens {
   repository: string;
@@ -15,17 +16,17 @@ interface EntityDiTokens {
 }
 
 /**
- * Реестр class → токены (issue #94).
+ * Registry of class → tokens (issue #94).
  *
- * Токен исторически строится из имени класса, но привязывается к конкретному
- * классу: одноимённые классы из разных файлов/пакетов получают разные токены
- * (первый — в прежнем формате без суффикса, последующие — с суффиксом `#N`),
- * поэтому провайдеры больше не перезаписывают друг друга молча. Повторное
- * обращение к тому же классу (forFeature, getRepositoryToken,
- * InjectRepository) всегда возвращает те же строки.
+ * The token is historically built from the class name but is bound to a
+ * specific class: same-named classes from different files/packages get
+ * different tokens (the first one in the previous suffix-less format, the
+ * rest with a `#N` suffix), so providers no longer silently overwrite each
+ * other. A repeated lookup of the same class (forFeature,
+ * getRepositoryToken, InjectRepository) always returns the same strings.
  *
- * WeakMap не держит класс сильной ссылкой; счётчик занятых имён хранит
- * только строки, поэтому классы собираются GC как раньше.
+ * The WeakMap doesn't hold classes strongly; the name counter only stores
+ * strings, so classes are GC'd as before.
  */
 const tokensByClass = new WeakMap<
   YdbEntityConstructor<YdbBaseEntity>,
@@ -39,15 +40,15 @@ function resolveEntityTokens(
   const cached = tokensByClass.get(entityClass);
   if (cached) return cached;
 
-  // У анонимных/сминифицированных классов имя может отсутствовать.
+  // Anonymous/minified classes may have no name.
   const baseName = entityClass.name || 'AnonymousEntity';
 
   const ordinal = claimedNames.get(baseName) ?? 0;
   claimedNames.set(baseName, ordinal + 1);
 
-  // Первый класс с данным именем сохраняет исторический формат токена;
-  // каждый следующий одноимённый класс получает уникальный суффикс —
-  // коллизия разрешается явно, а не перезаписью провайдеров.
+  // The first class with a given name keeps the historic token format;
+  // every next same-named class gets a unique suffix — a collision is
+  // resolved explicitly rather than by overwriting providers.
   const suffix = ordinal === 0 ? '' : `#${ordinal + 1}`;
   const tokens: EntityDiTokens = {
     repository: `${REPOSITORY_TOKEN_PREFIX}${baseName}${suffix}`,
@@ -58,9 +59,9 @@ function resolveEntityTokens(
 }
 
 /**
- * Возвращает DI-токен для репозитория указанной сущности.
- * connectionName (#199): конфигурация, которой принадлежит репозиторий;
- * дефолтная конфигурация сохраняет исторический формат токена.
+ * Returns the DI token for the repository of the given entity.
+ * connectionName (#199): the configuration the repository belongs to; the
+ * default configuration keeps the historic token format.
  */
 export function getRepositoryToken<T extends YdbBaseEntity>(
   entityClass: YdbEntityConstructor<T>,
@@ -73,11 +74,11 @@ export function getRepositoryToken<T extends YdbBaseEntity>(
 }
 
 /**
- * Возвращает DI-токен провайдера, который при инициализации модуля
- * подключает executor/провайдеры к Active Record сущности
- * (см. createActiveRecordEntityProvider). Используется и при объявлении
- * провайдера, и в `inject` репозитория — рассинхрон строк невозможен.
- * connectionName (#199): конфигурация, которой принадлежит провайдер.
+ * Returns the DI token of the provider that wires the executor/providers to
+ * the Active Record entity on module initialization (see
+ * createActiveRecordEntityProvider). Used both when declaring the provider
+ * and in the repository's `inject` — a string mismatch is impossible.
+ * connectionName (#199): the configuration the provider belongs to.
  */
 export function getActiveRecordInitToken<T extends YdbBaseEntity>(
   entityClass: YdbEntityConstructor<T>,
@@ -90,7 +91,7 @@ export function getActiveRecordInitToken<T extends YdbBaseEntity>(
 }
 
 /**
- * Декоратор для инъекции репозитория сущности в NestJS-сервисы.
+ * Decorator to inject an entity's repository into NestJS services.
  *
  * ```ts
  * @Injectable()
@@ -99,7 +100,7 @@ export function getActiveRecordInitToken<T extends YdbBaseEntity>(
  * }
  * ```
  *
- * Для именованной конфигурации (#199): `@InjectRepository(User, 'reporting')`.
+ * For a named configuration (#199): `@InjectRepository(User, 'reporting')`.
  */
 export function InjectRepository<T extends YdbBaseEntity>(
   entityClass: YdbEntityConstructor<T>,

--- a/src/nest/ydb-core.module.ts
+++ b/src/nest/ydb-core.module.ts
@@ -58,20 +58,22 @@ import {
 } from './core-module-registry.js';
 
 /**
- * Внутренний lifecycle-провайдер ядра (#93).
+ * Internal core lifecycle provider (#93).
  *
- * - onApplicationBootstrap: schema sync (если `sync: true`). Хук выполняется
- *   после того, как все модули скомпилированы и все `forFeature`-сущности
- *   получили executor — порядок инициализации детерминирован, результат
- *   больше не зависит от порядка импортов сущностей. Ошибка DDL пробрасывается
- *   из app.init() как исходная ошибка схемы, а не как невнятный сбой DI-фабрики.
- *   Гонки DDL между репликами не решаются на этом уровне — безопасность
- *   обеспечивает сам schema sync (DescribeTable перед каждым DDL).
+ * - onApplicationBootstrap: schema sync (if `sync: true`). The hook runs
+ *   after all modules are compiled and every `forFeature` entity received
+ *   its executor — the initialization order is deterministic, the result
+ *   no longer depends on the import order of entities. A DDL error
+ *   propagates from app.init() as the original schema error, not as an
+ *   obscure DI-factory failure. DDL races between replicas are not solved
+ *   at this level — safety is ensured by schema sync itself (DescribeTable
+ *   before each DDL).
  *
- * - onApplicationShutdown: снимает экземпляр с учёта (см. core-module-registry)
- *   и закрывает драйвер, созданный самим модулем. Драйвер, переданный снаружи
- *   (overrideProvider/useValue), не закрывается — им владеет вызывающий.
- *   Повторный shutdown безопасен (идемпотентен).
+ * - onApplicationShutdown: unregisters the instance (see
+ *   core-module-registry) and closes the driver created by the module
+ *   itself. A driver passed from outside (overrideProvider/useValue) is
+ *   not closed — the caller owns it. Repeated shutdown is safe
+ *   (idempotent).
  */
 class YdbCoreModuleLifecycle
   implements OnApplicationBootstrap, OnApplicationShutdown
@@ -86,16 +88,17 @@ class YdbCoreModuleLifecycle
   async onApplicationBootstrap(): Promise<void> {
     if (!this.state.options?.sync) return;
     try {
-      // Sync видит только сущности СВОЕГО приложения (#142): привязанные
-      // провайдерами forFeature этого контейнера через YDB_CORE_SCOPE.
+      // Sync only sees the entities of THIS application (#142): those bound
+      // by this container's forFeature providers through YDB_CORE_SCOPE.
       await this.schemaSyncer.sync(
         getRegisteredYdbEntities(this.state.entityScope),
       );
     } catch (error) {
-      // После неудачного бутстрапа приложение не стартовало: снимаем
-      // экземпляр с учёта и закрываем драйвер сразу — NestJS вызывает
-      // shutdown-хуки только при успешном init(), иначе слот инициализации
-      // остался бы занят навсегда. Наверх идёт исходная ошибка схемы.
+      // After a failed bootstrap the application never started: unregister the
+      // instance and close the driver right away — NestJS only calls the
+      // shutdown hooks on a successful init(), otherwise the initialization
+      // slot would stay occupied forever. The original schema error
+      // propagates up.
       await this.dispose({ ignoreCloseErrors: true });
       throw error;
     }
@@ -105,31 +108,31 @@ class YdbCoreModuleLifecycle
     await this.dispose();
   }
 
-  /** Идемпотентно: снятие с учёта + освобождение скоупа сущностей (#199)
-   * + закрытие созданного модулем драйвера. */
+  /** Idempotent: unregister + release the entity scope (#199)
+   * + close the module-created driver. */
   private async dispose(
     opts: { ignoreCloseErrors?: boolean } = {},
   ): Promise<void> {
     if (this.disposed) return;
     this.disposed = true;
     releaseCoreModuleInit(this.state);
-    // Сущности конфигурации освобождаются: после shutdown их можно
-    // привязать к другой конфигурации (#199).
+    // The configuration's entities are released: after shutdown they can be
+    // claimed by another configuration (#199).
     releaseOrmScope(this.state.ormScope);
 
     const driver = this.state.ownedDriver;
     if (!driver) return;
     try {
-      // close() у драйвера синхронный (void), но кастомная driverFactory
-      // может вернуть драйвер с асинхронным закрытием — дожидаемся его.
+      // Driver close() is synchronous (void), but a custom driverFactory may
+      // return a driver with async closing — wait for it.
       const closing = driver.close() as unknown;
       if (closing instanceof Promise) {
         await closing;
       }
     } catch (error) {
       if (!opts.ignoreCloseErrors) throw error;
-      // При падении бутстрапа наверх должна идти исходная ошибка схемы,
-      // поэтому ошибку закрытия драйвера только логируем.
+      // On a failed bootstrap the original schema error must propagate up,
+      // so the driver close error is only logged.
       console.error(
         'Failed to close YDB driver after failed bootstrap:',
         (error as Error)?.message ?? error,
@@ -141,14 +144,26 @@ class YdbCoreModuleLifecycle
 @Global()
 @Module({})
 export class YdbCoreModule {
+  /**
+   * Registers one named YDB configuration (#199): creates the driver, the
+   * YdbExecutor (via query(driver)) and the credentials provider — from
+   * `auth` (AuthManager from @ycforge/auth) or an explicit
+   * credentialsProvider / driverOptions.credentialsProvider (conflicting
+   * sources → error). Optional encryption/blind-index/validation providers
+   * are lifted from the options; schema sync runs at bootstrap when
+   * `sync: true`.
+   *
+   * @param options - async module options (useFactory/useClass/useExisting)
+   */
   static forRootAsync(options: YdbModuleAsyncOptions): DynamicModule {
-    // Состояние конкретного экземпляра модуля: живёт в замыкании провайдеров,
-    // по нему выполняется claim/release и учитывается владение драйвером.
-    // Скоуп сущностей создаётся здесь же — один на экземпляр DynamicModule:
-    // провайдеры forFeature привязывают сущности к нему через DI-токен
-    // YDB_CORE_SCOPE и не зависят от порядка резолва (#142).
-    // Имя конфигурации (#199): конфигурации с разными именами сосуществуют
-    // в одном процессе, их DI-токены разнесены через getScopedToken.
+    // The module instance state: lives in the providers' closure; the
+    // claim/release and driver-ownership accounting operate on it. The
+    // entity scope is created here too — one per DynamicModule instance:
+    // forFeature providers bind entities to it via the YDB_CORE_SCOPE DI
+    // token and don't depend on provider resolution order (#142).
+    // Configuration name (#199): configurations with different names
+    // coexist in one process, their DI tokens are separated via
+    // getScopedToken.
     const name = options.name ?? DEFAULT_CONNECTION_NAME;
     if (!name) {
       throw new Error(
@@ -172,11 +187,11 @@ export class YdbCoreModule {
     const state: CoreModuleState = {
       entityScope: createEntityScope(),
       name,
-      // Дефолтная конфигурация использует процессный синглтон-скоуп:
-      // повторный бутстрап (тесты, hot-restart) с теми же сущностями —
-      // идемпотентный claim, как раньше. Одновременно живых экземпляров
-      // с именем 'default' быть не может (claimCoreModuleInit), поэтому
-      // общий скоуп безопасен. Именованные конфигурации — изолированы.
+      // The default configuration uses a process-singleton scope: a repeated
+      // bootstrap (tests, hot-restart) with the same entities is an
+      // idempotent claim, as before. Two live instances named 'default'
+      // cannot exist at once (claimCoreModuleInit), so sharing the scope is
+      // safe. Named configurations are isolated.
       ormScope:
         name === DEFAULT_CONNECTION_NAME
           ? getDefaultOrmScope()
@@ -195,9 +210,10 @@ export class YdbCoreModule {
         ...asyncProviders,
 
         {
-          // Имя конфигурации (#199): useValue-строка делает module token
-          // этого DynamicModule уникальным для каждого имени — иначе NestJS
-          // дедуплицирует два forRootAsync одного класса в один модуль.
+          // Configuration name (#199): the useValue string makes this
+          // DynamicModule's module token unique per name — otherwise NestJS
+          // deduplicates two forRootAsync calls of the same class into one
+          // module.
           provide: YDB_CONNECTION_NAME,
           useValue: name,
         },
@@ -213,16 +229,16 @@ export class YdbCoreModule {
         },
 
         {
-          // Провайдер учётных данных (#96): явный opts.credentialsProvider
-          // используется как есть; иначе auth (AuthManager из @ycforge/auth);
-          // иначе driverOptions.credentialsProvider.
+          // Credentials provider (#96): an explicit opts.credentialsProvider
+          // is used as-is; otherwise auth (AuthManager from @ycforge/auth);
+          // otherwise driverOptions.credentialsProvider.
           provide: tokens.credentials,
           useFactory: (opts: YdbModuleOptions) => {
             try {
               return resolveCredentialsProvider(opts);
             } catch (error) {
-              // Компиляция упала после claim — освобождаем слот,
-              // чтобы следующий бутстрап в этом процессе был возможен.
+              // Compilation failed after the claim — release the slot so a
+              // later bootstrap in this process is possible.
               releaseCoreModuleInit(state);
               throw error;
             }
@@ -237,9 +253,9 @@ export class YdbCoreModule {
             credentialsProvider: CredentialsProvider,
           ) => {
             try {
-              // driverFactory — кастомное создание (тесты/нестандартные
-              // транспорты); такой драйвер тоже считается созданным модулем
-              // и закрывается при shutdown.
+              // driverFactory is a custom creation path (tests / non-standard
+              // transports); such a driver is also considered created by the
+              // module and is closed on shutdown.
               const driver =
                 opts.driverFactory !== undefined
                   ? await opts.driverFactory()
@@ -286,10 +302,10 @@ export class YdbCoreModule {
         },
 
         /**
-         * Синхронизатор схемы БД. Только создаётся здесь; сам sync
-         * выполняется в onApplicationBootstrap (см. YdbCoreModuleLifecycle):
-         * к этому моменту зарегистрированы все сущности всех модулей.
-         * Провайдер экспортируется: syncer.verify() можно вызвать вручную.
+         * DB schema synchronizer. Only created here; the actual sync runs in
+         * onApplicationBootstrap (see YdbCoreModuleLifecycle): by then all
+         * entities of all modules are registered. The provider is exported:
+         * syncer.verify() can be called manually.
          */
         {
           provide: tokens.schemaSync,
@@ -308,8 +324,8 @@ export class YdbCoreModule {
         },
 
         {
-          // Менеджер транзакций конфигурации (#199): настройки — из её
-          // скоупа, а не процессно-глобальные.
+          // The configuration's transaction manager (#199): its settings come
+          // from its scope, not from process-global ones.
           provide: tokens.transactionManager,
           useFactory: (db: YdbExecutor) =>
             new YdbTransactionManager(db, state.ormScope.transactions),
@@ -337,10 +353,11 @@ export class YdbCoreModule {
     state: CoreModuleState,
     optionsToken: symbol,
   ): Provider[] {
-    // Настройки транзакций (#98/#199): для дефолтной конфигурации — как
-    // раньше, процессно-глобально (даже если YDB_QUERY переопределён извне,
-    // конфигурация ambient/warn не теряется); для любой конфигурации — в её
-    // скоуп, откуда их заберут AR-провайдеры forFeature и менеджер транзакций.
+    // Transaction settings (#98/#199): for the default configuration — as
+    // before, process-global (even if YDB_QUERY is overridden externally,
+    // the ambient/warn configuration isn't lost); for any configuration —
+    // into its scope, where the forFeature AR providers and the transaction
+    // manager will take them from.
     const applyTransactions = (opts: YdbModuleOptions): void => {
       if (state.name === DEFAULT_CONNECTION_NAME) {
         configureTransactionContext(opts.transactions);

--- a/src/nest/ydb-orm.module.ts
+++ b/src/nest/ydb-orm.module.ts
@@ -12,6 +12,11 @@ import { DEFAULT_CONNECTION_NAME } from './constants.js';
 
 @Module({})
 export class YdbOrmModule {
+  /**
+   * Registers the core YDB module (driver/executor/credentials) and
+   * re-exports it, so one YdbOrmModule.forRoot(...) import in the root
+   * module is enough for the whole application.
+   */
   static forRoot(options: YdbModuleAsyncOptions): DynamicModule {
     const core = YdbCoreModule.forRootAsync(options);
     return {
@@ -22,9 +27,9 @@ export class YdbOrmModule {
   }
 
   /**
-   * Подключает сущности к конфигурации connectionName (#199, по умолчанию
-   * 'default'). Один класс сущности может принадлежать только одной
-   * активной конфигурации: регистрация в чужой — ошибка при bootstrap.
+   * Attaches entities to the connectionName configuration (#199, defaults
+   * to 'default'). An entity class can belong to only one active
+   * configuration: registering it in a foreign one fails at bootstrap.
    */
   static forFeature(
     entities: (typeof YdbBaseEntity)[],

--- a/src/persistence/entity-persistence.ts
+++ b/src/persistence/entity-persistence.ts
@@ -56,22 +56,22 @@ import {
 import { resolveManyToManyJoinTable } from '../relations/resolve-join-table.js';
 
 /**
- * Конструктор сущности, совместимый с YdbBaseEntity.
+ * Entity constructor type compatible with YdbBaseEntity.
  */
 export type YdbEntityConstructor<T extends YdbBaseEntity> = {
   new (): T;
 } & typeof YdbBaseEntity;
 
 /**
- * Контекст одной операции гидратации: identity guard против двойного
- * afterFind на одном инстансе (см. YdbEntityPersistence.hydrate).
+ * Context for a single hydration operation: an identity guard against firing
+ * afterFind twice on the same instance (see YdbEntityPersistence.hydrate).
  */
 export interface HydrationContext {
   seen: WeakSet<object>;
 }
 
 /**
- * Зависимости persistence: executor и опциональные провайдеры.
+ * Persistence dependencies: the executor plus optional providers.
  */
 export interface PersistenceDeps {
   encryptionProvider?: YdbEncryptionProvider;
@@ -79,37 +79,38 @@ export interface PersistenceDeps {
   validationProvider?: YdbValidationProvider;
   uuidGenerator?: () => string;
   /**
-   * Формат сериализации Security AAD (#165). По умолчанию безопасный `v2`;
-   * `legacy` — только для переходного периода (дешифровка старого ciphertext).
+   * Security AAD serialization format (#165). Defaults to the safe `v2`;
+   * `legacy` is intended only for a transition period (decrypting old ciphertext).
    */
   aadFormat?: AadFormat;
   /**
-   * Автоматическое определение формата AAD при дешифровке (#165, по умолчанию
-   * true): если расшифровка основным форматом упала, повторяется вторым.
-   * Без этого смена дефолта на `v2` сделала бы незаписи, написанные старым
-   * `legacy`-форматом, нечитаемыми сразу после апгрейда. После полной
-   * перешифровки данных выключите (`false`) — строгий режим: сбой формата
-   * больше не маскируется, а поверхностно неверный AAD падает первым
-   * исключением.
+   * Automatic AAD format detection during decryption (#165, default true): if
+   * decryption with the primary format fails, retry with the secondary one.
+   * Without this, switching the default to `v2` would make rows written with
+   * the old `legacy` format unreadable immediately after an upgrade. Once data
+   * has been fully re-encrypted, disable it (`false`) for strict mode: format
+   * failures are no longer masked, and a superficially wrong AAD throws on the
+   * first exception.
    */
   aadReadFallback?: boolean;
   /**
-   * @internal Общий контекст гидратации одной операции чтения.
-   * Прокидывается в persistence связанных сущностей при догрузке связей.
+   * @internal Shared hydration context of one read operation.
+   * Forwarded to the persistence of related entities when loading relations.
    */
   hydrationContext?: HydrationContext;
 }
 
 /**
- * Состояние lazy-дешифровки инстансов: поле → ciphertext из БД.
- * Записывается при instantiate(); снимается после decryptField().
- * WeakMap — не мешает сборке мусора и не виден в Object.entries/toJSON.
+ * Per-instance lazy-decryption state: field -> ciphertext from the DB.
+ * Populated at instantiate(); cleared after decryptField().
+ * A WeakMap so it neither blocks garbage collection nor shows up in
+ * Object.entries/toJSON.
  */
 const lazyPendingCiphertext = new WeakMap<object, Map<string, any>>();
 
 /**
- * Проверяет, есть ли у инстанса недешифрованные lazy-поля.
- * Экспортируется для toJSON() в YdbBaseEntity.
+ * Returns whether the instance still has any undecrypted lazy fields.
+ * Exported for toJSON() in YdbBaseEntity.
  */
 export function hasLazyPendingCiphertext(instance: object): boolean {
   const pending = lazyPendingCiphertext.get(instance);
@@ -117,7 +118,7 @@ export function hasLazyPendingCiphertext(instance: object): boolean {
 }
 
 /**
- * Возвращает имена недешифрованных lazy-полей инстанса.
+ * Returns the names of the instance's undecrypted lazy fields.
  */
 export function getLazyPendingFieldNames(instance: object): string[] {
   const pending = lazyPendingCiphertext.get(instance);
@@ -125,7 +126,7 @@ export function getLazyPendingFieldNames(instance: object): string[] {
 }
 
 /**
- * Расширенная схема: entity поля + synthetic {field}_bi колонки.
+ * Extended schema: entity fields plus synthetic {field}_bi columns.
  */
 export function getEntityDbSchema(
   meta: YdbEntityMetadata,
@@ -145,20 +146,20 @@ export interface WhereBuildContext {
 }
 
 /**
- * Окружение построения одного WHERE-узла.
+ * Environment of building a single WHERE node.
  *
- * `forbidEncrypted` включается внутри related-предикатов (#17): фильтрация
- * по колонкам связанных сущностей разрешена только для нешифрованных колонок
- * (blind index тоже запрещён — подзапрос по связанной таблице не имеет
- * доступа к провайдеру хешей корневого запроса и усложнил бы семантику).
+ * `forbidEncrypted` is enabled inside related predicates (#17): filtering by
+ * related-entity columns is allowed only for non-encrypted columns (the blind
+ * index is also forbidden — a subquery against a related table has no access
+ * to the root query's hash provider and would complicate the semantics).
  */
 export interface WhereBuildEnv {
   forbidEncrypted: boolean;
 }
 
 /**
- * Persistence-класс: все CRUD-операции, шифрование/дешифровка,
- * lifecycle hooks, enum-конвертация, timestamp-автопростановка.
+ * Persistence class: all CRUD operations, encryption/decryption,
+ * lifecycle hooks, enum conversion, and timestamp auto-fill.
  */
 export class YdbEntityPersistence<T extends YdbBaseEntity> {
   constructor(
@@ -167,7 +168,7 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
     private readonly options: PersistenceDeps = {},
   ) {}
 
-  /** Обновляет executor (вызывается из runtime при смене deps). */
+  /** Updates the executor (called from runtime when deps change). */
   setExecutor(executor: YdbExecutor | undefined): void {
     this.executor = executor;
   }
@@ -185,16 +186,16 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 
   private getExecutor(trx?: YdbExecutor): YdbExecutor {
-    // Резолв учитывает ambient-контекст транзакций (#98): auto-join,
-    // запрет смешивания с посторонним trx, предупреждения вне транзакции.
-    // Настройки берутся из конфигурации-владельца сущности (#199).
+    // Resolution accounts for the ambient transaction context (#98): auto-join,
+    // rejecting mixing with a foreign trx, and warnings outside a transaction.
+    // Settings come from the entity's owning configuration (#199).
     const db = resolveOperationExecutor(
       trx,
       this.executor,
       this.entityClass.name,
       getEntityRuntime(this.entityClass).transactions,
-      // Логгер СВОЕЙ конфигурации (#206): предупреждение warnOutsideTransaction
-      // уходит в логгер конфигурации-владельца сущности, а не напрямую в консоль.
+      // The configuration's own logger (#206): the warnOutsideTransaction warning
+      // goes to the owning configuration's logger, not straight to the console.
       resolveExecutorLogger(this.executor),
     );
     if (!db) {
@@ -279,8 +280,8 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 
   /**
-   * PK-поля сущности: из метаданных (поддерживается составной PK).
-   * Бросает ошибку, если первичный ключ не объявлен через @YdbPrimaryColumn.
+   * Returns the entity's PK fields from metadata (composite primary keys are
+   * supported). Throws if no primary key is declared via @YdbPrimaryColumn.
    */
   getPkFields(meta: YdbEntityMetadata): string[] {
     if (meta.primaryKeys.length === 0) {
@@ -292,9 +293,9 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 
   /**
-   * Проверяет, что все компоненты PK заданы в объекте, и возвращает
-   * фильтр { pkField: value }. Бросает понятную ошибку, если какой-то
-   * компонент отсутствует (undefined/null).
+   * Verifies that every PK component is set on the given object and returns a
+   * { pkField: value } filter. Throws a clear error if any component is
+   * missing (undefined/null).
    */
   requirePkValues(
     meta: YdbEntityMetadata,
@@ -318,8 +319,8 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 
   /**
-   * Строковое представление PK для контекста шифрования:
-   * значения всех компонентов, соединённые через ':'.
+   * String representation of the PK for the encryption context: the values of
+   * all components joined with ':'.
    */
   pkValueForContext(
     meta: YdbEntityMetadata,
@@ -420,19 +421,19 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 
   /**
-   * Дешифрует поле с безопасным переходом форматов AAD (#165).
+   * Decrypts a field with a safe AAD format transition (#165).
    *
-   * Основной формат берётся из `buildAAD` (конфигурация `aadFormat`). Если
-   * расшифровка основным форматом упала и включён `aadReadFallback` (по
-   * умолчанию true), делается повтор второго формата: legacy-строки,
-   * написанные до введения v2, остаются читаемыми сразу после апгрейда
-   * (дефолт сменился на v2, а данные в БД ещё старые). Поля с `aadOverride`
-   * не зависят от формата — повтор бессмыслен, выполняем один вызов.
+   * The primary format comes from `buildAAD` (the `aadFormat` configuration).
+   * If decryption with the primary format fails and `aadReadFallback` is
+   * enabled (default true), a second attempt is made with the other format:
+   * legacy rows written before v2 was introduced stay readable right after an
+   * upgrade (the default switched to v2 while the DB data is still old). Fields
+   * with `aadOverride` are format-independent, so a fallback is pointless and
+   * only a single call is made.
    *
-   * Если упали ОБА формата — возвращается ошибка ПЕРВОГО (настроечного)
-   * формата: двойной сбой означает не «несовпадение формата», а
-   * испорченный ciphertext или неверный контекст, и падать нужно
-   * детерминированно.
+   * If BOTH formats fail, the error of the FIRST (configured) format is
+   * returned: a double failure means not "format mismatch" but corrupted
+   * ciphertext or a wrong context, so it must fail deterministically.
    */
   private async decryptWithAadFallback(
     provider: YdbEncryptionProvider,
@@ -460,18 +461,18 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 
   /**
-   * Возвращает копию сущности с зашифрованными полями и _bi колонками.
-   * Исходный объект не мутируется: он должен хранить plaintext, иначе
-   * повторный save() зашифрует ciphertext повторно.
-   * Не шифруются: undefined (колонка опускается — омиссия) и null
-   * (колонка очищается). Явный null дополнительно очищает blind index
-   * ({field}_bi = null, #175): иначе старый хеш остался бы в строке и
-   * поиск прежнего plaintext вернул бы очищенную запись.
+   * Returns a copy of the entity with encrypted fields and _bi columns.
+   * The source object is not mutated: it must keep the plaintext, otherwise a
+   * repeated save() would re-encrypt the ciphertext.
+   * Not encrypted: undefined (the column is omitted) and null (the column is
+   * cleared). An explicit null additionally clears the blind index
+   * ({field}_bi = null, #175): otherwise the old hash would remain in the row
+   * and a lookup of the previous plaintext would return the cleared record.
    *
-   * Lazy-поля: если инстанс пришёл из БД и поле не менялось (в нём всё ещё
-   * ciphertext), оно прокидывается как есть — повторное шифрование и
-   * пересчёт blind index не нужны. Если пользователь присвоил новое
-   * значение, оно шифруется как обычный plaintext.
+   * Lazy fields: if the instance came from the DB and the field is unchanged
+   * (it still holds ciphertext), it is passed through as-is — no re-encryption
+   * or blind-index recalculation is needed. If the user assigned a new value,
+   * it is encrypted like regular plaintext.
    */
   async encryptEntity(
     entity: Record<string, any>,
@@ -501,8 +502,8 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
     const encrypted = { ...entity };
     for (const ef of meta.encryptedFields) {
       const value = entity[ef.propertyKey];
-      // undefined — поле не задано: колонки в результате вовсе нет
-      // (write-пути фильтруют по `!== undefined`). Омиссия, не очистка.
+      // undefined — the field is not set, so the column is absent from the
+      // result entirely (write paths filter by `!== undefined`). Omission, not clearing.
       if (value === undefined) continue;
 
       if (ef.lazy && pendingLazy?.get(ef.propertyKey) === value) {
@@ -510,9 +511,9 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
         continue;
       }
 
-      // Явный null — очистка: ciphertext (уже null в spread) И blind index
-      // (#175). Старый хеш в {field}_bi иначе остался бы и поиск прежнего
-      // plaintext вернул бы очищенную строку.
+      // Explicit null — clearing: the ciphertext (already null in the spread)
+      // AND the blind index (#175). Otherwise the old hash in {field}_bi would
+      // remain and a lookup of the previous plaintext would return the cleared row.
       if (value === null) {
         if (ef.blindIndex) {
           encrypted[blindIndexColumnName(ef.propertyKey)] = null;
@@ -547,7 +548,7 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
     return encrypted;
   }
 
-  /** Дешифрует поля в результате запроса. Null/undefined и lazy-поля пропускаются. */
+  /** Decrypts fields in a query result. Null/undefined and lazy fields are skipped. */
   async decryptResult(
     result: Record<string, any> | Record<string, any>[] | null,
   ): Promise<void> {
@@ -593,14 +594,14 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 
   /**
-   * Проверяет, является ли ключ логическим комбинатором WHERE.
+   * Returns whether the key is a logical WHERE combinator.
    */
   private isLogicalKey(key: string): boolean {
     return key === '$and' || key === '$or';
   }
 
   /**
-   * Проверяет, является ли значение объектом-оператором (хотя бы один ключ начинается с $).
+   * Returns whether the value is an operator object (at least one key starts with $).
    */
   private isOperatorObject(value: unknown): value is Record<string, any> {
     if (value === null || typeof value !== 'object' || Array.isArray(value)) {
@@ -611,7 +612,7 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 
   /**
-   * Нормализует значение для WHERE: enum-конвертация, JSON-сериализация.
+   * Normalizes a value for WHERE: enum conversion, JSON serialization.
    */
   private normalizeWhereValue(field: string, value: any): any {
     if (value === null || value === undefined) return value;
@@ -623,12 +624,12 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 
   /**
-   * Извлекает однозначный скаляр для AAD-поля из where-предиката (#166).
-   * Разрешено только прямое скалярное равенство или { $eq: scalar }.
-   * Всё, что не задаёт ровно один экземпляр ($in, $between, диапазоны,
-   * $ne, $like, логические группы, массивы, null) — отклоняется до запроса:
-   * запись шифруется с одним AAD, а при чтении контекст AAD у строк разный —
-   * дешифровка вернёт мусор или упадёт.
+   * Extracts a unique scalar for an AAD field from a where predicate (#166).
+   * Only a direct scalar equality or { $eq: scalar } is allowed. Anything that
+   * does not select exactly one instance ($in, $between, ranges, $ne, $like,
+   * logical groups, arrays, null) is rejected before the query: a record is
+   * encrypted with a single AAD, while on read the AAD context differs per row
+   * — decryption would return garbage or fail.
    */
   private extractUniqueAadValue(
     field: string,
@@ -667,7 +668,7 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 
   /**
-   * Возвращает хеш blind index для зашифрованного поля.
+   * Returns the blind index hash for an encrypted field.
    */
   private async hashBlindIndexForWhere(field: string, value: string) {
     const provider = this.getBlindIndexProvider();
@@ -690,7 +691,7 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 
   /**
-   * Рекурсивно строит SQL-условие для одного поля.
+   * Recursively builds the SQL condition for a single field.
    */
   private async buildFieldCondition(
     field: string,
@@ -710,8 +711,8 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
       );
     }
 
-    // Synthetic {field}_bi колонки в related-предикатах запрещены (#17):
-    // это производное шифрованного поля, а не самостоятельная колонка.
+    // Synthetic {field}_bi columns are forbidden in related predicates (#17):
+    // they are a derived value of an encrypted field, not a standalone column.
     if (env.forbidEncrypted && isSyntheticColumn(meta, field)) {
       throw new Error(
         `Cannot filter related entity ${this.entityClass.name} by blind index column "${field}": ` +
@@ -722,9 +723,9 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
     const ef = meta.encryptedFields.find((e) => e.propertyKey === field);
     const fieldType = dbSchema[field];
 
-    // Зашифрованные поля ищутся только по blind-index (равенство).
+    // Encrypted fields are searchable only via their blind index (equality).
     if (ef) {
-      // В related-предикатах шифрованные поля запрещены полностью (#17).
+      // Inside related predicates encrypted fields are entirely forbidden (#17).
       if (env.forbidEncrypted) {
         throw new Error(
           `Cannot filter related entity ${this.entityClass.name} by encrypted field "${field}": ` +
@@ -789,12 +790,12 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
         : `(${subConditions.join(' AND ')})`;
     }
 
-    // Обычное равенство
+    // Plain equality
     if (value === null) return `${quotedField} IS NULL`;
     if (value === undefined) return undefined;
     const paramName = isRoot ? field : `${field}_${ctx.counter++}_eq`;
-    // Корневое равенство оставляем "сырым": bindParams сам выполнит
-    // enum/JSON-конвертацию по имени поля (для совместимости).
+    // Root equality is left "raw": bindParams performs the enum/JSON conversion
+    // itself by field name (for compatibility).
     ctx.values[paramName] = isRoot
       ? value
       : this.normalizeWhereValue(field, value);
@@ -804,7 +805,7 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 
   /**
-   * Проверяет, является ли колонка JSON-совместимой для JSON_EXISTS/JSON_VALUE.
+   * Returns whether the column is JSON-compatible for JSON_EXISTS/JSON_VALUE.
    */
   private isJsonColumn(
     meta: YdbEntityMetadata,
@@ -819,9 +820,9 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 
   /**
-   * Строит условие для одного оператора над полем. Логические `$and`/`$or`
-   * на уровне значения поля (#201) рекурсивно строят вложенные условия той же
-   * колонки — это делает JSON-предикаты (JSON_EXISTS/JSON_VALUE) композируемыми.
+   * Builds the condition for a single operator over a field. Logical `$and`/`$or`
+   * at the field-value level (#201) recursively build nested conditions of the
+   * same column — this makes JSON predicates (JSON_EXISTS/JSON_VALUE) composable.
    */
   private async buildSingleOperatorCondition(
     field: string,
@@ -1015,11 +1016,11 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 
   /**
-   * Рекурсивно строит SQL-условие из WHERE-объекта.
+   * Recursively builds the SQL condition from a WHERE object.
    *
-   * Ключи резолвятся по приоритету: логический комбинатор ($and/$or) →
-   * колонка сущности → related-фильтр (#17, свойство-связь с объектом
-   * условий по колонкам связанной сущности).
+   * Keys resolve by priority: logical combinator ($and/$or) -> entity column ->
+   * related filter (#17, a relation property holding conditions on the related
+   * entity's columns).
    */
   private async buildWhereNode(
     node: Record<string, any>,
@@ -1055,9 +1056,9 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
           parts.push(`(${subs.join(` ${combiner} `)})`);
         }
       } else if (!dbSchema[key] && this.findRelation(key)) {
-        // Related-фильтр (#17): ключ — свойство-связь, значение — предикат
-        // по колонкам связанной сущности. Колонки проверяются первыми:
-        // существующее поведение для полей не меняется.
+        // Related filter (#17): the key is a relation property and the value is
+        // a predicate over the related entity's columns. Columns are checked
+        // first, so existing behavior for fields is unchanged.
         const sql = await this.buildRelatedCondition(key, value, ctx);
         parts.push(sql);
       } else {
@@ -1077,9 +1078,9 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 
   /**
-   * Общий конвейер WHERE для find/findAll/count/updateBy/deleteBy:
-   * рекурсивная поддержка операторов сравнения, $in, $like, $between,
-   * JSON-операторов и логических групп $and/$or.
+   * Common WHERE pipeline for find/findAll/count/updateBy/deleteBy: recursive
+   * support for comparison operators, $in, $like, $between, JSON operators,
+   * and the logical groups $and/$or.
    */
   async buildWhere(where: Record<string, any>): Promise<{
     whereClause: string;
@@ -1107,9 +1108,9 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
     };
   }
 
-  // ---- Related-фильтры (#17): findAll({ relation: { column: value } }) ----
+  // ---- Related filters (#17): findAll({ relation: { column: value } }) ----
 
-  /** Ищет связь по имени свойства. */
+  /** Finds a relation by its property name. */
   private findRelation(propertyKey: string): RelationMetadata | undefined {
     return getYdbRelationsMetadata(this.entityClass).find(
       (r) => r.propertyKey === propertyKey,
@@ -1117,10 +1118,10 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 
   /**
-   * @internal Строит WHERE-узел предиката связанной сущности в ОБЩИЙ контекст
-   * параметров родительского запроса (#17). Шифрованные колонки запрещены.
-   * Вызывается на persistence-инстансе целевой сущности, поэтому enum/JSON-
-   * нормализация значений работает по метаданным цели.
+   * @internal Builds a WHERE node of a related-entity predicate into the SHARED
+   * parameter context of the parent query (#17). Encrypted columns are
+   * forbidden. It is invoked on the persistence instance of the target entity,
+   * so enum/JSON value normalization follows the target's metadata.
    */
   async buildRelatedPredicate(
     node: Record<string, any>,
@@ -1130,29 +1131,28 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 
   /**
-   * Условие фильтрации корня по колонкам связанной сущности (#17).
+   * Condition to filter the root by the columns of a related entity (#17).
    *
-   * Стратегия — полуслияние через IN с некоррелированным подзапросом:
-   * семантика EXISTS без дубликатов корневых строк. Классический EXISTS
-   * не генерируется намеренно: ядро YQL не поддерживает коррелированные
-   * подзапросы (ссылку на внешний запрос), а некоррелированный EXISTS
-   * менял бы семантику на «существует хотя бы одна строка вообще».
+   * Strategy: a semi-join via IN with a non-correlated subquery — EXISTS
+   * semantics without duplicating root rows. A classic EXISTS is deliberately
+   * not generated: the YQL core does not support correlated subqueries (a
+   * reference to the outer query), and a non-correlated EXISTS would change the
+   * semantics to "at least one row exists at all".
    *
-   * Join-колонки и пути резолвятся только из существующих метаданных связи
-   * (@OneToMany/@ManyToOne/@OneToOne/@ManyToMany + @JoinTable); произвольные
-   * SQL-фрагменты невозможны. Все значения биндятся через общий контекст
-   * параметров (ctx) — интерполяции пользовательских значений нет.
+   * Join columns and paths are resolved only from existing relation metadata
+   * (@OneToMany/@ManyToOne/@OneToOne/@ManyToMany + @JoinTable); arbitrary SQL
+   * fragments are impossible. All values are bound through the shared parameter
+   * context (ctx) — there is no interpolation of user values.
    *
-   * Поддержанные формы:
+   * Supported forms:
    * - one-to-many: `root.pk IN (SELECT child.fk FROM target WHERE pred)`
    * - many-to-one / one-to-one: `root.fk IN (SELECT target.pk FROM target WHERE pred)`
    * - many-to-many: `root.pk IN (SELECT jt.owner FROM jt WHERE jt.inverse IN
    *   (SELECT target.pk FROM target WHERE pred))`
    *
-   * Формы, которые текущая рантайм-модель связей моделирует некорректно
-   * (составные PK на стороне соединения, необъявленные join-колонки,
-   * несовместимые типы, отсутствие @JoinTable), отвергаются с понятной
-   * ошибкой ДО выполнения SQL.
+   * Forms the current relation runtime models incorrectly (composite PKs on the
+   * join side, undeclared join columns, incompatible types, missing @JoinTable)
+   * are rejected with a clear error BEFORE executing the SQL.
    */
   private async buildRelatedCondition(
     relationPropertyKey: string,
@@ -1195,9 +1195,10 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
     const rootMeta = this.getMeta();
     const relationDesc = `"${relationPropertyKey}" (${relation.type}) of ${this.entityClass.name} -> ${Target.name}`;
 
-    // Предикат по колонкам цели строится persistence-инстансом ЦЕЛИ в общий
-    // контекст параметров родителя: уникальность имён обеспечивает общий
-    // счётчик, конвертация enum/JSON — метаданные цели.
+    // The predicate over the target's columns is built by the TARGET's
+    // persistence instance into the parent's shared parameter context: name
+    // uniqueness is guaranteed by the shared counter, and enum/JSON conversion
+    // by the target's metadata.
     const targetPersistence = new YdbEntityPersistence(Target, undefined, {});
     const innerWhere = await targetPersistence.buildRelatedPredicate(
       predicate as Record<string, any>,
@@ -1279,8 +1280,9 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
               `is supported from the owning side that declares the join table.`,
           );
         }
-        // resolveManyToManyJoinTable гарантирует одиночные PK обеих сторон:
-        // составной PK дал бы ошибку конфигурации выше по резолву.
+        // resolveManyToManyJoinTable guarantees single PKs on both sides: a
+        // composite PK would have raised a configuration error earlier in the
+        // resolution.
         const rootPk = rootMeta.primaryKeys[0];
         const targetPk = targetMeta.primaryKeys[0];
         return (
@@ -1298,9 +1300,9 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 
   /**
-   * Совместимость типов join-колонок для related-фильтра (#17):
-   * сравнение разных YDB-типов в IN (...) упало бы уже на сервере —
-   * сообщаем о конфигурации связи раньше, с именами колонок и типов.
+   * Join-column type compatibility for a related filter (#17): comparing
+   * different YDB types in an IN (...) would fail only on the server, so we
+   * report the relation misconfiguration earlier, with the column names and types.
    */
   private assertCompatibleJoinTypes(
     relationDesc: string,
@@ -1332,8 +1334,8 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 
   /**
-   * Создаёт инстанс сущности из строки БД.
-   * Synthetic {field}_bi колонки (blind index) в инстанс не попадают.
+   * Creates an entity instance from a DB row.
+   * Synthetic {field}_bi columns (blind index) never end up on the instance.
    */
   instantiate(row: Record<string, any>): T {
     const meta = this.getMeta();
@@ -1341,9 +1343,9 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
     const instance = new Ctor();
     const enums = getYdbEnumMetadata(this.entityClass);
     for (const [key, value] of Object.entries(row)) {
-      // Только объявленные колонки. Synthetic {field}_bi и ЛЮБЫЕ столбцы,
-      // выпиленные из метаданных (#164), в инстанс не попадают — иначе
-      // legacy-секреты утекли бы в toJSON()/JSON.stringify().
+      // Only declared columns. Synthetic {field}_bi and ANY column removed from
+      // the metadata (#164) are excluded from the instance — otherwise legacy
+      // secrets would leak into toJSON()/JSON.stringify().
       if (!meta.schema[key]) continue;
       const enumMeta = enums.find((e) => e.propertyKey === key);
       let converted = this.convertEnumIn(value, enumMeta);
@@ -1380,20 +1382,19 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 
   /**
-   * Единый конвейер гидратации результатов SELECT: дешифровка →
-   * instantiate → [eager relations] → afterFind.
+   * Unified hydration pipeline for SELECT results: decryption ->
+   * instantiate -> [eager relations] -> afterFind.
    *
-   * Семантика lifecycle (#83):
-   * - afterFind вызывается ровно один раз для каждого инстанса в рамках
-   *   операции чтения и никогда — при пустом результате;
-   * - хуки корневых сущностей срабатывают после догрузки связей;
-   * - связанные сущности (fetchByColumnIn) проходят тот же конвейер с
-   *   `eager: false`: глубина eager остаётся равной 1, как и до #83,
-   *   что исключает бесконечную рекурсию на циклических/self-referencing
-   *   eager-связях.
+   * Lifecycle semantics (#83):
+   * - afterFind fires exactly once per instance within a read operation and
+   *   never on an empty result;
+   * - hooks of root entities fire after relations are loaded;
+   * - related entities (fetchByColumnIn) go through the same pipeline with
+   *   `eager: false`: eager depth stays 1, as before #83, which rules out
+   *   infinite recursion on cyclic/self-referencing eager relations.
    *
-   * `hydrationContext.seen` — identity guard: инстанс, уже попавший в
-   * гидратацию этой операции, не получит afterFind повторно.
+   * `hydrationContext.seen` is an identity guard: an instance already hydrated
+   * by this operation will not receive afterFind again.
    */
   private async hydrate(
     raw: Record<string, any>[],
@@ -1416,9 +1417,9 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
       await this.loadEagerRelations(fresh, options, ctx);
     }
 
-    // afterFind может откладываться (#16): промежуточные уровни вложенного
-    // eager-пути срабатывают в пост-порядке — только после догрузки своих
-    // детей (см. YdbEntityRelations.loadRelationPath / fireAfterFindOn).
+    // afterFind can be deferred (#16): intermediate levels of a nested eager
+    // path fire in post-order — only after their own children are loaded
+    // (see YdbEntityRelations.loadRelationPath / fireAfterFindOn).
     if (
       (opts?.afterFind ?? true) &&
       getLifecycleHooks(this.entityClass).afterFind.length
@@ -1440,15 +1441,22 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 
   /**
-   * Дефолтная проекция SELECT: только объявленные (физические) колонки
-   * сущности (#164). SELECT * утянул бы и столбцы, выпиленные из
-   * метаданных (например legacy recovery_token) — в инстансы и JSON
-   * они попадать не должны.
+   * Default SELECT projection: only the entity's declared (physical) columns
+   * (#164). SELECT * would also pull in columns removed from the metadata
+   * (e.g. a legacy recovery_token) — they must not reach instances or JSON.
    */
   private buildDefaultSelect(meta: YdbEntityMetadata): string {
     return Object.keys(meta.schema).map(quoteIdentifier).join(', ');
   }
 
+  /**
+   * Finds a single entity matching the conditions, or null if none match.
+   * Requires at least one non-empty WHERE condition — use findAll() to query
+   * without filters.
+   * @param where filter conditions (supports operators, relations, $and/$or).
+   * @param options query options (limit/offset, transaction, etc.).
+   * @returns the first matching entity, or null when nothing matches.
+   */
   async find(
     where: Record<string, any>,
     options?: QueryOptions,
@@ -1485,6 +1493,13 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
     return result;
   }
 
+  /**
+   * Finds all entities matching the conditions. With no conditions it returns
+   * the whole table's rows up to the resolveRetrieveLimit default of 100.
+   * @param where filter conditions (defaults to an empty filter).
+   * @param options query options (limit/offset semantics, transaction, etc.).
+   * @returns the matching entities.
+   */
   async findAll(
     where: Record<string, any> = {},
     options?: QueryOptions,
@@ -1511,6 +1526,12 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
     return this.hydrate(rows[0] ?? [], options);
   }
 
+  /**
+   * Counts entities matching the conditions.
+   * @param where filter conditions (defaults to an empty filter).
+   * @param options query options.
+   * @returns the number of matching rows.
+   */
   async count(
     where: Record<string, any> = {},
     options?: QueryOptions,
@@ -1532,6 +1553,7 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
     return Number(rows[0]?.[0]?.cnt ?? 0);
   }
 
+  /** Alias for find(). */
   async findOneBy(
     where: Record<string, any>,
     options?: QueryOptions,
@@ -1539,6 +1561,7 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
     return this.find(where, options);
   }
 
+  /** Alias for findAll(). */
   async findBy(
     where: Record<string, any>,
     options?: QueryOptions,
@@ -1546,11 +1569,12 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
     return this.findAll(where, options);
   }
 
+  /** Returns a fluent query builder scoped to this entity. */
   query(): YdbQueryBuilder<T> {
     return new YdbQueryBuilder<T>(this.entityClass);
   }
 
-  /** @internal Мост для YdbQueryBuilder. */
+  /** @internal Bridge for YdbQueryBuilder. */
   async executeSelect(
     sql: string,
     values: Record<string, any>,
@@ -1570,7 +1594,7 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
     return this.hydrate(rows[0] ?? [], options);
   }
 
-  /** @internal Мост для YdbQueryBuilder. */
+  /** @internal Bridge for YdbQueryBuilder. */
   async executeCount(
     sql: string,
     values: Record<string, any>,
@@ -1589,6 +1613,13 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
     return Number(rows[0]?.[0]?.cnt ?? 0);
   }
 
+  /**
+   * Upserts an entity: updates it if every PK component is set, otherwise
+   * inserts it (auto-filling a `uuid` / timestamp columns as needed).
+   * @param entity the entity to persist (mutated by timestamp/uuid fill).
+   * @param options query options.
+   * @returns the persisted entity.
+   */
   async save(entity: T, options?: QueryOptions): Promise<T> {
     const meta = this.getMeta();
     const pkFields = this.getPkFields(meta);
@@ -1720,6 +1751,14 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
     return this.instantiate(raw);
   }
 
+  /**
+   * Inserts many entities in batches (grouped by identical column sets, up to
+   * BATCH_SIZE rows per UPSERT). Auto-fills `uuid`/timestamp columns and runs
+   * beforeInsert/afterInsert lifecycle hooks for each entity.
+   * @param entities rows to insert.
+   * @param options query options.
+   * @returns the inserted entities (mutated by uuid/timestamp fill).
+   */
   async insertMany(entities: T[], options?: QueryOptions): Promise<T[]> {
     if (!entities.length) return [];
 
@@ -1747,8 +1786,8 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
       }
     }
 
-    // beforeInsert: как в insert() — до валидации, шифрования и формирования
-    // параметров; мутации полей из хуков попадают в БД.
+    // beforeInsert: as in insert() — before validation, encryption and
+    // parameter building; field mutations from the hooks reach the DB.
     for (const e of entities) {
       await this.callHooks('beforeInsert', e);
     }
@@ -1819,7 +1858,7 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
       }
     }
 
-    // afterInsert: только после успешного завершения всех батчей записи.
+    // afterInsert: only after all write batches have completed successfully.
     for (const e of entities) {
       await this.callHooks('afterInsert', e);
     }
@@ -1827,6 +1866,16 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
     return entities;
   }
 
+  /**
+   * Updates all rows matching `where` with the given patch (which must not
+   * overlap the WHERE fields). Refuses an empty WHERE/patch or a full-table
+   * update. Encrypted fields in the patch are re-encrypted with the AAD derived
+   * from the fixed WHERE predicate.
+   * @param where filter selecting the rows to update.
+   * @param patch the fields and new values to set.
+   * @param options query options.
+   * @returns the number of rows updated (via RETURNING over the PK).
+   */
   async updateBy(
     where: Record<string, any>,
     patch: Partial<Record<string, any>>,
@@ -1870,17 +1919,18 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
       const encryptionProvider = this.requireEncryptionProvider();
       for (const ef of encryptedFieldsToProcess) {
         const value = data[ef.propertyKey];
-        // undefined — поле не задано: исключаем из patch (омиссия), чтобы
-        // колонка осталась как есть и в SET не попадала ни она, ни её
-        // blind index (#175). null же — ЯВНАЯ очистка, см. ниже.
+        // undefined — the field is not set: exclude it from the patch
+        // (omission), so the column stays untouched and neither it nor its
+        // blind index enters SET (#175). null, in contrast, is an EXPLICIT
+        // clearing — see below.
         if (value === undefined) {
           delete data[ef.propertyKey];
           continue;
         }
 
-        // Явный null — очистка ciphertext и blind index вместе (#175):
-        // иначе старый хеш в {field}_bi остался бы, и поиск прежнего
-        // plaintext вернул бы обновлённые строки.
+        // Explicit null — clear the ciphertext and the blind index together
+        // (#175): otherwise the old hash in {field}_bi would remain and a
+        // lookup of the previous plaintext would return the updated rows.
         if (value === null) {
           if (ef.blindIndex) {
             data[blindIndexColumnName(ef.propertyKey)] = null;
@@ -1991,6 +2041,14 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
     return rows[0]?.length ?? 0;
   }
 
+  /**
+   * Deletes the row identified by its primary key and returns the deleted
+   * entity (decrypted), or null if no such row exists. Runs beforeRemove if the
+   * entity declares it.
+   * @param pkValue the PK value, or an object with all PK components.
+   * @param options query options.
+   * @returns the deleted entity, or null when nothing matched.
+   */
   async delete(
     pkValue: string | number | Record<string, any>,
     options?: QueryOptions,
@@ -2044,6 +2102,13 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
     return this.instantiate(raw);
   }
 
+  /**
+   * Deletes all rows matching `where`. Refuses an empty or ineffective WHERE to
+   * prevent a full-table delete.
+   * @param where filter selecting the rows to delete.
+   * @param options query options.
+   * @returns the number of rows deleted (via RETURNING over the PK).
+   */
   async deleteBy(
     where: Record<string, any>,
     options?: QueryOptions,
@@ -2079,8 +2144,8 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 
   /**
-   * Дешифрует одно lazy-поле (@YdbEncrypted({ lazy: true })) на инстансе.
-   * Идемпотентно: повторный вызов отдаёт закешированный plaintext.
+   * Decrypts a single lazy field (@YdbEncrypted({ lazy: true })) on an
+   * instance. Idempotent: a subsequent call returns the cached plaintext.
    */
   async decryptField(instance: T, name: string): Promise<any> {
     const meta = this.getMeta();
@@ -2142,7 +2207,7 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 
   /**
-   * Дешифрует все lazy-поля инстанса. Идемпотентно.
+   * Decrypts all lazy fields of an instance. Idempotent.
    */
   async decryptLazyFields(instance: T): Promise<T> {
     const meta = this.getMeta();
@@ -2156,9 +2221,9 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 
   /**
-   * Вызывает afterFind на переданных инстансах (в пост-порядке вложенного
-   * eager-пути #16). Инстансы промежуточного уровня уже гидратированы с
-   * `afterFind: false`, поэтому срабатывание здесь — ровно один раз.
+   * Fires afterFind on the given instances (in post-order of a nested eager
+   * path #16). Intermediate-level instances were already hydrated with
+   * `afterFind: false`, so firing here happens exactly once.
    */
   async fireAfterFind(instances: object[]): Promise<void> {
     if (!getLifecycleHooks(this.entityClass).afterFind.length) return;
@@ -2170,20 +2235,20 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   // ---- Relations helpers (delegated to YdbEntityRelations at repository level) ----
 
   /**
-   * Batch-загрузка по колонке IN (...). Используется relations-модулем.
+   * Batch load by an IN (...) column. Used by the relations module.
    *
-   * Guard-ы (#86):
-   * - пустой список значений — пустой результат БЕЗ выполнения SQL
-   *   (раньше уходил невалидный `WHERE col IN ()`);
-   * - дубликаты значений убираются до построения IN (...) — они раздували
-   *   список параметров и не меняли результат;
-   * - значения больше MAX_IN_CLAUSE_VALUES режутся на несколько чанков
-   *   (лимиты YDB на текст запроса/число параметров), результаты сливаются
-   * по порядку чанков без дубликатов строк (по PK).
+   * Guards (#86):
+   * - an empty value list returns an empty result WITHOUT executing SQL
+   *   (previously an invalid `WHERE col IN ()` was sent);
+   * - duplicate values are removed before building the IN (...) — they only
+   *   bloated the parameter list without changing the result;
+   * - more values than MAX_IN_CLAUSE_VALUES are split into several chunks
+   *   (YDB limits on query text/parameter count), and results are merged in
+   *   chunk order without duplicate rows (by PK).
    *
-   * `hydration.afterFind` (по умолчанию true): если false, гидратированные
-   * инстансы НЕ получают afterFind сразу — их послеFind откладывается для
-   * пост-порядка вложенного eager-пути (#16).
+   * `hydration.afterFind` (default true): when false, hydrated instances do NOT
+   * receive afterFind immediately — it is deferred for the post-order of a
+   * nested eager path (#16).
    */
   async fetchByColumnIn(
     column: string,
@@ -2203,7 +2268,7 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
     const uniqueValues = dedupeInValues(values);
     if (!uniqueValues.length) return [];
 
-    // PK для дедупликации результатов между чанками.
+    // PK used to deduplicate results across chunks.
     const pkFields = this.getPkFields(meta);
 
     const result: T[] = [];
@@ -2224,19 +2289,19 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
         options,
       );
 
-      // Внутренний batch-фетч связей: без вложенной догрузки eager — глубина
-      // собственных eager-связей цели остаётся 1 (как до #83), иначе
-      // циклические связи рекурсируют. afterFind при этом обязателен для
-      // связанных сущностей (issue #83), но для промежуточных уровней
-      // вложенного eager-пути (#16) его можно отложить через hydration.
+      // Internal batch fetch of relations: no nested eager loading — the depth
+      // of the target's own eager relations stays 1 (as before #83), otherwise
+      // cyclic relations would recurse. afterFind is mandatory for related
+      // entities (issue #83), but for intermediate levels of a nested eager
+      // path (#16) it can be deferred via hydration.
       const hydrated = await this.hydrate(rows[0] ?? [], options, {
         eager: false,
         afterFind: hydration?.afterFind ?? true,
       });
 
       for (const entity of hydrated) {
-        // Инъективный ключ идентичности PK (#86): без разделительной
-        // конкатенации — 'a|b'+'c' и 'a'+'b|c' не должны совпадать.
+        // Injective PK identity key (#86): without delimiter concatenation —
+        // 'a|b'+'c' and 'a'+'b|c' must not collide.
         const key = valueIdentityKey(pkFields.map((f) => (entity as any)[f]));
         if (seenPks.has(key)) continue;
         seenPks.add(key);
@@ -2248,9 +2313,9 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 
   /**
-   * Загружает eager relations для списка сущностей.
-   * Вызывается из find/findAll/executeSelect. Контекст гидратации
-   * прокидывается в связанные сущности (identity guard для afterFind).
+   * Loads eager relations for a list of entities.
+   * Called from find/findAll/executeSelect. The hydration context is forwarded
+   * to related entities (identity guard for afterFind).
    */
   private async loadEagerRelations(
     items: T[],
@@ -2273,7 +2338,7 @@ export class YdbEntityPersistence<T extends YdbBaseEntity> {
   }
 }
 
-/** Проверяет, что колонка — synthetic blind index ({field}_bi) */
+/** Returns whether the column is a synthetic blind index ({field}_bi) */
 export function isSyntheticColumn(
   meta: YdbEntityMetadata,
   key: string,
@@ -2287,7 +2352,7 @@ export function isSyntheticColumn(
 }
 
 /**
- * Обратно-совместимый алиас канонического ключа PK: реализация перенесена
- * в core/value-identity.ts (#174) и обобщена до valueIdentityKey.
+ * Backward-compatible alias of the canonical PK key: the implementation moved
+ * to core/value-identity.ts (#174) and was generalized to valueIdentityKey.
  */
 export { valueIdentityKey as pkIdentityKey } from '../core/value-identity.js';

--- a/src/persistence/idempotent-threading.spec.ts
+++ b/src/persistence/idempotent-threading.spec.ts
@@ -3,10 +3,10 @@ import { YdbEntityPersistence } from './entity-persistence.js';
 import { YdbEntityRelations } from '../relations/entity-relations.js';
 
 /**
- * Проводка QueryOptions.idempotent (#27): точки исполнения ORM обязаны
- * передавать явную пометку идемпотентности в нижележащий запрос — только
- * она разрешает retry-политике повторять запрос (fail-safe по умолчанию:
- * без пометки запрос выполняется ровно один раз).
+ * Threading of QueryOptions.idempotent (#27): ORM execution points must
+ * forward an explicit idempotency flag to the underlying query — only it
+ * allows the retry policy to repeat a request (fail-safe by default: without
+ * the flag the query runs exactly once).
  */
 
 function fakeQuery(marks: boolean[]): any {
@@ -28,8 +28,8 @@ function fakeQuery(marks: boolean[]): any {
   return query;
 }
 
-describe('QueryOptions.idempotent пробрасывается в запрос (#27)', () => {
-  it('persistence.executeQuery: пометка применяется при { idempotent: true }', async () => {
+describe('QueryOptions.idempotent is threaded into the query (#27)', () => {
+  it('persistence.executeQuery: marker applied when { idempotent: true }', async () => {
     const persistence: any = Object.create(YdbEntityPersistence.prototype);
 
     const marked: boolean[] = [];
@@ -41,7 +41,7 @@ describe('QueryOptions.idempotent пробрасывается в запрос (
     expect(unmarked).toEqual([]);
   });
 
-  it('relations.executeQuery: пометка применяется при { idempotent: true }', async () => {
+  it('relations.executeQuery: marker applied when { idempotent: true }', async () => {
     const relations: any = Object.create(YdbEntityRelations.prototype);
 
     const marked: boolean[] = [];

--- a/src/persistence/related-filter.spec.ts
+++ b/src/persistence/related-filter.spec.ts
@@ -19,10 +19,10 @@ import {
   runWithTransactionContext,
 } from '../transaction/transaction-context.js';
 
-// ---- Тестовая модель (#17): все типы связей + формы для ошибок ----
-// Классы-цели объявляются ДО классов-владельцев singular-связей:
-// emitDecoratorMetadata порождает design:type со ссылкой на класс,
-// и прямая ссылка «вперёд» упала бы по TDZ.
+// ---- Test model (#17): all relation types + error shapes ----
+// Target classes are declared BEFORE the owner classes of singular relations:
+// emitDecoratorMetadata produces a design:type referencing the class, and a
+// direct "forward" reference would fail on the TDZ.
 
 @YdbEntity('rf_profiles')
 class RfProfile extends YdbBaseEntity {
@@ -38,8 +38,8 @@ class RfRole extends YdbBaseEntity {
   @YdbPrimaryColumn('Uuid')
   uuid: string;
 
-  // FK на владельца; составной PK дочерней сущности не мешает o2m-фильтру:
-  // соединение идёт по колонке user_uuid, а не по PK цели.
+  // FK to the owner; the child's composite PK does not impede the o2m filter:
+  // the join goes through the user_uuid column, not the target's PK.
   @YdbPrimaryColumn('Uuid')
   user_uuid: string;
 
@@ -98,7 +98,7 @@ class RfUser extends YdbBaseEntity {
   tags?: RfTag[];
 }
 
-// Составной PK корня: one-to-many по первому PK смоделирован быть не может.
+// Composite root PK: a one-to-many joining on the first PK cannot be modeled.
 @YdbEntity('rf_composites')
 class RfComposite extends YdbBaseEntity {
   @YdbPrimaryColumn('Uuid')
@@ -110,15 +110,15 @@ class RfComposite extends YdbBaseEntity {
   @OneToMany(() => RfRole, (role) => role.user_uuid)
   roles?: RfRole[];
 
-  // m2o на составной PK цели — неподдерживаемая форма.
+  // m2o onto a composite target PK — an unsupported form.
   @YdbColumn('Uuid')
   big_ref: string;
 
   @ManyToOne(() => RfBig, (self) => self.big_ref)
   big?: RfBig;
 
-  // m2o с одиночным PK цели — для проверки запрета шифрованных колонок
-  // и вложенных related-путей.
+  // m2o with a single target PK — to check the encrypted-column ban and
+  // nested related paths.
   @YdbColumn('Uuid')
   user_link: string;
 
@@ -126,7 +126,7 @@ class RfComposite extends YdbBaseEntity {
   linkedUser?: RfUser;
 }
 
-// Несовпадение типов join-колонок: Int32 (корень) vs Uuid (FK цели).
+// Join-column type mismatch: Int32 (root) vs Uuid (target FK).
 @YdbEntity('rf_mismatch_users')
 class RfMismatchUser extends YdbBaseEntity {
   @YdbPrimaryColumn('Int32')
@@ -136,7 +136,7 @@ class RfMismatchUser extends YdbBaseEntity {
   roles?: RfRole[];
 }
 
-// Join-колонка не объявлена на целевой сущности.
+// The join column is not declared on the target entity.
 @YdbEntity('rf_ghosts')
 class RfGhost extends YdbBaseEntity {
   @YdbPrimaryColumn('Uuid')
@@ -146,7 +146,7 @@ class RfGhost extends YdbBaseEntity {
   profiles?: RfProfile[];
 }
 
-// many-to-many без @JoinTable.
+// many-to-many without @JoinTable.
 @YdbEntity('rf_orphans')
 class RfOrphan extends YdbBaseEntity {
   @YdbPrimaryColumn('Uuid')
@@ -156,7 +156,7 @@ class RfOrphan extends YdbBaseEntity {
   tags?: RfTag[];
 }
 
-// Цель связи — класс без @YdbEntity.
+// The relation target is a class without @YdbEntity.
 @YdbEntity('rf_to_bare')
 class RfToBare extends YdbBaseEntity {
   @YdbPrimaryColumn('Uuid')
@@ -179,11 +179,11 @@ function mockRuntime(rows: any[][] = [[]], sequential = false) {
 
 describe('Related-entity filters (#17): findAll({ relation: { column } })', () => {
   afterEach(() => {
-    // Глобальные настройки транзакций не должны протекать между тестами.
+    // Global transaction settings must not leak between tests.
     configureTransactionContext(undefined);
   });
 
-  it('1. one-to-many: фильтр по одной колонке связанной сущности', async () => {
+  it('1. one-to-many: filter on a single column of the related entity', async () => {
     const mock = mockRuntime([
       [{ uuid: UUID, status: 'active', profile_uuid: UUID }],
     ]);
@@ -198,13 +198,13 @@ describe('Related-entity filters (#17): findAll({ relation: { column } })', () =
     expect(sql).toContain(
       '`uuid` IN (SELECT `user_uuid` FROM `rf_roles` WHERE `role` = $',
     );
-    // Полуслияние, а не JOIN: дубликаты корневых строк невозможны.
+    // Semi-join rather than a JOIN: duplicate root rows are impossible.
     expect(sql.toUpperCase()).not.toContain('JOIN');
     expect(sql).not.toContain("'admin'");
     expect(sql).toMatch(/LIMIT 100 OFFSET 0$/);
   });
 
-  it('2. несколько related-предикатов AND с обычными условиями корня', async () => {
+  it('2. several related-predicates AND-combined with root conditions', async () => {
     const mock = mockRuntime([]);
 
     await RfUser.findAll({
@@ -214,7 +214,7 @@ describe('Related-entity filters (#17): findAll({ relation: { column } })', () =
     });
 
     const sql = mock.queries[0].sql;
-    // Корневое равенство + два независимых IN-подзапроса через AND.
+    // Root equality + two independent IN subqueries combined with AND.
     expect(sql).toContain('`status` = $status');
     expect(sql).toContain(
       '`profile_uuid` IN (SELECT `uuid` FROM `rf_profiles` WHERE `bio` = $',
@@ -226,7 +226,7 @@ describe('Related-entity filters (#17): findAll({ relation: { column } })', () =
     expect((mock.queries[0].params.status as any).value).toBe('active');
   });
 
-  it('3. вложенные логические условия: $or/$and смешивают корень и связи', async () => {
+  it('3. nested logical conditions: $or/$and mix root and relations', async () => {
     const mock = mockRuntime([]);
 
     await RfUser.findAll({
@@ -237,7 +237,7 @@ describe('Related-entity filters (#17): findAll({ relation: { column } })', () =
       '(`status` = $status_0_eq OR `uuid` IN (SELECT `user_uuid` FROM `rf_roles` WHERE `role` = $',
     );
 
-    // $or ВНУТРИ предиката связи.
+    // $or INSIDE a relation predicate.
     await RfUser.findAll({
       roles: { $or: [{ role: 'admin' }, { is_admin: true }] },
     });
@@ -247,7 +247,7 @@ describe('Related-entity filters (#17): findAll({ relation: { column } })', () =
     );
     expect(innerOrSql).toContain('OR `is_admin` = $');
 
-    // Та же связь дважды через $and: два отдельных подзапроса (семантика EXISTS).
+    // The same relation twice via $and: two separate subqueries (EXISTS semantics).
     await RfUser.findAll({
       $and: [{ roles: { role: 'admin' } }, { roles: { is_admin: true } }],
     });
@@ -255,7 +255,7 @@ describe('Related-entity filters (#17): findAll({ relation: { column } })', () =
     expect(andSql.match(/`uuid` IN \(SELECT `user_uuid`/g)?.length).toBe(2);
     expect(andSql).toContain(') AND `uuid` IN (SELECT');
 
-    // Вложенный related-путь: связь связи.
+    // Nested related path: a relation of a relation.
     getEntityRuntime(RfComposite).executor = mock.executor;
     await RfComposite.findAll({ linkedUser: { roles: { role: 'admin' } } });
     const nestedSql = mock.queries[3].sql;
@@ -274,7 +274,7 @@ describe('Related-entity filters (#17): findAll({ relation: { column } })', () =
       roles: { role: 'admin' },
     });
 
-    // Один запрос, одна строка: полуслияние IN не размножает корневые строки.
+    // One query, one row: the IN semi-join does not multiply root rows.
     expect(mock.queries).toHaveLength(1);
     expect(users).toHaveLength(1);
     expect(mock.queries[0].sql.toUpperCase()).not.toContain('JOIN ');
@@ -283,17 +283,17 @@ describe('Related-entity filters (#17): findAll({ relation: { column } })', () =
   it('5. unknown relation/column fails BEFORE executing SQL', async () => {
     const mock = mockRuntime();
 
-    // Неизвестное свойство вообще (не колонка и не связь).
+    // An entirely unknown property (neither a column nor a relation).
     await expect(RfUser.findAll({ bogus_relation: { x: 1 } })).rejects.toThrow(
       /Unknown field in WHERE: "bogus_relation"/,
     );
 
-    // Связь существует, колонка на цели — нет.
+    // The relation exists, but the target column does not.
     await expect(RfUser.findAll({ roles: { nope: 1 } })).rejects.toThrow(
       /Unknown field in WHERE: "nope" on entity RfRole/,
     );
 
-    // Невалидная форма предиката.
+    // An invalid predicate shape.
     await expect(RfUser.findAll({ roles: null as any })).rejects.toThrow(
       /Invalid filter on relation "roles".*got null/,
     );
@@ -305,12 +305,12 @@ describe('Related-entity filters (#17): findAll({ relation: { column } })', () =
   });
 
   it('6. encrypted related column is rejected clearly (incl. blind index)', async () => {
-    // RfComposite нужен собственный executor: проверка executor'а происходит
-    // до построения WHERE, а валидация шифрованных колонок — до выполнения SQL.
+    // RfComposite needs its own executor: executor checks happen before the
+    // WHERE is built, while encrypted-column validation is before SQL execution.
     const mock = createMockExecutor([[[]]]);
     getEntityRuntime(RfComposite).executor = mock.executor;
 
-    // Даже blind index запрещён внутри related-фильтров (#17).
+    // Even the blind index is forbidden inside related filters (#17).
     await expect(
       RfComposite.findAll({ linkedUser: { email_encrypted: 'a@b.c' } }),
     ).rejects.toThrow(
@@ -327,7 +327,7 @@ describe('Related-entity filters (#17): findAll({ relation: { column } })', () =
   });
 
   it('7. empty predicate and no-match related rows return correct results', async () => {
-    // Пустой предикат {} = «есть хотя бы одна связанная строка».
+    // An empty {} predicate = "there is at least one related row".
     const emptyMock = mockRuntime([]);
     const none = await RfUser.findAll({ roles: {} });
     expect(none).toEqual([]);
@@ -335,7 +335,7 @@ describe('Related-entity filters (#17): findAll({ relation: { column } })', () =
       '`uuid` IN (SELECT `user_uuid` FROM `rf_roles`) LIMIT',
     );
 
-    // Связанные строки есть, но предикат не совпал — пустой результат корней.
+    // Related rows exist, but the predicate does not match — empty root result.
     const noMatchMock = mockRuntime([[]]);
     const noMatch = await RfUser.findAll({ roles: { role: 'admin' } });
     expect(noMatch).toEqual([]);
@@ -347,7 +347,7 @@ describe('Related-entity filters (#17): findAll({ relation: { column } })', () =
     const trx = createMockExecutor([[[]]]);
     getEntityRuntime(RfUser).executor = base.executor;
 
-    // Явная транзакция.
+    // An explicit transaction.
     await RfUser.findAll({ roles: { role: 'admin' } }, { trx: trx.executor });
     expect(trx.queries).toHaveLength(1);
     expect(base.queries).toHaveLength(0);
@@ -378,7 +378,7 @@ describe('Related-entity filters (#17): findAll({ relation: { column } })', () =
       .limit(10)
       .toYql();
 
-    // Ни одного литерала значения в SQL — только плейсхолдеры $param.
+    // No value literals in the SQL — only $param placeholders.
     expect(sql).not.toContain('admin');
     expect(sql).not.toContain("'active'");
     expect(sql).toContain('LIMIT 10');

--- a/src/query/query-builder.ts
+++ b/src/query/query-builder.ts
@@ -8,16 +8,18 @@ import {
   resolveRetrieveOffset,
 } from '../core/query-limits.js';
 
-// Константы живут в core/query-limits.ts (единая точка семантики LIMIT/OFFSET
-// для билдера и persistence); реэкспорт сохраняет публичный API.
+// The canonical constants live in core/query-limits.ts (single definition point
+// of LIMIT/OFFSET semantics for the builder and persistence); re-export keeps
+// the public API intact.
 export {
   DEFAULT_RETRIEVE_LIMIT,
   MAX_RETRIEVE_LIMIT,
 } from '../core/query-limits.js';
 
+/** Sort direction for ORDER BY clauses. */
 export type OrderDirection = 'ASC' | 'DESC';
 
-/** Результат toYql(): собранный SQL и значения параметров (до маппинга в типы YDB). */
+/** Result of toYql(): the assembled SQL and parameter values (before mapping to YDB types). */
 export interface BuiltQuery {
   sql: string;
   values: Record<string, any>;
@@ -33,16 +35,16 @@ type EntityClass<T extends YdbBaseEntity> = {
 } & typeof YdbBaseEntity;
 
 /**
- * Цепочный query builder поверх Active Record сущности.
- * Условия where/andWhere — только равенство, объединяются через AND
- * (повторное поле в andWhere перезаписывает предыдущее). JSON-предикаты
- * (andWhereJsonExists/andWhereJsonValue) для одной колонки НЕ перезаписывают
- * друг друга, а компонуются через AND (#201).
- * Зашифрованные поля с blind index поддерживаются так же, как в find/findAll.
+ * Chainable query builder over an Active Record entity.
+ * where/andWhere conditions are equality-only and combined with AND
+ * (repeating a field in andWhere overwrites the previous value). JSON
+ * predicates (andWhereJsonExists/andWhereJsonValue) for the same column do
+ * NOT overwrite each other — they compose via AND (#201).
+ * Encrypted fields with a blind index are supported just like in find/findAll.
  *
- * Билдер переиспользуем: методы-строители (where/orderBy/limit/... ) и методы
- * выполнения (getMany/getOne/toYql) не мутируют состояние друг друга.
- * Один и тот же билдер можно выполнить несколько раз — результат одинаковый.
+ * The builder is reusable: builder methods (where/orderBy/limit/... ) and
+ * execution methods (getMany/getOne/toYql) do not mutate each other's state.
+ * The same builder can be executed multiple times — the result is identical.
  *
  * @example
  *   const photos = await PhotoEntity.query()
@@ -61,35 +63,35 @@ export class YdbQueryBuilder<T extends YdbBaseEntity> {
 
   constructor(private readonly entity: EntityClass<T>) {}
 
-  /** Добавить условия равенства (AND). Повторный вызов дополняет условия. */
+  /** Adds equality conditions (AND). Repeated calls append to the conditions. */
   where(criteria: Record<string, any>): this {
     this.whereValues = { ...this.whereValues, ...criteria };
     return this;
   }
 
-  /** Синоним where() для читаемости цепочек. */
+  /** Alias of where() for readable chains. */
   andWhere(criteria: Record<string, any>): this {
     return this.where(criteria);
   }
 
   /**
-   * Добавить условие, объединённое со ВСЕМ накопленным предикатом через OR
-   * (#173): `.where(A).orWhere(B)` — `A OR B`, а не `A AND (B)`.
+   * Adds a condition OR-ed with the ENTIRE accumulated predicate
+   * (#173): `.where(A).orWhere(B)` yields `A OR B`, not `A AND (B)`.
    *
-   * Повторные orWhere выстраивают плоскую цепочку `A OR B OR C`; следующий
-   * andWhere/where связывается через AND: `(A OR B OR C) AND D`.
+   * Repeated orWhere calls build a flat chain `A OR B OR C`; a subsequent
+   * andWhere/where is combined via AND: `(A OR B OR C) AND D`.
    */
   orWhere(criteria: Record<string, any>): this {
     const keys = Object.keys(this.whereValues).filter(
       (key) => this.whereValues[key] !== undefined,
     );
-    // Накопленного предиката нет — первый orWhere задаёт просто предикат.
+    // No accumulated predicate — the first orWhere just sets the predicate.
     if (keys.length === 0) {
       this.whereValues = criteria;
       return this;
     }
-    // Накопленный предикат — ровно $or: дополняем существующий список,
-    // сохраняя плоскую цепочку `A OR B OR C` без вложенности.
+    // The accumulated predicate is exactly $or: append to the existing list,
+    // keeping the flat `A OR B OR C` chain without nesting.
     if (keys.length === 1 && keys[0] === '$or') {
       const existing = this.whereValues.$or;
       const list = Array.isArray(existing) ? existing : [existing];
@@ -101,23 +103,23 @@ export class YdbQueryBuilder<T extends YdbBaseEntity> {
   }
 
   /**
-   * Добавить условие JSON_EXISTS для JSON-колонки (#201).
-   * Колонка должна быть объявлена как `@YdbColumn('Json')`, `@YdbColumn('JsonDocument')`
-   * или `@YdbJson()`.
+   * Adds a JSON_EXISTS condition for a JSON column (#201).
+   * The column must be declared as `@YdbColumn('Json')`, `@YdbColumn('JsonDocument')`
+   * or `@YdbJson()`.
    *
-   * Несколько JSON-предикатов для одной колонки сохраняются и объединяются
-   * через AND (композиция через `$and`), а не перезаписывают друг друга.
+   * Multiple JSON predicates for the same column are preserved and combined
+   * via AND (`$and` composition), not overwriting each other.
    */
   andWhereJsonExists(column: string, path: string): this {
     return this.appendJsonCondition(column, { $jsonExists: path });
   }
 
   /**
-   * Добавить условие JSON_VALUE = значение для JSON-колонки (#201).
-   * Значение сравнивается как строка (Utf8).
+   * Adds a JSON_VALUE = value condition for a JSON column (#201).
+   * The value is compared as a string (Utf8).
    *
-   * Несколько JSON-предикатов для одной колонки сохраняются и объединяются
-   * через AND (композиция через `$and`), а не перезаписывают друг друга.
+   * Multiple JSON predicates for the same column are preserved and combined
+   * via AND (`$and` composition), not overwriting each other.
    */
   andWhereJsonValue(column: string, path: string, value: any): this {
     return this.appendJsonCondition(column, {
@@ -126,9 +128,9 @@ export class YdbQueryBuilder<T extends YdbBaseEntity> {
   }
 
   /**
-   * Накопить JSON-предикат для колонки (#201). Существующий предикат той же
-   * колонки не перезаписывается: первым задаётся как есть, каждый следующий
-   * присоединяется через `$and` (явная AND-семантика).
+   * Accumulates a JSON predicate for a column (#201). An existing predicate
+   * for the same column is not overwritten: the first is stored as-is, every
+   * subsequent one is appended via `$and` (explicit AND semantics).
    */
   private appendJsonCondition(
     column: string,
@@ -145,17 +147,18 @@ export class YdbQueryBuilder<T extends YdbBaseEntity> {
     if (existing === undefined) {
       next = predicate;
     } else if (isJsonGroup) {
-      // Уже накопленная группа — дополняем плоский список `$and`.
+      // Already-accumulated group — append to the flat `$and` list.
       const members = (existing as { $and: unknown[] }).$and;
       next = { $and: [...members, predicate] };
     } else {
-      // Любое предыдущее значение той же колонки сохраняется в группу.
+      // Any previous value of the same column is preserved into the group.
       next = { $and: [existing, predicate] };
     }
     this.whereValues = { ...this.whereValues, [column]: next };
     return this;
   }
 
+  /** Sets the ORDER BY clause, replacing any previously set order. */
   orderBy(field: string, direction: OrderDirection = 'ASC'): this {
     this.orderClauses = [
       { field, direction: this.normalizeDirection(direction) },
@@ -163,6 +166,7 @@ export class YdbQueryBuilder<T extends YdbBaseEntity> {
     return this;
   }
 
+  /** Appends an additional ORDER BY clause. */
   addOrderBy(field: string, direction: OrderDirection = 'ASC'): this {
     this.orderClauses.push({
       field,
@@ -172,9 +176,9 @@ export class YdbQueryBuilder<T extends YdbBaseEntity> {
   }
 
   /**
-   * Рантайм-валидация направления сортировки: trim + uppercase,
-   * whitelist ASC|DESC. Защита от SQL-инъекции через direction,
-   * переданный как any/из JS в обход TS-типа OrderDirection.
+   * Runtime validation of the sort direction: trim + uppercase,
+   * whitelist ASC|DESC. Protects against SQL injection via a direction
+   * passed as any/from JS, bypassing the TS OrderDirection type.
    */
   private normalizeDirection(direction: unknown): OrderDirection {
     if (typeof direction !== 'string') {
@@ -192,11 +196,12 @@ export class YdbQueryBuilder<T extends YdbBaseEntity> {
   }
 
   /**
-   * Указать конкретные колонки для SELECT (вместо SELECT *).
+   * Selects specific columns for the query (instead of SELECT *).
    *
-   * Семантика пустой проекции (#202): `select([])` явно отклоняется ошибкой,
-   * а не молчаливо превращается в дефолтную проекцию. Пропущенный `select()`
-   * продолжает использовать дефолтную проекцию всех объявленных колонок (#164).
+   * Empty-projection semantics (#202): `select([])` is explicitly rejected
+   * with an error rather than silently falling back to the default
+   * projection. Omitting `select()` keeps the default projection of all
+   * declared columns (#164).
    */
   select(columns: string[]): this {
     if (!Array.isArray(columns) || columns.length === 0) {
@@ -211,42 +216,43 @@ export class YdbQueryBuilder<T extends YdbBaseEntity> {
   }
 
   /**
-   * Ограничить количество возвращаемых строк (LIMIT).
+   * Limits the number of returned rows (LIMIT).
    *
-   * Явная семантика (без молчаливого clamp в диапазон 1..1000):
-   * - `limit(0)` — `LIMIT 0`: гарантированно пустой результат `[]`;
-   * - положительное целое значение `n` — до `n` строк, сверху обрезается до
-   *   MAX_RETRIEVE_LIMIT (защитный потолок);
-   * - лимит вообще не задан — действует защитный дефолт
-   *   DEFAULT_RETRIEVE_LIMIT (см. resolveLimit);
-   * - отрицательное, дробное или неконечное значение — ошибка.
+   * Explicit semantics (no silent clamp into the 1..1000 range):
+   * - `limit(0)` — `LIMIT 0`: guaranteed empty result `[]`;
+   * - positive integer `n` — up to `n` rows, capped at
+   *   MAX_RETRIEVE_LIMIT (safety ceiling);
+   * - limit not set — the safety default DEFAULT_RETRIEVE_LIMIT applies
+   *   (see resolveLimit);
+   * - negative, fractional or non-finite value — error.
    *
-   * Значение сохраняется в билдере и не меняется при выполнении:
-   * getOne()/getMany()/toYql() его читают, но не перезаписывают.
+   * The value is stored on the builder and does not change during execution:
+   * getOne()/getMany()/toYql() read it but never overwrite it.
    */
   limit(limit: number): this {
     this.limitValue = limit;
     return this;
   }
 
+  /** Sets the offset for the query. Fractional values are floored; negatives become 0. */
   offset(offset: number): this {
     this.offsetValue = offset;
     return this;
   }
 
-  /** QueryOptions: trx, signal, timeout. limit/offset из билдера приоритетнее. */
+  /** QueryOptions: trx, signal, timeout. Builder limit/offset take precedence. */
   options(options: QueryOptions): this {
     this.queryOptions = options;
     return this;
   }
 
-  /** Собирает SQL и значения параметров без выполнения. */
+  /** Assembles the SQL and parameter values without executing. */
   async toYql(): Promise<BuiltQuery> {
     const { sql, values } = await this.build();
     return { sql, values };
   }
 
-  /** Выполняет запрос и возвращает сущности (с eager relations). */
+  /** Executes the query and returns entities (with eager relations). */
   async getMany(): Promise<T[]> {
     const { sql, values, keys, dbSchema } = await this.build();
     const rows = await this.entity._executeSelect(
@@ -259,23 +265,23 @@ export class YdbQueryBuilder<T extends YdbBaseEntity> {
     return rows as T[];
   }
 
-  /** Алиас getMany(). */
+  /** Alias of getMany(). */
   execute(): Promise<T[]> {
     return this.getMany();
   }
 
   /**
-   * Первая запись или null.
+   * Returns the first row or null.
    *
-   * Не мутирует исходный билдер: LIMIT 1 применяется к копии. Повторный
-   * getMany()/toYql() на этом же билдере сохранит заданный пользователем лимит.
+   * Does not mutate the source builder: LIMIT 1 is applied to a clone.
+   * A later getMany()/toYql() on the same builder keeps the user-set limit.
    */
   async getOne(): Promise<T | null> {
     const result = await this.clone().limit(1).getMany();
     return result[0] ?? null;
   }
 
-  /** COUNT(*) по тем же условиям (без limit/offset/order). */
+  /** COUNT(*) over the same conditions (ignores limit/offset/order). */
   async getCount(): Promise<number> {
     const meta = this.getMeta();
     const { whereClause, values, keys, dbSchema } =
@@ -292,7 +298,7 @@ export class YdbQueryBuilder<T extends YdbBaseEntity> {
     );
   }
 
-  /** Копия билдера: выполнение на копии не меняет состояние исходника. */
+  /** Clone of the builder: executing the clone does not change the source's state. */
   private clone(): YdbQueryBuilder<T> {
     const copy = new YdbQueryBuilder<T>(this.entity);
     copy.whereValues = { ...this.whereValues };
@@ -322,8 +328,8 @@ export class YdbQueryBuilder<T extends YdbBaseEntity> {
 
     const selectClause = this.selectColumns?.length
       ? this.selectColumns.map(quoteIdentifier).join(', ')
-      : // Дефолтная проекция — только объявленные колонки (#164):
-        // SELECT * утянул бы и столбцы, выпиленные из метаданных.
+      : // Default projection — only declared columns (#164):
+        // SELECT * would also pull columns removed from the metadata.
         Object.keys(meta.schema).map(quoteIdentifier).join(', ');
 
     const sql =
@@ -374,9 +380,9 @@ export class YdbQueryBuilder<T extends YdbBaseEntity> {
     return Object.keys(dbSchema).join(', ');
   }
 
-  // Семантика LIMIT/OFFSET — общая с persistence (core/query-limits.ts):
-  // limit() билдера приоритетнее queryOptions.limit; 0 → LIMIT 0;
-  // отрицательные/дробные — ошибка; потолок MAX_RETRIEVE_LIMIT.
+  // LIMIT/OFFSET semantics are shared with persistence (core/query-limits.ts):
+  // builder limit() takes precedence over queryOptions.limit; 0 → LIMIT 0;
+  // negative/fractional → error; ceiling MAX_RETRIEVE_LIMIT.
   private resolveLimit(): number {
     return resolveRetrieveLimit(this.limitValue ?? this.queryOptions?.limit);
   }

--- a/src/query/query-builder.ts
+++ b/src/query/query-builder.ts
@@ -36,10 +36,13 @@ type EntityClass<T extends YdbBaseEntity> = {
 
 /**
  * Chainable query builder over an Active Record entity.
- * where/andWhere conditions are equality-only and combined with AND
- * (repeating a field in andWhere overwrites the previous value). JSON
- * predicates (andWhereJsonExists/andWhereJsonValue) for the same column do
- * NOT overwrite each other — they compose via AND (#201).
+ * `where()` / `andWhere()` add conditions that support the same WHERE
+ * operators as the persistence layer, including comparison operators,
+ * `$in`, `$like`, `$between`, `$and` / `$or`, JSON predicates, and
+ * related-entity filters where supported.
+ *
+ * JSON predicates (`andWhereJsonExists` / `andWhereJsonValue`) for the same
+ * column do NOT overwrite each other — they compose via AND (#201).
  * Encrypted fields with a blind index are supported just like in find/findAll.
  *
  * The builder is reusable: builder methods (where/orderBy/limit/... ) and

--- a/src/relations/entity-relations.ts
+++ b/src/relations/entity-relations.ts
@@ -34,29 +34,29 @@ import {
 } from './resolve-join-table.js';
 import { valueIdentityKey } from '../core/value-identity.js';
 
-/** Канонический value-ключ отношений (#174): Bytes и Date сравниваются
- * по значению, а не по ссылке (гидрация создаёт независимые инстансы
- * Uint8Array/Date — по ссылке валидные связи «не находились»). */
+/** Canonical value key for relations (#174): Bytes and Date are compared by
+ * value, not by reference (hydration creates independent Uint8Array/Date
+ * instances, so by-reference valid relations would go "not found"). */
 function relationKey(value: unknown): string {
   return valueIdentityKey([value]);
 }
 
 /**
- * Зависимости relations-модуля.
+ * Relations module dependencies.
  */
 export interface RelationsDeps {
   encryptionProvider?: YdbEncryptionProvider;
   blindIndexProvider?: YdbBlindIndexProvider;
   /**
-   * @internal Общий контекст гидратации одной операции чтения.
-   * Передаётся в persistence связанных сущностей при batch-фетче,
-   * чтобы afterFind сработал ровно один раз на инстанс (см. #83).
+   * @internal Shared hydration context of one read operation.
+   * Passed to the persistence of related entities during batch fetch so that
+   * afterFind fires exactly once per instance (see #83).
    */
   hydrationContext?: HydrationContext;
 }
 
 /**
- * Relations-класс: eager loading, lazy loadRelations, many-to-many.
+ * Relations class: eager loading, lazy loadRelations, many-to-many.
  */
 export class YdbEntityRelations<T extends YdbBaseEntity> {
   constructor(
@@ -65,15 +65,15 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
     private readonly options: RelationsDeps = {},
   ) {}
 
-  /** Обновляет executor (вызывается из runtime при смене deps). */
+  /** Updates the executor (called from runtime when deps change). */
   setExecutor(executor: YdbExecutor | undefined): void {
     this.executor = executor;
   }
 
   private getExecutor(trx?: YdbExecutor): YdbExecutor | undefined {
-    // Ambient-контекст транзакций (#98): auto-join / запрет смешивания.
-    // Настройки — из конфигурации-владельца сущности (#199), логгер — тоже
-    // из неё (#206): предупреждения warnOutsideTransaction не эмитятся чужим.
+    // Ambient transaction context (#98): auto-join / no mixing. Settings come
+    // from the entity's owning configuration (#199), and so does the logger
+    // (#206): warnOutsideTransaction warnings are not emitted by a foreign one.
     return resolveOperationExecutor(
       trx,
       this.executor,
@@ -101,7 +101,8 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
   }
 
   /**
-   * Batch-загрузка по колонке IN (...).
+   * Batch loads related entities by an IN (...) column, delegating to the
+   * target's persistence (deduplicating, chunking, and hydration rules apply).
    */
   private async fetchByColumnIn(
     Target: typeof YdbBaseEntity,
@@ -129,33 +130,32 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
   }
 
   /**
-   * Batch-загрузка many-to-many: join-таблица + инверсные сущности.
-   * Возвращает Map<owner PK, related entities[]>.
+   * Batch load of many-to-many: join table + inverse entities.
+   * Returns a Map<owner PK, related entities[]>.
    *
-   * Батчинг и guard-ы (#86): пустой список владельцев — ноль запросов;
-   * дубликаты PK владельцев убираются; join-select чанкуется по
-   * MAX_IN_CLAUSE_VALUES (чанки по owner-PK не пересекаются, поэтому
-   * каждый владелец встречается ровно в одном чанке).
+   * Batching and guards (#86): an empty owner list results in zero queries;
+   * duplicate owner PKs are removed; the join select is chunked by
+   * MAX_IN_CLAUSE_VALUES (owner-PK chunks do not overlap, so each owner appears
+   * in exactly one chunk).
    *
-   * Память ограничена (#209) и семантика эквивалентна одному согласованному
-   * чтению (#224): join-таблица читается ровно ОДИН раз на чанк — для
-   * каждого чанка сразу собираются уникальные inverse FK, по ним выбираются
-   * (только ещё не загруженные) инверсные сущности, и результат заполняется.
-   * Полный `links[]` не материализуется, повторного чтения изменяемого
-   * состояния join-таблицы нет — рассинхронизации «pass 1 vs pass 2», когда
-   * ссылка появляется во втором чтении, но отсутствует в собранных FK (и
-   * потому молча теряется), не существует: каждый inverse FK результата
-   * получен ровно из того же чтения, что и его ссылка.
+   * Memory is bounded (#209) and semantics equal a single consistent read
+   * (#224): the join table is read exactly ONCE per chunk — for each chunk the
+   * unique inverse FKs are collected on the fly, the (not-yet-loaded) inverse
+   * entities are fetched by them, and the result is filled in. A full `links[]`
+   * is never materialized and there is no re-read of the mutable join-table
+   * state, so a "pass 1 vs pass 2" desync — a link appearing in the second
+   * read but absent from the collected FKs (and thus silently lost) — cannot
+   * exist: every inverse FK of the result comes from the same read as its link.
    *
-   * Общие инстансы между чанками: инверсные сущности кешируются по PK в
-   * `byInversePk` — один тег, общий для нескольких владельцев в разных
-   * чанках, гидратируется (и получает afterFind) ровно один раз и разделяется
-   * между владельцами по ссылке. Инверсный FK, уже загруженный в другом
-   * чанке, не выбирается повторно (без N+1 и без дублей инстансов).
+   * Shared instances across chunks: inverse entities are cached by PK in
+   * `byInversePk` — one tag shared by several owners in different chunks is
+   * hydrated (and gets afterFind) exactly once and is shared between owners by
+   * reference. An inverse FK already loaded in another chunk is not fetched
+   * again (no N+1, no duplicate instances).
    *
-   * Кардинальность и порядок совпадают с одиночным чтением join-таблицы:
-   * одинаковые (owner, inverse) строки не дедуплицируются, порядок сущностей
-   * владельца — порядок строк его чанка из БД.
+   * Cardinality and ordering match a single read of the join table: identical
+   * (owner, inverse) rows are not deduplicated, and an owner's entity order is
+   * the order of its chunk rows from the DB.
    */
   private async loadManyToManyRelation(
     items: YdbBaseEntity[],
@@ -181,9 +181,9 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
     const targetPkField = getPrimaryKey(Target);
 
     const result = new Map<string, YdbBaseEntity[]>();
-    // Общий кеш инверсных сущностей: общий инстанс на PK между чанками.
-    // Растёт до числа различных инверсных сущностей (масштаб результата),
-    // а не до числа повторений ссылок.
+    // Shared cache of inverse entities: one instance per PK across chunks.
+    // It grows up to the number of distinct inverse entities (result scale),
+    // not the number of link repetitions.
     const byInversePk = new Map<string, YdbBaseEntity>();
 
     for (const chunk of chunkInValues(uniqueOwnerPks)) {
@@ -203,7 +203,7 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
       const chunkRows = await this.executeQuery(joinQuery, options);
       const rows = (chunkRows[0] ?? []) as { [key: string]: any }[];
 
-      // Уникальные inverse FK этого чанка (для выборки сущностей).
+      // Unique inverse FKs of this chunk (to fetch the entities).
       const inverseFkValues: any[] = [];
       const seenFk = new Set<string>();
       for (const row of rows) {
@@ -216,8 +216,8 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
         }
       }
 
-      // Выбираем только те инверсные сущности, которых ещё нет в кеше:
-      // общие инстансы между чанками, без повторной гидратации и без N+1.
+      // Fetch only the inverse entities not yet in the cache: shared instances
+      // across chunks, without re-hydration and without N+1.
       const missing = inverseFkValues.filter(
         (fk) => !byInversePk.has(relationKey(fk)),
       );
@@ -234,8 +234,8 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
         }
       }
 
-      // Заполняем результат по строкам этого единственного чтения join-
-      // таблицы: порядок и кардинальность — как у базового SELECT'а.
+      // Fill the result from the rows of this single join-table read: ordering
+      // and cardinality match the underlying SELECT.
       for (const row of rows) {
         const ownerFk = row[ownerColumn];
         const inverseFk = row[inverseColumn];
@@ -255,14 +255,14 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
   }
 
   /**
-   * Eager loading: батч IN (...) на каждый уровень связи (без N+1).
+   * Eager loading: a batch IN (...) per relation level (no N+1).
    *
-   * Каждая запись @EagerLoad — путь из имён relations, разделённых точкой
-   * (например `tags.owner`). Допустимая длина пути:
-   * - один сегмент — классическая eager-загрузка одного уровня (как до #16);
-   * - несколько сегментов — вложенная загрузка (issue #16): после загрузки
-   *   первого уровня его инстансы становятся «родителями» для следующего
-   *   сегмента, ключи переносятся вперёд батчами.
+   * Each @EagerLoad entry is a path of dot-separated relation names
+   * (for example `tags.owner`). Allowed path lengths:
+   * - one segment — classic single-level eager loading (as before #16);
+   * - several segments — nested loading (issue #16): after the first level is
+   *   loaded, its instances become the "parents" for the next segment, and the
+   *   keys are carried forward by batches.
    */
   async loadEagerRelations(items: T[], options?: QueryOptions): Promise<void> {
     if (!items.length) return;
@@ -277,20 +277,21 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
   }
 
   /**
-   * Единый обход relation-пути (#16): рекурсивно загружает сегменты пути по
-   * одному батчу IN (...) на уровень, перенося ключи предыдущего уровня вперёд.
+   * Single traversal of a relation path (#16): recursively loads path segments,
+   * one batch IN (...) per level, carrying the previous level's keys forward.
    *
-   * Для многоуровневых путей afterFind промежуточных инстансов откладывается
-   * (afterFind: false в гидратации) и срабатывает в пост-порядке — после
-   * загрузки собственных детей — через fireAfterFindOn (см. #83/#107).
+   * For multi-level paths, the afterFind of intermediate instances is deferred
+   * (afterFind: false in hydration) and fires in post-order — after their own
+   * children are loaded — via fireAfterFindOn (see #83/#107).
    *
-   * Явный { trx } пробрасывается во ВЕСЬ обход (#16): на время многоуровневого
-   * пути открывается внутренний транзакционный контекст (per-call ambient из
-   * #98), поэтому запросы БЕЗ явного { trx } — включая те, что запускают
-   * afterFind-хуки промежуточных уровней — выполняются через тот же executor
-   * транзакции. Глобальный ambient для этого не нужен и не меняется; новая
-   * транзакция/сессия не создаётся (SDK исполняет повторные вызовы executor'а
-   * транзакции в ней же), commit/rollback остаётся у владельца транзакции.
+   * An explicit { trx } is threaded through the ENTIRE traversal (#16): for the
+   * duration of a multi-level path an internal transaction context is opened
+   * (the per-call ambient from #98), so queries WITHOUT an explicit { trx } —
+   * including those that fire the afterFind hooks of intermediate levels — go
+   * through the same transaction executor. Global ambient is neither needed nor
+   * changed; no new transaction/session is created (the SDK runs repeated
+   * transaction-executor calls in it), and commit/rollback stays with the
+   * transaction owner.
    */
   private async loadRelationPath(
     items: YdbBaseEntity[],
@@ -313,11 +314,11 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
       );
     }
 
-    // Внутренний контекст нужен только для многоуровневых путей с явным
-    // { trx }: одноуровневая eager-load и ambient-режим ведут себя как раньше.
+    // The internal context is only needed for multi-level paths with an explicit
+    // { trx }: single-level eager load and ambient mode behave as before.
     if (options?.trx && segments.length > 1) {
-      // Извлекаем transactionId из явного trx (или генерируем и сохраняем его),
-      // чтобы resolveOperationExecutor не ругался на смешивание транзакций.
+      // Extract the transactionId from the explicit trx (or generate and store
+      // one) so resolveOperationExecutor does not complain about mixing transactions.
       const extractedId = getTransactionId(options.trx);
       const transactionId: symbol =
         typeof extractedId === 'symbol' ? extractedId : Symbol('transaction');
@@ -344,7 +345,7 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
     await this.loadRelationSegments(rel, items, segments, options);
   }
 
-  /** Тело обхода пути без управления транзакционным контекстом (#16). */
+  /** The path traversal body, without transaction-context management (#16). */
   private async loadRelationSegments(
     rel: RelationMetadata,
     items: YdbBaseEntity[],
@@ -357,22 +358,22 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
     });
 
     if (isIntermediate) {
-      // Дети этого уровня уже загружены — пост-порядковый afterFind
-      // срабатывает для этого уровня после его потомков.
+      // This level's children are already loaded — post-order afterFind fires
+      // for this level after its descendants.
       await this.loadRelationPath(targets, segments.slice(1), options);
       await this.fireAfterFindOn(targets, options);
     }
   }
 
   /**
-   * Загружает ОДНУ связь для списка инстансов одним (или несколькими
-   * чанками) IN (...) и возвращает свежезагруженные инстансы цели — они
-   * становятся «родителями» следующего уровня вложенного eager-пути (#16).
+   * Loads ONE relation for a list of instances with one (or several chunks of)
+   * IN (...) and returns the freshly loaded target instances — they become the
+   * "parents" of the next level of a nested eager path (#16).
    *
-   * `hydration.afterFind:false` применяется для промежуточных уровней пути,
-   * чтобы их afterFind сработал в пост-порядке (после детей).
-   * `strict` (для публичной loadRelations) сохраняет прежние контракты
-   * ошибок: бросает на undefined PK/FK, тогда как eager-путь их пропускает.
+   * `hydration.afterFind:false` is applied for intermediate path levels so that
+   * their afterFind fires in post-order (after children).
+   * `strict` (for the public loadRelations) preserves the previous error
+   * contracts: it throws on undefined PK/FK, whereas the eager path skips them.
    */
   private async loadRelation(
     items: YdbBaseEntity[],
@@ -402,9 +403,9 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
         }
       }
 
-      // null-PK не входят в IN (...) — их группы и так пусты ([]).
-      // В строгом режиме (публичный loadRelations) всё равно назначаем [],
-      // как было до #16; в eager-пути пустой список ключей — просто skip.
+      // null PKs are left out of the IN (...) — their groups are empty ([]) even
+      // without them. In strict mode (public loadRelations) we still assign [],
+      // as before #16; in the eager path an empty key list is simply skipped.
       const pks = dedupeInValues(
         items
           .map((item) => (item as any)[pkField])
@@ -431,8 +432,8 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
         }
       }
 
-      // Копия массива на инстанс: два инстанса с одним PK не должны
-      // разделять один массив (раньше у каждого был свой findAll).
+      // A copy of the array per instance: two instances sharing one PK must not
+      // share a single array (each used to have its own findAll).
       for (const item of items) {
         const group = byFk.get(relationKey((item as any)[pkField]));
         (item as any)[rel.propertyKey] = group ? [...group] : [];
@@ -473,7 +474,7 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
       );
       if (!pks.length && !strict) return [];
 
-      // Один батч-вызов на ВСЕ инстансы вместо пары запросов на каждый.
+      // One batch call for ALL instances instead of a couple of queries each.
       const related = await this.loadManyToManyRelation(
         items,
         Target,
@@ -488,9 +489,8 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
         (item as any)[rel.propertyKey] = group ? [...group] : [];
       }
 
-      // Уникальные инстансы целей (по ссылке): один тег, общий для
-      // нескольких владельцев, должен встретиться в следующих уровнях
-      // пути ровно один раз.
+      // Unique target instances (by reference): one tag shared by several
+      // owners must appear in the next path levels exactly once.
       const targets: YdbBaseEntity[] = [];
       const seenInst = new Set<object>();
       for (const group of related.values()) {
@@ -522,8 +522,8 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
       }
     }
 
-    // null-FK не входят в IN (...) — им назначается null, как возвращал
-    // find() по условию «PK = NULL» (пустой результат).
+    // null FKs are left out of the IN (...) — they are assigned null, as
+    // find() with a "PK = NULL" condition would return (empty result).
     const fks = dedupeInValues(
       items
         .map((item) => (item as any)[joinColumnName])
@@ -552,12 +552,12 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
   }
 
   /**
-   * Пост-порядковый afterFind для инстансов промежуточного уровня
-   * вложенного eager-пути (#16): срабатывает после их детей.
+   * Post-order afterFind for intermediate-level instances of a nested eager
+   * path (#16): fires after their children.
    *
-   * Persistence создаётся с тем же { trx }, что и загрузка связи (#16-fix):
-   * отложенный afterFind промежуточного уровня не теряет транзакцию
-   * вызывающего — любые DB-операции внутри хуков идут через неё.
+   * Persistence is created with the same { trx } as the relation load
+   * (#16-fix): the deferred afterFind of an intermediate level does not lose
+   * the caller's transaction — any DB operations inside the hooks go through it.
    */
   private async fireAfterFindOn(
     targets: YdbBaseEntity[],
@@ -573,16 +573,16 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
   }
 
   /**
-   * Явная загрузка relations для одного или нескольких инстансов.
+   * Explicitly loads relations for one or more instances.
    *
-   * Батчинг (#86): для каждой связи сначала собираются все значения
-   * FK/PK по массиву инстансов, затем выполняется один (или несколько
-   * чанков) IN (...) запрос — как в eager-пути. Раньше каждый тип связи
-   * ходил запросом НА КАЖДЫЙ инстанс: 100 записей = 100–200 запросов.
+   * Batching (#86): for each relation all FK/PK values across the instance list
+   * are collected first, then one (or several chunks of) IN (...) query runs —
+   * as in the eager path. Previously each relation type sent a query PER
+   * INSTANCE: 100 records = 100-200 queries.
    *
-   * Делегирует в общий loadRelation (#16) в строгом режиме: проверяет
-   * неизвестное имя связи и сохраняет прежние контракты ошибок для
-   * undefined PK/FK и отсутствующей join-таблицы.
+   * Delegates to the shared loadRelation (#16) in strict mode: it checks for an
+   * unknown relation name and preserves the previous error contracts for
+   * undefined PK/FK and a missing join table.
    */
   async loadRelations(
     items: T[],
@@ -618,7 +618,7 @@ export class YdbEntityRelations<T extends YdbBaseEntity> {
   }
 }
 
-/** Возвращает первый PK из метаданных. Бросает ошибку, если PK не объявлен. */
+/** Returns the first PK from the metadata. Throws if no PK is declared. */
 function getPrimaryKey(target: typeof YdbBaseEntity): string {
   const meta = getYdbEntityMetadata(target);
   if (!meta?.primaryKeys?.length) {

--- a/src/relations/resolve-join-table.ts
+++ b/src/relations/resolve-join-table.ts
@@ -7,21 +7,21 @@ import {
 import type { YdbPrimitive } from '../core/types.js';
 
 /**
- * Метаданные join-таблицы many-to-many, ориентированные относительно
- * запрашиваемой сущности (owner).
+ * Many-to-many join-table metadata, oriented relative to the requesting
+ * entity (the owner).
  *
- * Вынесено из entity-relations в отдельный модуль (#17): related-фильтры
- * в entity-persistence используют тот же резолв, что и eager/lazy-загрузка,
- * а прямой импорт entity-relations из persistence породил бы цикл.
+ * Extracted from entity-relations into a separate module (#17): related filters
+ * in entity-persistence use the same resolution as eager/lazy loading, and a
+ * direct import of entity-relations from persistence would create a cycle.
  */
 export interface ResolvedJoinTable {
   tableName: string;
   ownerColumn: string;
   inverseColumn: string;
   /**
-   * YDB-тип owner-колонки join-таблицы (#90): тип PK owner-сущности.
-   * Схема join-таблицы (schema sync) выводит те же имена и типы, поэтому
-   * чтение всегда совместимо со сгенерированной таблицей.
+   * YDB type of the join table's owner column (#90): the owner entity's PK type.
+   * The join-table schema (schema sync) derives the same names and types, so
+   * reads are always compatible with the generated table.
    */
   ownerColumnType: YdbPrimitive;
   ownerEntity: typeof YdbBaseEntity;
@@ -29,12 +29,12 @@ export interface ResolvedJoinTable {
 }
 
 /**
- * Находит метаданные join-таблицы для many-to-many.
+ * Resolves the join-table metadata for a many-to-many relation.
  *
- * Валидация и разрешение конфликтов выполняются тем же кодом, что и при
- * генерации схемы: getManyToManyJoinTables для пары сущностей. Поэтому
- * рантайм не может молча выбрать одно из расходящихся объявлений таблицы —
- * он упадёт с той же ошибкой конфликта, что и schema sync/migrations (#139).
+ * Validation and conflict resolution run through the same code used for schema
+ * generation: getManyToManyJoinTables for the entity pair. The runtime
+ * therefore cannot silently pick one of diverging table declarations — it
+ * throws the same conflict error as schema sync/migrations (#139).
  */
 export function resolveManyToManyJoinTable(
   owner: typeof YdbBaseEntity,
@@ -45,11 +45,11 @@ export function resolveManyToManyJoinTable(
   const inverseMeta = getYdbEntityMetadata(inverseEntity);
   if (!ownerMeta || !inverseMeta) return undefined;
 
-  // Все объявления join-таблиц, видимые для пары (владелец, inverse):
-  // здесь же проверяются PK и конфликты объявлений одного имени (#90/#139).
+  // All join-table declarations visible for the (owner, inverse) pair: PKs and
+  // conflicts of same-name declarations are checked here as well (#90/#139).
   const definitions = getManyToManyJoinTables([owner, inverseEntity]);
 
-  // Декларация на самом владельце для этой связи.
+  // A declaration on the owner itself for this relation.
   const own = definitions.find(
     (d) => d.ownerEntity === owner && d.ownerProperty === relation.propertyKey,
   );
@@ -59,17 +59,18 @@ export function resolveManyToManyJoinTable(
       tableName: own.tableName,
       ownerColumn: own.joinColumn,
       inverseColumn: own.inverseJoinColumn,
-      // Имя, тип и сущности берутся из того же определения, по которому
-      // строится схема join-таблицы (#87): расхождений между рантаймом
-      // и schema sync быть не может.
+      // The name, type and entities come from the same definition used to
+      // build the join-table schema (#87): no divergence between the runtime
+      // and schema sync is possible.
       ownerColumnType: own.joinColumnType,
       ownerEntity: owner,
       inverseEntity,
     };
   }
 
-  // Зеркальная декларация на обратной стороне: колонки разворачиваются —
-  // joinColumn объявления принадлежит inverse-сущности, inverseJoinColumn — владельцу.
+  // A mirrored declaration on the inverse side: the columns are flipped — the
+  // declaration's joinColumn belongs to the inverse entity, and its
+  // inverseJoinColumn to the owner.
   const inverseOwned = definitions.find(
     (d) => d.ownerEntity === inverseEntity && d.inverseEntity === owner,
   );
@@ -79,7 +80,7 @@ export function resolveManyToManyJoinTable(
       tableName: inverseOwned.tableName,
       ownerColumn: inverseOwned.inverseJoinColumn,
       inverseColumn: inverseOwned.joinColumn,
-      // Тип owner-колонки = тип PK владельца = тип её колонки в объявлении.
+      // Owner-column type = owner PK type = its column type in the declaration.
       ownerColumnType: inverseOwned.inverseJoinColumnType,
       ownerEntity: owner,
       inverseEntity,

--- a/src/repository/repository-resolver.ts
+++ b/src/repository/repository-resolver.ts
@@ -41,8 +41,8 @@ function sameDeps(
 }
 
 /**
- * Возвращает (или создаёт) YdbRepository для сущности из текущих runtime deps.
- * Repository кешируется в entity-runtime и пересоздаётся при смене executor/провайдеров.
+ * Returns (or creates) a YdbRepository for an entity from current runtime deps.
+ * Repository is cached in entity-runtime and recreated when executor/providers change.
  */
 export function getOrCreateRepository<T extends YdbBaseEntity>(
   entityClass: YdbEntityConstructor<T>,

--- a/src/repository/ydb-entity-manager.ts
+++ b/src/repository/ydb-entity-manager.ts
@@ -4,13 +4,17 @@ import { YdbRepository } from './ydb-repository.js';
 import { getOrCreateRepository } from './repository-resolver.js';
 
 /**
- * Менеджер сущностей — фабрика репозиториев.
+ * Entity manager — a repository factory.
  *
- * Удобен, когда сервису нужны несколько репозиториев или их набор
- * заранее неизвестен. Репозитории не хранят состояния, поэтому
- * можно создавать их на лету.
+ * Useful when a service needs multiple repositories or their set
+ * is not known in advance. Repositories don't hold state, so
+ * they can be created on the fly.
  */
 export class YdbEntityManager {
+  /**
+   * Returns the `YdbRepository` for the given entity class, creating
+   * it from the current runtime dependencies if not yet cached.
+   */
   getRepository<T extends YdbBaseEntity>(
     entityClass: YdbEntityConstructor<T>,
   ): YdbRepository<T> {

--- a/src/repository/ydb-repository.ts
+++ b/src/repository/ydb-repository.ts
@@ -10,13 +10,13 @@ import type { YdbEntityRelations } from '../relations/entity-relations.js';
 export type { YdbEntityConstructor };
 
 /**
- * Репозиторий для работы с конкретной сущностью YDB.
+ * Repository for working with a specific YDB entity.
  *
- * Содержит `YdbEntityPersistence` (CRUD, шифрование, lifecycle hooks)
- * и `YdbEntityRelations` (eager/lazy relations). Является публичным DI-API:
- * `YdbOrmModule.forFeature([...])` регистрирует инжектируемый `YdbRepository<Entity>`.
+ * Contains `YdbEntityPersistence` (CRUD, encryption, lifecycle hooks)
+ * and `YdbEntityRelations` (eager/lazy relations). Serves as the public DI API:
+ * `YdbOrmModule.forFeature([...])` registers an injectable `YdbRepository<Entity>`.
  *
- * Использование в NestJS:
+ * Usage in NestJS:
  * ```ts
  * @Injectable()
  * class UserService {

--- a/src/schema/schema-sync.spec.ts
+++ b/src/schema/schema-sync.spec.ts
@@ -81,7 +81,7 @@ class TestNoPkEntity extends YdbBaseEntity {
   name: string;
 }
 
-// #89: составной PK — порядок колонок значим при сравнении схем
+// #89: composite PK — column order matters when comparing schemas
 @YdbEntity('test_composite_pk')
 class TestCompositePkEntity extends YdbBaseEntity {
   @YdbPrimaryColumn('Utf8')
@@ -139,12 +139,12 @@ class TestNumericTtlEntity extends YdbBaseEntity {
   @YdbPrimaryColumn('Uuid')
   uuid: string;
 
-  // Uint32 нет в YdbPrimitive — числовые TTL-типы проверяются отдельно
+  // Uint32 is not in YdbPrimitive — numeric TTL types are verified separately
   @YdbColumn('Uint32' as never)
   expires_at: number;
 }
 
-// Сущность для проверки не-примитивных типов в БД (#91)
+// Entity for verifying non-primitive types in the DB (#91)
 @YdbEntity('test_unsupported_types')
 class TestUnsupportedTypesEntity extends YdbBaseEntity {
   @YdbPrimaryColumn('Uuid')
@@ -168,7 +168,7 @@ class TestPhotoEntity extends YdbBaseEntity {
   tags?: TestTagEntity[];
 }
 
-// #90: many-to-many с не-uuid PK (кастомные имена свойств)
+// #90: many-to-many with non-uuid PK (custom property names)
 @YdbEntity('test_articles')
 class TestArticleEntity extends YdbBaseEntity {
   @YdbPrimaryColumn('Uuid')
@@ -194,7 +194,7 @@ class TestAuthorEntity extends YdbBaseEntity {
   articles?: TestArticleEntity[];
 }
 
-// #90: разные PK-типы на сторонах связи (Int64 ↔ Utf8) + явные имена колонок
+// #90: different PK types on relation sides (Int64 ↔ Utf8) + explicit column names
 @YdbEntity('test_orders')
 class TestOrderEntity extends YdbBaseEntity {
   @YdbPrimaryColumn('Int64')
@@ -223,7 +223,7 @@ class TestSkuEntity extends YdbBaseEntity {
   orders?: TestOrderEntity[];
 }
 
-// #90: составной PK на стороне owner — явный отказ
+// #90: composite PK on the owner side — explicitly rejected
 @YdbEntity('test_m2m_comp_users')
 class TestCompositeUserEntity extends YdbBaseEntity {
   @YdbPrimaryColumn('Utf8')
@@ -252,8 +252,8 @@ class TestCompositeRoleEntity extends YdbBaseEntity {
   users?: TestCompositeUserEntity[];
 }
 
-// #90/#139: зеркальные декларации одной join-таблицы на обеих сторонах —
-// физически эквивалентны, дедуплицируются безопасно
+// #90/#139: mirrored declarations of the same join table on both sides are
+// physically equivalent and are deduplicated safely
 @YdbEntity('test_sym_lefts')
 class TestSymLeftEntity extends YdbBaseEntity {
   @YdbPrimaryColumn('Int64')
@@ -286,8 +286,8 @@ class TestSymRightEntity extends YdbBaseEntity {
   lefts?: TestSymLeftEntity[];
 }
 
-// #139: конфликтующие объявления одного имени таблицы
-// (разные пары сущностей с разными PK-типами)
+// #139: conflicting declarations of one table name
+// (different entity pairs with different PK types)
 @YdbEntity('test_dup_orders')
 class TestDupOrderEntity extends YdbBaseEntity {
   @YdbPrimaryColumn('Int64')
@@ -356,8 +356,8 @@ const description = (
   ...(ttl ? { ttl } : {}),
 });
 
-// #89: описание таблицы с составным PK; primaryKey передаётся явно,
-// чтобы проверять перестановки порядка
+// #89: table description with a composite PK; primaryKey is passed
+// explicitly so order permutations can be tested
 const compositePkExpected = buildExpectedTableSchema(
   meta(TestCompositePkEntity),
 );
@@ -432,7 +432,7 @@ describe('buildExpectedJoinTableSchema', () => {
     expect(joinTables).toHaveLength(1);
 
     const [jt] = joinTables;
-    // PK называются article_id/author_id — дефолтные имена выводятся из них
+    // PKs are named article_id/author_id — default names are derived from them
     expect(jt.joinColumn).toBe('test_articles_article_id');
     expect(jt.inverseJoinColumn).toBe('test_authors_author_id');
 
@@ -469,9 +469,9 @@ describe('buildExpectedJoinTableSchema', () => {
   });
 
   it('definition always carries explicit column types; schema builds from it as-is (#87)', () => {
-    // Единственный источник имён/типов — resolveRelationJoinTableDefinition:
-    // типы обязательны и выводятся только там (ошибкой конфигурации, без
-    // молчаливого фолбэка). Отдельного пути вывода типов в схеме нет (#87).
+    // The only source of names/types is resolveRelationJoinTableDefinition:
+    // types are mandatory and derived only there (a configuration error, no
+    // silent fallback). There is no separate type inference path in the schema (#87).
     const [jt] = getManyToManyJoinTables([TestOrderEntity, TestSkuEntity]);
     expect(jt.joinColumnType).toBe('Int64');
     expect(jt.inverseJoinColumnType).toBe('Utf8');
@@ -506,12 +506,12 @@ describe('duplicate join-table declarations (#139)', () => {
       TestSymLeftEntity,
       TestSymRightEntity,
     ]);
-    // Оба объявления описывают одну физическую таблицу — остаётся одно
+    // Both declarations describe one physical table — only one remains
     expect(joinTables).toHaveLength(1);
 
     const jt = joinTables[0];
     expect(jt.tableName).toBe('test_sym_join');
-    // Первое объявление (от left): колонка left → left_ref (Int64)
+    // First declaration (from left): column left → left_ref (Int64)
     expect(jt.joinColumn).toBe('left_ref');
     expect(jt.joinColumnType).toBe('Int64');
     expect(jt.inverseJoinColumn).toBe('right_code');
@@ -538,7 +538,7 @@ describe('duplicate join-table declarations (#139)', () => {
     expect(error!.message).toContain(
       'Conflicting definitions for many-to-many join table "test_duplicated_join"',
     );
-    // В ошибке перечислены оба определения с сущностями и колонками/типами
+    // The error lists both definitions with entities and columns/types
     expect(error!.message).toContain('TestDupOrderEntity.items');
     expect(error!.message).toContain(
       'test_dup_orders_order_id:Int64, test_dup_items_item_uuid:Uuid',
@@ -550,8 +550,8 @@ describe('duplicate join-table declarations (#139)', () => {
   });
 
   it('treats mirrored declarations with different column names as conflicting', () => {
-    // test_sym_join объявлен зеркально корректно; проверим, что подмена
-    // имени колонки на одной стороне даёт конфликт
+    // test_sym_join is declared correctly mirrored; check that swapping
+    // the column name on one side yields a conflict
     const [fromLeft] = getManyToManyJoinTables([TestSymLeftEntity]);
     const [fromRight] = getManyToManyJoinTables([TestSymRightEntity]);
 
@@ -937,7 +937,7 @@ describe('composite primary key comparison (#89)', () => {
     );
 
     expect(check.primaryKeyMatches).toBe(false);
-    // Чистая перестановка: наборы колонок равны — диагностируется именно порядок
+    // Pure permutation: the column sets are equal — the order itself is diagnosed
     expect(check.primaryKeyOrderMismatch).toBe(true);
     expect(check.missingPrimaryKeyColumns).toEqual([]);
     expect(check.extraPrimaryKeyColumns).toEqual([]);
@@ -1051,7 +1051,7 @@ describe('checkTableSchema TTL (#88)', () => {
   });
 
   it('detects changed TTL interval semantically (by seconds)', () => {
-    // P1DT0H == 24 часа != PT2H; при этом "PT120M" эквивалентен "PT2H"
+    // P1DT0H == 24 hours != PT2H; meanwhile "PT120M" is equivalent to "PT2H"
     const equalCheck = checkTableSchema(
       ttlExpected,
       sessionDescription({
@@ -1075,7 +1075,7 @@ describe('checkTableSchema TTL (#88)', () => {
   });
 
   it('matches fractional-second TTL without precision loss (#88)', () => {
-    // PT0.5S == ровно 500000µs; сравнение в целых микросекундах YDB Interval
+    // PT0.5S == exactly 500000µs; comparison in whole YDB Interval microseconds
     const fractionalExpected = {
       ...ttlExpected,
       ttl: { interval: 'PT0.5S', column: 'expires_at' },
@@ -1088,7 +1088,7 @@ describe('checkTableSchema TTL (#88)', () => {
     );
     expect(equalCheck.ttlMismatches).toEqual([]);
 
-    // Сдвиг на микросекунду фиксируется как расхождение
+    // A one-microsecond shift is detected as a mismatch
     const changedCheck = checkTableSchema(
       fractionalExpected,
       sessionDescription({
@@ -1099,8 +1099,8 @@ describe('checkTableSchema TTL (#88)', () => {
   });
 
   it('treats sub-microsecond intervals as mismatch instead of truncating (#88)', () => {
-    // "PT0.0000001S" непредставим в YDB Interval: усечение до 0µs дало бы
-    // ложное «совпадение» с TTL = 0 секунд в БД
+    // "PT0.0000001S" is not representable in a YDB Interval: truncation to 0µs
+    // would give a false "match" with TTL = 0 seconds in the DB
     const subMicroExpected = {
       ...ttlExpected,
       ttl: { interval: 'PT0.0000001S', column: 'expires_at' },
@@ -1331,7 +1331,7 @@ describe('YdbSchemaSyncer', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    // driver не используется: describeTable мокается
+    // driver is not used: describeTable is mocked
     syncer = new YdbSchemaSyncer({} as never, executor);
   });
 
@@ -1603,8 +1603,8 @@ describe('YdbSchemaSyncer', () => {
     expect(executedSql()).toEqual([]);
   });
 
-  // Синхронизация TTL (#88): отсутствующий ставим, изменённый заменяем,
-  // лишний не сбрасываем.
+  // TTL sync (#88): missing is set, changed is replaced,
+  // extra is not reset.
   describe('sync applies TTL changes', () => {
     const sessionDescriptionFull = (ttl?: YdbTableTtl): YdbTableDescription =>
       description(
@@ -1880,8 +1880,8 @@ describe('YdbSchemaSyncer.describeTable TTL parsing (#88)', () => {
   });
 });
 
-// Регресс-тесты #91: describeTable различает «таблицы нет» и другие
-// SCHEME_ERROR, а не-примитивные типы не деградируют до «typeId=0».
+// Regression tests #91: describeTable distinguishes "no table" from other
+// SCHEME_ERRORs, and non-primitive types do not degrade to "typeId=0".
 describe('YdbSchemaSyncer.describeTable: not-found vs other errors (#91)', () => {
   const sessionResult = anyPack(
     CreateSessionResultSchema,
@@ -1972,8 +1972,8 @@ describe('YdbSchemaSyncer.describeTable: not-found vs other errors (#91)', () =>
   });
 
   it('treats issues-less SCHEME_ERROR as an error, not as missing table', async () => {
-    // ydb-platform/ydb#7791: DescribeTable может не прислать issues вовсе.
-    // Без текста «не существует» это нельзя считать not-found (#91).
+    // ydb-platform/ydb#7791: DescribeTable may send no issues at all.
+    // Without "does not exist" text it cannot be treated as not-found (#91).
     const { syncer } = makeDescribeTableSyncer({
       operation: { status: StatusIds_StatusCode.SCHEME_ERROR },
     });
@@ -2008,7 +2008,7 @@ describe('YdbSchemaSyncer.describeTable: not-found vs other errors (#91)', () =>
       /Access denied/,
     );
 
-    // Ни CREATE TABLE, ни какого-либо другого DDL
+    // Neither CREATE TABLE nor any other DDL
     expect(executedSql()).toEqual([]);
   });
 
@@ -2103,9 +2103,9 @@ describe('DescribeTable non-primitive column types (#91)', () => {
 
     const desc = await syncer.describeTable('mixed_table');
 
-    // Примитивная колонка осталась в columns…
+    // The primitive column stays in columns...
     expect(desc?.columns.get('uuid')).toBe(Type_PrimitiveTypeId.UUID);
-    // …а не-примитивные ушли в unsupportedColumns с фактическим типом
+    // ...while non-primitives went into unsupportedColumns with the actual type
     expect(desc?.columns.has('price')).toBe(false);
     expect(desc?.unsupportedColumns).toEqual(
       new Map([
@@ -2288,11 +2288,11 @@ describe('DescribeTable non-primitive column types (#91)', () => {
 });
 
 /**
- * #23: детекция вероятных переименований колонок. Чистые литеральные
- * схемы — без декораторов, чтобы точно управлять PK/индексами/TTL.
+ * #23: detection of likely column renames. Plain literal schemas —
+ * without decorators, so PK/indexes/TTL can be controlled precisely.
  */
 describe('checkTableSchema: column rename hints (#23)', () => {
-  // Сущность переименовала label -> title; в БД осталась label
+  // The entity renamed label -> title; the DB still has label
   const renameExpected = (overrides: Partial<ExpectedTableSchema> = {}) => ({
     tableName: 'photos',
     columns: { uuid: 'Uuid', title: 'Utf8' } as Record<string, YdbPrimitive>,
@@ -2463,7 +2463,7 @@ describe('checkTableSchema: column rename hints (#23)', () => {
     };
 
     const result = checkTableSchema(renameExpected(), withUnsupported);
-    // Тип label неизвестен (#91) — сравнение типов невозможно, подсказки нет.
+    // The type of label is unknown (#91) — type comparison is impossible, no hint.
     expect(result.extraColumns).toEqual(['label']);
     expect(result.missingColumns).toEqual([['title', 'Utf8']]);
     expect(result.typeMismatches).toEqual([]);
@@ -2506,8 +2506,8 @@ describe('rename-suggestion diagnostics consistency (#23)', () => {
     expect(issues.filter((i) => i.kind === 'rename-suggestion')).toHaveLength(
       1,
     );
-    // Расхождение само по себе не «закрыто» подсказкой: колонки по-прежнему
-    // числятся отсутствующей и лишней.
+    // The mismatch itself is not "resolved" by the hint: the columns still
+    // count as missing and extra.
     expect(issues.filter((i) => i.kind === 'missing-column')).toHaveLength(1);
     expect(issues.filter((i) => i.kind === 'extra-column')).toHaveLength(1);
   });

--- a/src/schema/schema-sync.ts
+++ b/src/schema/schema-sync.ts
@@ -39,7 +39,7 @@ import {
   YdbTtlUnit,
 } from '../decorators/ttl.decorator.js';
 
-/** Ожидаемый вторичный индекс таблицы. */
+/** Expected secondary index of the table. */
 export interface ExpectedIndex {
   name: string;
   columns: string[];
@@ -47,30 +47,30 @@ export interface ExpectedIndex {
 }
 
 /**
- * Нормализованные TTL-настройки существующей таблицы
- * (TtlSettings из DescribeTable, см. issue #81/#88).
+ * Normalized TTL settings of an existing table
+ * (TtlSettings from DescribeTable, see issue #81/#88).
  */
 export interface YdbTableTtl {
   column: string;
-  /** Задержка до истечения в секундах (expire_after_seconds из proto). */
+  /** Delay until expiration in seconds (expire_after_seconds from proto). */
   expireAfterSeconds: number;
-  /** Единица числовой колонки; отсутствует для Date/Datetime/Timestamp. */
+  /** Unit of the numeric column; absent for Date/Datetime/Timestamp. */
   unit?: YdbTtlUnit;
 }
 
 /**
- * Вероятное переименование колонки (#23): `from` — лишняя колонка в БД,
- * `to` — новая колонка сущности. Только предположение по структурным
- * признакам схемы; никогда не применяется автоматически.
+ * Likely column rename (#23): `from` — an extra column in the DB,
+ * `to` — a new entity column. Only a guess based on structural schema
+ * signals; never applied automatically.
  */
 export interface LikelyRename {
-  /** Лишняя колонка в БД (старое имя). */
+  /** Extra column in the DB (old name). */
   from: string;
-  /** Отсутствующая в БД колонка сущности (новое имя). */
+  /** Entity column missing in the DB (new name). */
   to: string;
 }
 
-/** Ожидаемая схема таблицы, построенная по метаданным сущности. */
+/** Expected table schema built from the entity metadata. */
 export interface ExpectedTableSchema {
   tableName: string;
   columns: Record<string, YdbPrimitive>;
@@ -79,83 +79,83 @@ export interface ExpectedTableSchema {
   ttl?: YdbTtlMetadata;
 }
 
-/** Нормализованное описание существующей таблицы из DescribeTable. */
+/** Normalized description of an existing table from DescribeTable. */
 export interface YdbTableDescription {
-  /** Колонка → примитивный typeId (Optional обёртка снята). */
+  /** Column → primitive typeId (Optional wrapper stripped). */
   columns: Map<string, Type_PrimitiveTypeId>;
   primaryKey: string[];
-  /** Индексы, описанные в БД. */
+  /** Indexes described in the DB. */
   indexes?: Array<{ name: string; columns: string[]; unique: boolean }>;
   /**
-   * TTL-настройки таблицы из DescribeTable (undefined — TTL не задан).
-   * Сравнивается с метаданными @YdbTtl при verify/миграциях (#88).
+   * Table TTL settings from DescribeTable (undefined — no TTL set).
+   * Compared against @YdbTtl metadata during verify/migrations (#88).
    */
   ttl?: YdbTableTtl;
   /**
-   * Колонки БД с не-примитивными типами (Decimal/List/Pg и т.п.), которые
-   * нельзя выразить typeId (#91): имя → человекочитаемое описание типа.
-   * Такие колонки всегда считаются расхождением типов — но с честным
-   * описанием фактического типа вместо бессмысленного «typeId=0».
+   * DB columns with non-primitive types (Decimal/List/Pg, etc.) that
+   * cannot be expressed as a typeId (#91): name → human-readable type
+   * description. Such columns always count as a type mismatch — but with
+   * an honest description of the actual type instead of a meaningless
+   * "typeId=0".
    */
   unsupportedColumns?: Map<string, string>;
 }
 
-/** Результат проверки существующей таблицы против ожидаемой схемы. */
+/** Result of checking an existing table against the expected schema. */
 export interface SchemaCheckResult {
   tableName: string;
-  /** Колонки, которых нет в БД (можно добавить через ALTER TABLE). */
+  /** Columns missing in the DB (can be added via ALTER TABLE). */
   missingColumns: [string, YdbPrimitive][];
-  /** Колонки с несовпадающим типом (YDB не умеет менять тип — только ручная миграция). */
+  /** Columns with a mismatching type (YDB cannot alter a type — manual migration only). */
   typeMismatches: { column: string; expected: YdbPrimitive; actual: string }[];
-  /** Лишние колонки в БД (не удаляются автоматически — потеря данных). */
+  /** Extra columns in the DB (not removed automatically — data loss risk). */
   extraColumns: string[];
   /**
-   * Вероятные переименования колонок (#23): ровно одна лишняя колонка БД
-   * и ровно одна новая колонка сущности с совпадающим типом, не затронутые
-   * PK/индексами/TTL/blind-index. Диагностическая подсказка — не команда
-   * к действию; ADD/DROP и ручная миграция остаются явными.
+   * Likely column renames (#23): exactly one extra DB column and exactly
+   * one new entity column with a matching type, not touched by
+   * PK/indexes/TTL/blind-index. A diagnostic hint, not a command to act;
+   * ADD/DROP and manual migration stay explicit.
    */
   likelyRenames: LikelyRename[];
   primaryKeyMatches: boolean;
   /**
-   * Ожидаемый PK из метаданных сущности — копия входа, нужна для
-   * диагностики перестановок порядка (#89).
+   * Expected PK from the entity metadata — a copy of the input, needed to
+   * diagnose order permutations (#89).
    */
   expectedPrimaryKey: string[];
-  /** Фактический PK из DescribeTable (для диагностики порядка, #89). */
+  /** Actual PK from DescribeTable (for order diagnostics, #89). */
   actualPrimaryKey: string[];
-  /** Ожидаемые PK-колонки, которых нет в PK БД (#89). */
+  /** Expected PK columns that are absent from the DB PK (#89). */
   missingPrimaryKeyColumns: string[];
-  /** PK-колонки БД, не объявленные как PK в сущности (#89). */
+  /** DB PK columns not declared as PK in the entity (#89). */
   extraPrimaryKeyColumns: string[];
   /**
-   * Чистая перестановка: наборы PK-колонок совпадают, но порядок
-   * различается (#89). В YDB порядок колонок PK определяет
-   * партиционирование и сортировку диапазонов, поэтому [tenant, id] и
-   * [id, tenant] — принципиально разные таблицы.
+   * Pure permutation: the PK column sets match, but the order differs (#89).
+   * In YDB the PK column order defines partitioning and range sorting, so
+   * [tenant, id] and [id, tenant] are fundamentally different tables.
    */
   primaryKeyOrderMismatch: boolean;
-  /** Индексы, которые есть в метаданных, но нет в БД. */
+  /** Indexes present in metadata but absent in the DB. */
   missingIndexes: ExpectedIndex[];
-  /** Индексы, которые есть в БД, но нет в метаданных. */
+  /** Indexes present in the DB but absent in metadata. */
   extraIndexes: Array<{ name: string; columns: string[]; unique: boolean }>;
-  /** Индексы с несовпадающим флагом unique. */
+  /** Indexes with a mismatching unique flag. */
   uniqueMismatches: { name: string; expected: boolean; actual: boolean }[];
-  /** Индексы с тем же именем, но другим списком/порядком колонок. */
+  /** Indexes with the same name but a different column list/order. */
   indexColumnsMismatches: {
     name: string;
     expected: string[];
     actual: string[];
   }[];
-  /** TTL объявлен сущностью, но в БД не задан. */
+  /** TTL declared by the entity but not set in the DB. */
   missingTtl: { expected: YdbTtlMetadata }[];
-  /** TTL задан и в БД, и в метаданных, но колонка/unit/интервал различаются. */
+  /** TTL set both in the DB and metadata, but column/unit/interval differ. */
   ttlMismatches: { expected: YdbTtlMetadata; actual: YdbTableTtl }[];
-  /** В БД задан TTL, которого нет в метаданных (не сбрасывается автоматически). */
+  /** A TTL set in the DB but absent from metadata (not reset automatically). */
   extraTtl: { actual: YdbTableTtl }[];
 }
 
-/** Проблема схемы, найденная при verify. */
+/** A schema problem found during verify. */
 export interface YdbSchemaIssue {
   tableName: string;
   kind:
@@ -175,7 +175,7 @@ export interface YdbSchemaIssue {
   message: string;
 }
 
-/** YdbPrimitive → PrimitiveTypeId (для сравнения с DescribeTable). */
+/** YdbPrimitive → PrimitiveTypeId (for comparison with DescribeTable). */
 const PRIMITIVE_TO_TYPE_ID: Record<YdbPrimitive, Type_PrimitiveTypeId> = {
   Uuid: Type_PrimitiveTypeId.UUID,
   Utf8: Type_PrimitiveTypeId.UTF8,
@@ -197,10 +197,11 @@ const TYPE_ID_TO_PRIMITIVE = new Map<Type_PrimitiveTypeId, YdbPrimitive>(
 );
 
 /**
- * Числовые типы TTL-колонок: YDB допускает TTL по Uint32/Uint64/DyNumber
- * с unit, но эти типы не входят в YdbPrimitive (маппинг значений запросов
- * их не поддерживает). Здесь они нужны только для схемного сравнения,
- * чтобы sync/verify не считали такую колонку расхождением типов (#88).
+ * Numeric TTL column types: YDB allows TTL on Uint32/Uint64/DyNumber
+ * with a unit, but these types are not part of YdbPrimitive (the query
+ * value mapping does not support them). Here they are needed only for
+ * schema comparison so that sync/verify does not treat such a column as
+ * a type mismatch (#88).
  */
 const TTL_NUMERIC_TYPE_IDS: Record<string, Type_PrimitiveTypeId> = {
   Uint32: Type_PrimitiveTypeId.UINT32,
@@ -215,14 +216,14 @@ for (const [name, typeId] of Object.entries(TTL_NUMERIC_TYPE_IDS)) {
 }
 
 /**
- * Текст issues, однозначно говорящий, что путь/таблица не существует (#91).
- * Только такой SCHEME_ERROR трактуется как «таблицы нет»; остальные
- * (права доступа, битый путь и т.п.) пробрасываются наружу. Реальные
- * сообщения YDB: «path '/db/tbl' does not exist», «Path ... not found».
+ * Issue text unambiguously stating that the path/table does not exist (#91).
+ * Only such a SCHEME_ERROR is treated as "no table"; others (access
+ * permissions, broken path, etc.) are propagated. Real YDB messages:
+ * "path '/db/tbl' does not exist", "Path ... not found".
  */
 const NOT_FOUND_ISSUE_RE = /does not exist|not found/i;
 
-/** Enum Unit из TtlSettings → YdbTtlUnit (см. @YdbTtl). */
+/** TtlSettings Unit enum → YdbTtlUnit (see @YdbTtl). */
 const TTL_UNIT_BY_PROTO: Record<
   ValueSinceUnixEpochModeSettings_Unit,
   YdbTtlUnit | undefined
@@ -235,16 +236,16 @@ const TTL_UNIT_BY_PROTO: Record<
 };
 
 /**
- * Строит ожидаемую схему таблицы по метаданным сущности:
- * колонки + synthetic {field}_bi колонки blind index.
- * Требует явно объявленного первичного ключа через @YdbPrimaryColumn.
+ * Builds the expected table schema from the entity metadata:
+ * columns plus synthetic {field}_bi blind-index columns.
+ * Requires an explicitly declared primary key via @YdbPrimaryColumn.
  *
- * Бросает ошибку (fail-fast, по той же политике, что и для PK) при
- * невалидных метаданных TTL: неизвестная колонка, несовместимый тип
- * (YDB допускает Date/Datetime/Timestamp либо Uint32/Uint64/DyNumber
- * с unit), unit у даты или его отсутствие у числа. Так schema sync,
- * миграции и CLI не сгенерируют заведомо невалидный DDL; при инициализации
- * модуля те же проблемы раньше собирает validateEntityMetadata.
+ * Throws (fail-fast, same policy as for the PK) on invalid TTL metadata:
+ * unknown column, incompatible type (YDB allows Date/Datetime/Timestamp
+ * or Uint32/Uint64/DyNumber with a unit), unit on a date, or its absence
+ * on a number. This way schema sync, migrations and the CLI never generate
+ * invalid DDL; at module init the same problems are collected earlier by
+ * validateEntityMetadata.
  */
 export function buildExpectedTableSchema(
   meta: YdbEntityMetadata,
@@ -305,14 +306,14 @@ export function buildExpectedTableSchema(
 }
 
 /**
- * Ожидаемая схема join-таблицы many-to-many.
+ * Expected schema of a many-to-many join table.
  *
- * Имена и типы колонок берутся ровно из того определения, которое построил
- * resolveRelationJoinTableDefinition (#90/#87): типы выводятся из
- * фактических PK-метаданных обеих сущностей, а невыводимый тип — ошибка
- * конфигурации в самом резолве. Отдельного пути вывода типов здесь нет:
- * сгенерированная схема по построению совпадает с тем, что читает
- * relations-код (см. ResolvedJoinTable в entity-relations.ts).
+ * Column names and types are taken exactly from the definition built by
+ * resolveRelationJoinTableDefinition (#90/#87): types are derived from the
+ * actual PK metadata of both entities, and an underivable type is a
+ * configuration error in the resolver itself. There is no separate type
+ * inference path here: the generated schema by construction matches what
+ * the relations code reads (see ResolvedJoinTable in entity-relations.ts).
  */
 export function buildExpectedJoinTableSchema(
   joinTable: ManyToManyJoinTable,
@@ -329,16 +330,18 @@ export function buildExpectedJoinTableSchema(
 }
 
 /**
- * Собирает ожидаемые схемы всех таблиц сущностей и их many-to-many join-таблиц.
+ * Collects expected schemas of all entity tables and their many-to-many
+ * join tables.
  *
- * Гарантия «одна таблица — одна ожидаемая схема» (#92):
- *  - повтор класса в списке дедуплицируется;
- *  - класс без собственного @YdbEntity пропускается (не сущность — см.
- *    getYdbEntityMetadata), поэтому подкласс не порождает вторую схему
- *    для таблицы родителя;
- *  - две разные сущности с одним tableName — ошибка: иначе sync патчил бы
- *    одну таблицу двумя разными схемами, а verify выдавал противоречивые
- *    issues. Коллизия обнаруживается здесь — до любого обращения к БД.
+ * The "one table — one expected schema" guarantee (#92):
+ *  - a class repeated in the list is deduplicated;
+ *  - a class without its own @YdbEntity is skipped (not an entity — see
+ *    getYdbEntityMetadata), so a subclass does not produce a second schema
+ *    for the parent's table;
+ *  - two different entities with the same tableName is an error: otherwise
+ *    sync would patch one table with two different schemas and verify would
+ *    emit contradictory issues. The collision is detected here — before any
+ *    DB access.
  */
 export function buildExpectedSchemas(
   entities: (new (...args: any[]) => any)[],
@@ -376,15 +379,15 @@ export function buildExpectedSchemas(
 }
 
 /**
- * Генерирует TTL-секцию WITH (...) для CREATE TABLE.
- * По синтаксису YQL TTL задаётся только в WITH, а не внутри тела таблицы:
+ * Generates the WITH (...) TTL clause for CREATE TABLE.
+ * In YQL syntax the TTL is specified only in WITH, not inside the table body:
  *   WITH (TTL = Interval("PT2H") ON `col` [AS SECONDS])
  */
 export function generateTtlWithClause(ttl: YdbTtlMetadata): string {
   return `WITH (\n  ${ttlExpression(ttl)}\n)`;
 }
 
-/** Генерирует DDL создания таблицы. */
+/** Generates the CREATE TABLE DDL. */
 export function generateCreateTableYql(expected: ExpectedTableSchema): string {
   const columnDefs = Object.entries(expected.columns).map(
     ([name, type]) => `${quoteIdentifier(name)} ${type}`,
@@ -405,7 +408,7 @@ export function generateCreateTableYql(expected: ExpectedTableSchema): string {
   return yql;
 }
 
-/** Генерирует DDL добавления недостающих колонок (один ALTER на таблицу). */
+/** Generates DDL to add missing columns (one ALTER per table). */
 export function generateAddColumnsYql(
   tableName: string,
   columns: [string, YdbPrimitive][],
@@ -416,7 +419,7 @@ export function generateAddColumnsYql(
   return `ALTER TABLE ${quoteIdentifier(tableName)} ${clauses.join(', ')}`;
 }
 
-/** Генерирует DDL добавления индекса через ALTER TABLE. */
+/** Generates DDL to add an index via ALTER TABLE. */
 export function generateAddIndexYql(
   tableName: string,
   index: ExpectedIndex,
@@ -429,7 +432,7 @@ export function generateAddIndexYql(
   );
 }
 
-/** Генерирует DDL удаления индекса через ALTER TABLE. */
+/** Generates DDL to drop an index via ALTER TABLE. */
 export function generateDropIndexYql(
   tableName: string,
   indexName: string,
@@ -441,8 +444,8 @@ export function generateDropIndexYql(
 }
 
 /**
- * Генерирует DDL установки/замены TTL через ALTER TABLE.
- * Выражение TTL совпадает с WITH-секцией CREATE TABLE (#81):
+ * Generates DDL to set/replace TTL via ALTER TABLE.
+ * The TTL expression matches the WITH clause of CREATE TABLE (#81):
  *   ALTER TABLE `t` SET (TTL = Interval("PT2H") ON `col` [AS SECONDS])
  */
 export function generateSetTtlYql(
@@ -452,24 +455,24 @@ export function generateSetTtlYql(
   return `ALTER TABLE ${quoteIdentifier(tableName)} SET (${ttlExpression(ttl)})`;
 }
 
-/** Генерирует DDL сброса TTL: ALTER TABLE `t` RESET (TTL). */
+/** Generates DDL to reset TTL: ALTER TABLE `t` RESET (TTL). */
 export function generateResetTtlYql(tableName: string): string {
   return `ALTER TABLE ${quoteIdentifier(tableName)} RESET (TTL)`;
 }
 
-/** TTL-выражение `TTL = Interval(...) ON col [AS unit]`, общее для CREATE/ALTER. */
+/** The `TTL = Interval(...) ON col [AS unit]` expression, shared by CREATE/ALTER. */
 function ttlExpression(ttl: YdbTtlMetadata): string {
   const unitPart = ttl.unit ? ` AS ${ttl.unit.toUpperCase()}` : '';
   return `TTL = Interval("${ttl.interval}") ON ${quoteIdentifier(ttl.column)}${unitPart}`;
 }
 
-/** Человекочитаемое представление ожидаемого TTL (для issues/warnings). */
+/** Human-readable representation of the expected TTL (for issues/warnings). */
 function formatTtlMeta(ttl: YdbTtlMetadata): string {
   const unitPart = ttl.unit ? ` AS ${ttl.unit.toUpperCase()}` : '';
   return `${ttl.interval} on column "${ttl.column}"${unitPart}`;
 }
 
-/** Человекочитаемое представление фактического TTL из БД. */
+/** Human-readable representation of the actual TTL from the DB. */
 function formatTableTtl(ttl: YdbTableTtl): string {
   const unitPart = ttl.unit ? ` AS ${ttl.unit.toUpperCase()}` : '';
   return (
@@ -479,14 +482,14 @@ function formatTableTtl(ttl: YdbTableTtl): string {
 }
 
 /**
- * Сравнивает ожидаемый TTL с фактическим из DescribeTable:
- * колонка, unit и интервал. Интервал сравнивается семантически в целых
- * микросекундах (внутренней точности YDB Interval): "PT1H" и "PT60M"
- * равны, "PT0.5S" — это ровно 500000µs, без потерь на float.
- * Интервалы, непредставимые в YDB Interval точно, — календарные части
- * и дробь точнее микросекунд — считаются расхождением, чтобы миграция
- * или синхронизация выставили значение из метаданных вместо ложного
- * «совпадения» после усечения.
+ * Compares the expected TTL with the actual one from DescribeTable:
+ * column, unit and interval. The interval is compared semantically in whole
+ * microseconds (YDB Interval's internal precision): "PT1H" and "PT60M"
+ * are equal, "PT0.5S" is exactly 500000µs, without float loss.
+ * Intervals that cannot be represented exactly in a YDB Interval — calendar
+ * parts and fractions finer than microseconds — count as a mismatch so that
+ * migration or sync sets the value from metadata instead of a false "match"
+ * after truncation.
  */
 function ttlSettingsMatch(
   expected: YdbTtlMetadata,
@@ -502,23 +505,24 @@ function ttlSettingsMatch(
 }
 
 /**
- * Детекция вероятного переименования колонки (#23).
+ * Detects a likely column rename (#23).
  *
- * Консервативная эвристика на структурных признаках схемы, без сравнения
- * похожести имён. Подсказка выдаётся, только когда выполнено ВСЁ:
- *  - в БД ровно одна лишняя колонка (`from`) и в сущности ровно одна новая
- *    (`to`) — однозначное соответствие без кандидатов на выбор;
- *  - примитивный тип `to` совпадает с фактическим типом `from` в БД
- *    (колонки неявно неподдерживаемых типов #91 сразу отсекаются);
- *  - ни `from`, ни `to` не участвуют в PK;
- *  - ни `from`, ни `to` не упоминаются в колонках индексов (фактических
- *    и ожидаемых) — иначе это изменение индекса, а не переименование;
- *  - ни `from`, ни `to` не являются TTL-колонкой (фактической или ожидаемой);
- *  - расхождение не затрагивает blind index: обе колонки не synthetic `_bi`
- *    (BLIND_INDEX_SUFFIX) и у каждой нет `_bi`-парта в своей схеме.
+ * A conservative heuristic based on structural schema signals, without
+ * comparing name similarity. A hint is emitted only when ALL conditions hold:
+ *  - the DB has exactly one extra column (`from`) and the entity exactly one
+ *    new one (`to`) — an unambiguous match with no candidates to choose from;
+ *  - the primitive type of `to` equals the actual type of `from` in the DB
+ *    (implicitly unsupported type columns, #91, are filtered immediately);
+ *  - neither `from` nor `to` participates in the PK;
+ *  - neither `from` nor `to` appears in index columns (actual and expected) —
+ *    otherwise it is an index change, not a rename;
+ *  - neither `from` nor `to` is a TTL column (actual or expected);
+ *  - the mismatch does not involve a blind index: both columns are not
+ *    synthetic `_bi` (BLIND_INDEX_SUFFIX) and each has no `_bi` partner in
+ *    its own schema.
  *
- * При любом несоответствии возвращается пустой список — остаются прежние
- * ADD/DROP и предупреждения о ручной миграции.
+ * Any mismatch returns an empty list — the regular ADD/DROP and manual
+ * migration warnings remain.
  */
 function detectLikelyRenames(
   expected: ExpectedTableSchema,
@@ -531,7 +535,7 @@ function detectLikelyRenames(
   const from = extraColumns[0];
   const [to, toType] = missingColumns[0];
 
-  // Совпадение типа: необходимое условие «это та же колонка».
+  // Type match: the necessary condition for "it is the same column".
   const actualTypeId = existing.columns.get(from);
   if (
     actualTypeId === undefined ||
@@ -540,13 +544,13 @@ function detectLikelyRenames(
     return [];
   }
 
-  // PK: переименование ключевой колонки в YDB невозможно — только ручная миграция.
+  // PK: renaming a key column in YDB is impossible — manual migration only.
   if (existing.primaryKey.includes(from) || expected.primaryKey.includes(to)) {
     return [];
   }
 
-  // Индексы: расхождение индексов вокруг пары — это изменение индекса,
-  // а не простое переименование.
+  // Indexes: an index mismatch around the pair is an index change,
+  // not a plain rename.
   const referencedByIndex = (columnsList: string[][], name: string) =>
     columnsList.some((cols) => cols.includes(name));
   if (
@@ -562,11 +566,11 @@ function detectLikelyRenames(
     return [];
   }
 
-  // TTL: перенос TTL-колонки — изменение настроек TTL, не простое переименование.
+  // TTL: moving a TTL column is a TTL settings change, not a plain rename.
   if (existing.ttl?.column === from || expected.ttl?.column === to) return [];
 
-  // Blind index/шифрование: synthetic-колонка либо появление/исчезновение
-  // `_bi`-парта — изменение метаданных шифрования.
+  // Blind index/encryption: a synthetic column or the appearance/disappearance
+  // of its `_bi` partner means an encryption metadata change.
   if (from.endsWith(BLIND_INDEX_SUFFIX) || to.endsWith(BLIND_INDEX_SUFFIX)) {
     return [];
   }
@@ -581,8 +585,8 @@ function detectLikelyRenames(
 }
 
 /**
- * Чистая проверка: сравнивает ожидаемую схему с описанием таблицы из БД.
- * Не ходит в сеть и ничего не меняет.
+ * Pure check: compares the expected schema with the DB table description.
+ * Makes no network calls and changes nothing.
  */
 export function checkTableSchema(
   expected: ExpectedTableSchema,
@@ -593,9 +597,9 @@ export function checkTableSchema(
   const unsupportedColumns = existing.unsupportedColumns;
 
   for (const [name, type] of Object.entries(expected.columns)) {
-    // Не-примитивный тип в БД (#91): по typeId сравнивать нельзя —
-    // сообщаем расхождение с фактическим типом (decimal(22,9), list<...>),
-    // а не с бессмысленным typeId=0.
+    // Non-primitive type in the DB (#91): typeId comparison is impossible —
+    // report the mismatch with the actual type (decimal(22,9), list<...>)
+    // instead of a meaningless typeId=0.
     const actualUnsupported = unsupportedColumns?.get(name);
     if (actualUnsupported !== undefined) {
       typeMismatches.push({
@@ -610,8 +614,8 @@ export function checkTableSchema(
       missingColumns.push([name, type]);
       continue;
     }
-    // Числовые TTL-типы (Uint32/Uint64/DyNumber) не входят в YdbPrimitive,
-    // но валидны для схемного сравнения — см. TTL_NUMERIC_TYPE_IDS.
+    // Numeric TTL types (Uint32/Uint64/DyNumber) are not part of YdbPrimitive
+    // but are valid for schema comparison — see TTL_NUMERIC_TYPE_IDS.
     const expectedTypeId =
       PRIMITIVE_TO_TYPE_ID[type] ?? TTL_NUMERIC_TYPE_IDS[type];
     if (actualTypeId !== expectedTypeId) {
@@ -625,17 +629,17 @@ export function checkTableSchema(
   }
 
   const expectedColumns = new Set(Object.keys(expected.columns));
-  // Колонка БД живёт либо в columns, либо в unsupportedColumns — но
-  // описания могут прийти и из внешнего кода, поэтому дедуплицируем.
+  // A DB column lives either in columns or in unsupportedColumns — but
+  // descriptions may come from external code, so we deduplicate.
   const extraColumns = [
     ...existing.columns.keys(),
     ...(unsupportedColumns?.keys() ?? []),
   ].filter((name) => !expectedColumns.has(name));
   const uniqueExtraColumns = [...new Set(extraColumns)];
 
-  // Порядок колонок PK значим (#89): в YDB он определяет партиционирование
-  // и сортировку диапазонов, поэтому [tenant, id] и [id, tenant] — разные
-  // таблицы. Сравниваем поэлементно и никогда — как множество.
+  // PK column order matters (#89): in YDB it defines partitioning and range
+  // sorting, so [tenant, id] and [id, tenant] are different tables.
+  // Compare element-wise, never as a set.
   const primaryKeyMatches =
     expected.primaryKey.length === existing.primaryKey.length &&
     expected.primaryKey.every((pk, i) => existing.primaryKey[i] === pk);
@@ -645,8 +649,8 @@ export function checkTableSchema(
   const extraPrimaryKeyColumns = existing.primaryKey.filter(
     (pk) => !expected.primaryKey.includes(pk),
   );
-  // Чистая перестановка: наборы равны, порядок различается. Если есть
-  // отсутствующие или лишние PK-колонки, случай уже покрыт их списками.
+  // Pure permutation: the sets are equal, the order differs. If there are
+  // missing or extra PK columns, that case is already covered by their lists.
   const primaryKeyOrderMismatch =
     !primaryKeyMatches &&
     missingPrimaryKeyColumns.length === 0 &&
@@ -682,9 +686,9 @@ export function checkTableSchema(
         actual: existingIdx.unique,
       });
     }
-    // Колонки сравниваются с учётом порядка: в YDB порядок колонок
-    // индекса значим (префиксный поиск), а поменять его нельзя —
-    // только пересоздать индекс.
+    // Columns are compared in order: in YDB the index column order is
+    // significant (prefix search) and cannot be changed — only the index
+    // can be recreated.
     if (
       existingIdx.columns.length !== idx.columns.length ||
       existingIdx.columns.some((col, i) => col !== idx.columns[i])
@@ -697,8 +701,8 @@ export function checkTableSchema(
     }
   }
 
-  // TTL (#88): отсутствующий, изменённый и лишний — в БД TTL либо задан
-  // согласно @YdbTtl, либо его нет вовсе.
+  // TTL (#88): missing, changed and extra — a DB TTL either matches @YdbTtl
+  // or is not present at all.
   const missingTtl: SchemaCheckResult['missingTtl'] = [];
   const ttlMismatches: SchemaCheckResult['ttlMismatches'] = [];
   const extraTtl: SchemaCheckResult['extraTtl'] = [];
@@ -743,10 +747,10 @@ export function checkTableSchema(
 }
 
 /**
- * Человекочитаемое описание расхождения первичного ключа (#89):
- * различает чистую перестановку PK-колонок (порядок значим в YDB) и
- * отсутствующие/лишние PK-колонки. Используется в issues verify/diffSchemas
- * и в предупреждениях плана миграций.
+ * Human-readable description of a primary key mismatch (#89):
+ * distinguishes a pure PK column permutation (order matters in YDB) from
+ * missing/extra PK columns. Used in verify/diffSchemas issues and in
+ * migration plan warnings.
  */
 export function describePrimaryKeyMismatch(check: SchemaCheckResult): string {
   if (check.primaryKeyOrderMismatch) {
@@ -769,8 +773,8 @@ export function describePrimaryKeyMismatch(check: SchemaCheckResult): string {
 }
 
 /**
- * Превращает результат проверки таблицы в плоский список issues.
- * Используется и `YdbSchemaSyncer.verify`, и CLI (красивый diff).
+ * Turns a table check result into a flat list of issues.
+ * Used by both `YdbSchemaSyncer.verify` and the CLI (pretty diff).
  */
 export function checkToIssues(check: SchemaCheckResult): YdbSchemaIssue[] {
   const issues: YdbSchemaIssue[] = [];
@@ -805,9 +809,9 @@ export function checkToIssues(check: SchemaCheckResult): YdbSchemaIssue[] {
       message: `Table "${check.tableName}" has extra column "${column}"`,
     });
   }
-  // #23: подсказка о вероятном переименовании — информационная, схему
-  // самой по себе не исправляет (колонка по-прежнему отсутствует в БД),
-  // поэтому расхождение остаётся и в verify, и в diffSchemas.
+  // #23: the likely-rename hint is informational — it does not fix the
+  // schema by itself (the column is still missing in the DB), so the
+  // mismatch remains in both verify and diffSchemas.
   for (const rename of check.likelyRenames) {
     issues.push({
       tableName: check.tableName,
@@ -881,9 +885,9 @@ export function checkToIssues(check: SchemaCheckResult): YdbSchemaIssue[] {
 }
 
 /**
- * Чистый diff ожидаемых схем против текущего состояния БД
- * (null — таблицы нет). Не ходит в сеть. Используется CLI для
- * человекочитаемого вывода расхождений.
+ * Pure diff of the expected schemas against the current DB state
+ * (null — table does not exist). Makes no network calls. Used by the CLI
+ * for human-readable mismatch output.
  */
 export function diffSchemas(
   expected: ExpectedTableSchema[],
@@ -907,9 +911,9 @@ export function diffSchemas(
 }
 
 /**
- * Синхронизатор схемы БД: создаёт недостающие таблицы и колонки
- * по метаданным сущностей. Изменение типа колонки и первичного ключа
- * в YDB невозможно — такие расхождения приводят к ошибке.
+ * DB schema synchronizer: creates missing tables and columns from the
+ * entity metadata. Changing a column type or primary key is impossible in
+ * YDB — such mismatches result in an error.
  */
 export class YdbSchemaSyncer {
   private readonly logger = new YdbDevLogger(YdbSchemaSyncer.name);
@@ -920,8 +924,8 @@ export class YdbSchemaSyncer {
   ) {}
 
   /**
-   * Проверяет схему БД против метаданных сущностей, ничего не меняя.
-   * Возвращает список найденных расхождений.
+   * Checks the DB schema against the entity metadata without changing anything.
+   * Returns the list of mismatches found.
    */
   async verify(
     entities: (new (...args: any[]) => any)[],
@@ -946,16 +950,16 @@ export class YdbSchemaSyncer {
   }
 
   /**
-   * Подстраивает БД под схему сущностей:
-   *  - нет таблицы — CREATE TABLE;
-   *  - нет колонок — ALTER TABLE ADD COLUMN;
-   *  - нет индексов — ALTER TABLE ADD INDEX;
-   *  - нет TTL или TTL отличается от метаданных — ALTER TABLE SET (TTL = ...)
-   *    (SET перезаписывает существующие настройки);
-   *  - лишние колонки/индексы/TTL — только предупреждение в лог
-   *    (не удаляем данные и настройки);
-   *  - расхождение типа/PK/колонок индекса — ошибка (в YDB не меняется,
-   *    нужна миграция).
+   * Aligns the DB with the entity schema:
+   *  - no table — CREATE TABLE;
+   *  - missing columns — ALTER TABLE ADD COLUMN;
+   *  - missing indexes — ALTER TABLE ADD INDEX;
+   *  - no TTL or TTL differing from metadata — ALTER TABLE SET (TTL = ...)
+   *    (SET overwrites existing settings);
+   *  - extra columns/indexes/TTL — only a warning to the log
+   *    (we do not delete data or settings);
+   *  - type/PK/index-column mismatch — error (immutable in YDB,
+   *    a migration is required).
    */
   async sync(entities: (new (...args: any[]) => any)[]): Promise<void> {
     for (const expected of buildExpectedSchemas(entities)) {
@@ -1012,8 +1016,8 @@ export class YdbSchemaSyncer {
         );
       }
 
-      // #23: переименование никогда не применяется автоматически — sync
-      // по-прежнему добавляет новую колонку, старую не трогает.
+      // #23: a rename is never applied automatically — sync still adds the
+      // new column and leaves the old one untouched.
       for (const rename of check.likelyRenames) {
         this.logger.warn(
           `Table "${expected.tableName}" column "${rename.from}" may have been ` +
@@ -1056,9 +1060,9 @@ export class YdbSchemaSyncer {
         );
       }
 
-      // TTL: отсутствующий ставим, изменённый заменяем — SET (TTL = ...)
-      // перезаписывает существующие настройки. Лишний TTL не сбрасываем
-      // автоматически: та же политика, что и в planMigration (#88).
+      // TTL: missing is set, changed is replaced — SET (TTL = ...)
+      // overwrites existing settings. An extra TTL is not reset
+      // automatically: same policy as in planMigration (#88).
       if (check.missingTtl.length && check.missingTtl[0].expected) {
         this.logger.log(
           `Setting TTL on "${expected.tableName}" ` +
@@ -1097,16 +1101,16 @@ export class YdbSchemaSyncer {
   }
 
   /**
-   * DescribeTable через Table service (query service не отдаёт метаданные
-   * колонок). Сессия создаётся на один вызов и сразу закрывается.
+   * DescribeTable via the Table service (the query service does not return
+   * column metadata). A session is created per call and closed immediately.
    *
-   * Возвращает null только если таблицы действительно нет (#91): отдельный
-   * статус NOT_FOUND либо SCHEME_ERROR, в issues которого явно сказано, что
-   * путь/таблица не существует. Любой другой SCHEME_ERROR (нет прав,
-   * битый путь и т.п.) пробрасывается наружу с контекстом — раньше он
-   * тоже превращался в null, из-за чего sync делал CREATE TABLE уже
-   * существующей таблицы, а verify докладывал ложный missing-table.
-   * Публичный: используется также генератором миграций (migration:generate).
+   * Returns null only when the table genuinely does not exist (#91): a
+   * distinct NOT_FOUND status or a SCHEME_ERROR whose issues explicitly state
+   * that the path/table does not exist. Any other SCHEME_ERROR (no
+   * permissions, broken path, etc.) is propagated with context — previously
+   * it also became null, causing sync to CREATE TABLE an existing table and
+   * verify to report a false missing-table.
+   * Public: also used by the migration generator (migration:generate).
    */
   async describeTable(tableName: string): Promise<YdbTableDescription | null> {
     const client = this.driver.createClient(TableServiceDefinition);
@@ -1150,9 +1154,9 @@ export class YdbSchemaSyncer {
         throw new Error(`DescribeTable returned no result for "${path}"`);
       }
 
-      // Колонки с не-примитивными типами (Decimal/List/Pg и т.п.) нельзя
-      // выразить typeId — они уходят в unsupportedColumns с честным
-      // описанием типа, а не с бессмысленным typeId=0 (#91).
+      // Columns with non-primitive types (Decimal/List/Pg, etc.) cannot be
+      // expressed as a typeId — they go into unsupportedColumns with an
+      // honest type description instead of a meaningless typeId=0 (#91).
       const columns = new Map<string, Type_PrimitiveTypeId>();
       const unsupportedColumns = new Map<string, string>();
       for (const column of result.columns) {
@@ -1187,10 +1191,10 @@ export class YdbSchemaSyncer {
   }
 
   /**
-   * Снимает Optional-обёртки и возвращает примитивный typeId.
-   * null — тип не-примитивный (Decimal/List/Pg/…): сравнивать его по typeId
-   * нельзя, фактическое описание кладётся в unsupportedColumns (#91),
-   * а не подставляется бессмысленный PRIMITIVE_TYPE_ID_UNSPECIFIED (=0).
+   * Strips Optional wrappers and returns the primitive typeId.
+   * null — the type is non-primitive (Decimal/List/Pg/...): it cannot be
+   * compared by typeId, the actual description goes to unsupportedColumns (#91)
+   * instead of a meaningless PRIMITIVE_TYPE_ID_UNSPECIFIED (=0).
    */
   private extractPrimitiveTypeId(type?: Type): Type_PrimitiveTypeId | null {
     let current = type;
@@ -1204,9 +1208,9 @@ export class YdbSchemaSyncer {
   }
 
   /**
-   * Компактное человекочитаемое описание типа из DescribeTable (#91):
-   * decimal(22,9), list<utf8>, pg<int4> и т.п. Используется в сообщениях
-   * о расхождении типов вместо бессмысленного «typeId=0».
+   * Compact human-readable type description from DescribeTable (#91):
+   * decimal(22,9), list<utf8>, pg<int4>, etc. Used in type mismatch
+   * messages instead of a meaningless "typeId=0".
    */
   private formatYdbType(type?: Type): string {
     let current = type;
@@ -1248,16 +1252,17 @@ export class YdbSchemaSyncer {
           ? `pg<${t.value.typeName}>`
           : `pg(oid=${t.value.oid})`;
       default:
-        // variantType/taggedType/voidType/… — имя proto-case уже содержит
-        // фактическую информацию о типе.
+        // variantType/taggedType/voidType/... — the proto-case name already
+        // carries the actual type information.
         return t?.case ?? 'unknown';
     }
   }
 
   /**
-   * Нормализует TtlSettings из DescribeTable в YdbTableTtl.
-   * Date-режим (dateTypeColumn) не имеет unit; числовой (valueSinceUnixEpoch)
-   * маппит enum Unit в YdbTtlUnit, UNSPECIFIED трактуется как отсутствие unit.
+   * Normalizes TtlSettings from DescribeTable into YdbTableTtl.
+   * The date mode (dateTypeColumn) has no unit; the numeric mode
+   * (valueSinceUnixEpoch) maps the Unit enum to YdbTtlUnit, and UNSPECIFIED
+   * is treated as no unit.
    */
   private extractTtl(settings?: TtlSettings): YdbTableTtl | undefined {
     const mode = settings?.mode;

--- a/src/transaction/transaction-context.spec.ts
+++ b/src/transaction/transaction-context.spec.ts
@@ -327,7 +327,7 @@ describe('runWithTransactionContext(): rejects invalid contexts at the boundary 
       runWithTransactionContext(fake, () => Promise.resolve('never')),
     ).toThrow('invalid context');
 
-    // Контекст не попал в ALS.
+    // The context did not reach the ALS.
     expect(getActiveTransaction()).toBeUndefined();
   });
 

--- a/src/transaction/transaction-context.ts
+++ b/src/transaction/transaction-context.ts
@@ -3,7 +3,7 @@ import type { YdbExecutor } from '../core/interfaces.js';
 import type { YdbTransactionsSettings } from '../core/interfaces.js';
 import type { QueryLogger } from '../core/query-logger.js';
 
-/** Параметры создания контекста активной транзакции (#208). */
+/** Parameters for creating an active-transaction context (#208). */
 export interface TransactionContextParams {
   transactionId: symbol;
   trx: YdbExecutor;
@@ -13,38 +13,38 @@ export interface TransactionContextParams {
 }
 
 /**
- * Активная транзакция в цепочке async-вызовов (#98).
+ * The active transaction in an async-call chain (#98).
  *
- * Хранится в AsyncLocalStorage и используется для двух независимых задач:
- * 1. Детекция вложенных runInTransaction() — работает ВСЕГДА, независимо от
- *    настроек (иначе вложенный вызов молча открыл бы отдельную транзакцию
- *    на другой сессии).
- * 2. Ambient auto-join: если включён (глобально через настройки модуля или
- *    локально через опцию `ambient` вызова), операции репозиториев без
- *    явного { trx } выполняются в активной транзакции.
+ * It is stored in AsyncLocalStorage and used for two independent tasks:
+ * 1. Detection of nested runInTransaction() — always works, regardless of
+ *    settings (otherwise a nested call would silently open a separate
+ *    transaction on another session).
+ * 2. Ambient auto-join: when enabled (globally through the module settings or
+ *    locally through the `ambient` call option), repository operations without
+ *    an explicit { trx } run inside the active transaction.
  *
- * Идентичность транзакции определяется `transactionId`, а не ссылкой на
- * executor, так как разные обёртки могут представлять одну и ту же
- * логическую транзакцию (например, при оборачивании executor'а для логирования).
+ * Transaction identity is determined by `transactionId`, not by an executor
+ * reference, because different wrappers may represent one logical transaction
+ * (for example, when an executor is wrapped for logging).
  *
- * Инварианты (#208) валидируются в единственной точке создания — конструкторе,
- * поэтому невалидный инстанс создать невозможно ни через фабрику
- * createTransactionContext(), ни напрямую через new. Приватное brand-поле
- * делает контекст непрозрачным для структурной типизации и защищает
- * runWithTransactionContext() от подделок через cast/instanceof.
+ * Invariants (#208) are validated at the single creation point — the
+ * constructor — so an invalid instance cannot be created either through the
+ * createTransactionContext() factory or directly via new. A private brand
+ * field makes the context opaque to structural typing and protects
+ * runWithTransactionContext() against forgeries via cast/instanceof.
  */
 export class ActiveTransactionContext {
-  /** Уникальный идентификатор транзакции (символ) — для сравнения по значению. */
+  /** Unique transaction identifier (a symbol) — for by-value comparison. */
   readonly transactionId: symbol;
-  /** Executor транзакции — передаётся в операции вместо executor'а сущности. */
+  /** Transaction executor — passed into operations instead of the entity executor. */
   readonly trx: YdbExecutor;
-  /** Executor БД, открывший транзакцию: детекция вложенности по transactionId. */
+  /** The DB executor that opened the transaction: nesting is detected by transactionId. */
   readonly db: YdbExecutor;
-  /** Сигнал отмены конкретной попытки транзакции (при retry — новый). */
+  /** Cancellation signal for the specific transaction attempt (new on retry). */
   readonly signal: AbortSignal | undefined;
-  /** Включён ли ambient auto-join для этого контекста. */
+  /** Whether ambient auto-join is enabled for this context. */
   readonly ambient: boolean;
-  /** Приватная brand-метка: есть только у инстансов, созданных через фабрику. */
+  /** Private brand mark: only present on instances created through the factory. */
   readonly #brand = Symbol('ActiveTransactionContext');
 
   constructor(params: TransactionContextParams) {
@@ -56,7 +56,7 @@ export class ActiveTransactionContext {
     this.ambient = params.ambient;
   }
 
-  /** Возвращает true только для настоящего фабричного инстанса. */
+  /** Returns true only for a genuine factory-created instance. */
   static isContext(value: unknown): value is ActiveTransactionContext {
     return typeof value === 'object' && value !== null && #brand in value;
   }
@@ -64,16 +64,16 @@ export class ActiveTransactionContext {
 
 const storage = new AsyncLocalStorage<ActiveTransactionContext>();
 
-/** Настройки транзакций процесса (заполняются из YdbModuleOptions). */
+/** The process transaction settings (filled from YdbModuleOptions). */
 let settings: Required<YdbTransactionsSettings> = {
   ambient: false,
   warnOutsideTransaction: false,
 };
 
 /**
- * Конфигурирует транзакционное поведение процесса (#98).
- * Вызывается YdbOrmModule при инициализации; доступен и standalone-пользователям.
- * Настройки глобальные для процесса — как реестр сущностей.
+ * Configures the transactional behavior of the process (#98).
+ * Called by YdbOrmModule during initialization; also available to standalone
+ * users. Settings are global for the process — like the entity registry.
  */
 export function configureTransactionContext(
   options?: YdbTransactionsSettings,
@@ -84,15 +84,15 @@ export function configureTransactionContext(
   };
 }
 
-/** Текущие настройки (для тестов и менеджера транзакций). */
+/** Current settings (for tests and the transaction manager). */
 export function getTransactionContextSettings(): Required<YdbTransactionsSettings> {
   return { ...settings };
 }
 
 /**
- * Эффективные настройки транзакций для одной операции (#199):
- * настройки конфигурации-владельца сущности, если заданы, иначе
- * процессно-глобальные (прежнее поведение одиночной конфигурации).
+ * Effective transaction settings for one operation (#199):
+ * the owning entity configuration's settings, if provided, otherwise the
+ * process-global ones (the previous single-configuration behavior).
  */
 export function resolveTransactionSettings(
   scopeSettings?: Required<YdbTransactionsSettings>,
@@ -100,17 +100,17 @@ export function resolveTransactionSettings(
   return scopeSettings ?? settings;
 }
 
-/** Активная транзакция в текущей async-цепочке, если есть. */
+/** The active transaction in the current async chain, if any. */
 export function getActiveTransaction(): ActiveTransactionContext | undefined {
   return storage.getStore();
 }
 
 /**
- * Выполняет fn с заданным контекстом активной транзакции.
+ * Runs fn with the given active-transaction context.
  *
- * Публичная граница (#208): контекст обязан быть настоящим инстансом,
- * созданным через createTransactionContext() — приватный brand-проверкой
- * исключаются и обычные объекты, и подделки через cast/instanceof.
+ * Public boundary (#208): the context must be a genuine instance created via
+ * createTransactionContext() — the private brand check excludes plain objects
+ * and forgeries via cast/instanceof alike.
  */
 export function runWithTransactionContext<T>(
   context: ActiveTransactionContext,
@@ -125,22 +125,23 @@ export function runWithTransactionContext<T>(
 }
 
 /**
- * Резолвит executor для одной операции репозитория (#98).
+ * Resolves the executor for a single repository operation (#98).
  *
- * - Явный trx всегда побеждает, НО при активном ambient-контексте другой
- *   транзакции это почти наверняка ошибка — смешивать активную ambient-
- *   транзакцию с посторонней нельзя, кидаем понятную ошибку.
- * - Без явного trx при включённом ambient auto-join возвращаем активную
- *   транзакцию.
- * - Иначе — обычный executor сущности; если настроен
- *   warnOutsideTransaction и транзакции нет вовсе — предупреждение.
+ * - An explicit trx always wins, BUT under an active ambient context of a
+ *   different transaction this is almost certainly an error — an active
+ *   ambient transaction cannot be mixed with a foreign one, so we throw a
+ *   clear error.
+ * - Without an explicit trx, when ambient auto-join is enabled, the active
+ *   transaction is returned.
+ * - Otherwise — the entity's normal executor; if warnOutsideTransaction is
+ *   configured and no transaction is active at all, a warning is emitted.
  *
- * Предупреждение уходит в логгер через опциональный хук `warn` (#206).
- * Вызывающий код передаёт логгер СВОЕЙ конфигурации (resolveExecutorLogger);
- * без переданного логгера предупреждение не эмитится вовсе — прямой записи
- * в console.warn здесь нет.
+ * The warning goes to the logger through the optional `warn` hook (#206).
+ * The caller passes the logger of ITS own configuration (resolveExecutorLogger);
+ * without a passed logger no warning is emitted at all — there is no direct
+ * console.warn here.
  *
- * Ошибки не глотаются и не заменяются фолбэками.
+ * Errors are neither swallowed nor replaced with fallbacks.
  */
 export function resolveOperationExecutor(
   explicitTrx: YdbExecutor | undefined,
@@ -171,8 +172,8 @@ export function resolveOperationExecutor(
     return active.trx;
   }
 
-  // Нет executor'а — вызывающий код сам бросит понятную ошибку «executor
-  // not set», предупреждение тут не нужно.
+  // No executor — the caller itself throws a clear "executor not set" error,
+  // so no warning is needed here.
   if (!fallback) {
     return fallback;
   }
@@ -188,44 +189,45 @@ export function resolveOperationExecutor(
 }
 
 /**
- * Приватный реестр identity (#217): executor -> символ.
+ * Private identity registry (#217): executor -> symbol.
  *
- * Источник правды для transaction/executor identity находится ЗДЕСЬ, а не в
- * мутируемом свойстве executor'а. Слабые ключи позволяют собирать объекты,
- * на которые больше нет ссылок (в т.ч. краткоживущие trx-executor'ы каждой
- * попытки), и НЕ требуют мутации объект executor'а вовсе — frozen/sealed
- * executor'ы работают без изменений. Потребители не имеют доступа к реестру,
- * поэтому не могут перезаписать чужой identity и соединить два независимых
- * контекста в один.
+ * The source of truth for transaction/executor identity lives HERE, not in a
+ * mutable property on the executor. Weak keys let objects with no remaining
+ * references be collected (including the short-lived trx executors of each
+ * attempt) and require NO mutation of the executor object at all — frozen/sealed
+ * executors work unchanged. Consumers have no access to the registry, so they
+ * cannot overwrite someone else's identity or stitch two independent contexts
+ * into one.
  */
 const identityRegistry = new WeakMap<YdbExecutor, symbol>();
 
 /**
- * Получает identity-токен из executor'а (#207/#217).
- * Возвращает символ из приватного реестра (для live-транзакции это её
- * transactionId, для логического DB-executor'а — стабильный идентификатор
- * этого executor'а), иначе сам executor для обратной совместимости
- * (сравнение по ссылке для executor'ов без identity).
+ * Gets the identity token from the executor (#207/#217).
+ * Returns the symbol from the private registry (for a live transaction that is
+ * its transactionId, for a logical DB executor — a stable identifier of that
+ * executor); otherwise the executor itself for backwards compatibility
+ * (by-reference comparison for executors without identity).
  */
 export function getTransactionId(trx: YdbExecutor): symbol | YdbExecutor {
   return identityRegistry.get(trx) ?? trx;
 }
 
 /**
- * Явно запоминает identity-токен для executor'а в приватном реестре (#217).
- * Используется, чтобы присвоить свежесозданному trx-executor'у данной попытки
- * её transactionId (см. runAttemptBody, entity-relations). Не мутирует объект.
+ * Explicitly records an identity token for an executor in the private registry
+ * (#217). Used to assign a freshly created trx executor its attempt's
+ * transactionId (see runAttemptBody, entity-relations). Does not mutate the
+ * object.
  */
 export function setExecutorIdentity(executor: YdbExecutor, id: symbol): void {
   identityRegistry.set(executor, id);
 }
 
 /**
- * Присваивает executor'у стабильный identity-токен, если его ещё нет (#207).
- * Используется для логических DB-executor'ов: разные обёртки одного и того же
- * логического executor'а разделяют этот токен, поэтому детекция вложенных
- * транзакций может сравнивать DB-контексты по значению, а не по ссылке на
- * объект. Токен хранится в приватном реестре и не мутирует executor.
+ * Assigns the executor a stable identity token if it does not have one yet
+ * (#207). Used for logical DB executors: different wrappers of one logical
+ * executor share this token, so nested-transaction detection can compare DB
+ * contexts by value rather than by object reference. The token is stored in
+ * the private registry and does not mutate the executor.
  */
 export function ensureExecutorIdentity(executor: YdbExecutor): symbol {
   const existing = identityRegistry.get(executor);
@@ -236,10 +238,10 @@ export function ensureExecutorIdentity(executor: YdbExecutor): symbol {
 }
 
 /**
- * Наследует identity-токен с внутреннего executor'а на обёртку (#207):
- * wrapExecutorWithLogging()/withRetryPolicy() создают НОВЫЕ объекты, и чтобы
- * обёртки того же логического executor'а распознавались как один DB-контекст,
- * они копируют токен с исходного executor'а в приватный реестр обёртки.
+ * Inherits the identity token from an inner executor onto a wrapper (#207):
+ * wrapExecutorWithLogging()/withRetryPolicy() create NEW objects, and so that
+ * wrappers of the same logical executor are recognized as one DB context, they
+ * copy the token from the source executor into the wrapper's private registry.
  */
 export function inheritExecutorIdentity(
   source: YdbExecutor,
@@ -252,15 +254,15 @@ export function inheritExecutorIdentity(
 }
 
 /**
- * Единственная точка валидации инвариантов ActiveTransactionContext (#208):
+ * Single point of validation for ActiveTransactionContext invariants (#208):
  *
- * - transactionId должен быть символом
- * - trx должен быть валидным executor'ом (объект или функция)
- * - db должен быть валидным executor'ом (объект или функция)
- * - signal, если задан, должен быть AbortSignal
- * - ambient должен быть boolean
+ * - transactionId must be a symbol
+ * - trx must be a valid executor (object or function)
+ * - db must be a valid executor (object or function)
+ * - signal, if provided, must be an AbortSignal
+ * - ambient must be a boolean
  *
- * @throws Error если любой инвариант нарушен
+ * @throws Error if any invariant is violated
  */
 function validateTransactionContextParams(
   params: TransactionContextParams,
@@ -297,9 +299,10 @@ function validateTransactionContextParams(
 }
 
 /**
- * Канонический способ получения ActiveTransactionContext: валидация инвариантов
- * (#208) происходит в конструкторе, brand-поле блокирует структурные подделки
- * (объектные литералы и касты в runWithTransactionContext отклоняются).
+ * Canonical way to obtain an ActiveTransactionContext: invariant validation
+ * (#208) happens in the constructor, and the brand field blocks structural
+ * forgeries (object literals and casts are rejected in
+ * runWithTransactionContext).
  */
 export function createTransactionContext(
   params: TransactionContextParams,

--- a/src/transaction/transaction.manager.spec.ts
+++ b/src/transaction/transaction.manager.spec.ts
@@ -29,9 +29,9 @@ import type {
 } from '../core/interfaces.js';
 
 /**
- * Юнит-тесты менеджера транзакций (#98): валидация опций, проброс опций
- * в SDK-вызов, детекция вложенности, reuse, ambient-контекст, retry-
- * семантика. Сети нет — используется фейковый executor.
+ * Unit tests for the transaction manager (#98): option validation, option
+ * propagation to the SDK call, nesting detection, reuse, ambient context,
+ * retry semantics. No network — a fake executor is used.
  */
 
 interface RecordedTransaction {
@@ -42,13 +42,13 @@ interface RecordedTransaction {
 interface FakeDb {
   executor: YdbExecutor;
   transactions: RecordedTransaction[];
-  /** Сколько раз transaction() открывал транзакцию. */
+  /** How many times transaction() opened a transaction. */
   count(): number;
 }
 
 function makeFakeDb(
   opts: {
-    /** Имитировать idempotent-retry SDK: колбэк execute вызывается N раз. */
+    /** Simulate SDK idempotent-retry: the execute callback is invoked N times. */
     attemptsPerTransaction?: number;
   } = {},
 ): FakeDb {
@@ -84,8 +84,8 @@ function makeFakeDb(
     const trxExecutors = Array.from({ length: attempts }, () =>
       makeQueryExecutor(),
     );
-    // Каждая попытка — свой сигнал отмены (как linkSignals в @ydbjs/query),
-    // связанный с глобальным пользовательским сигналом из опций.
+    // Each attempt has its own cancellation signal (like linkSignals in
+    // @ydbjs/query), linked to the global user signal from the options.
     const attemptControllers = Array.from(
       { length: attempts },
       () => new AbortController(),
@@ -93,8 +93,8 @@ function makeFakeDb(
     transactions.push({ options: options ?? {}, trx: trxExecutors[0] });
     return {
       async execute(fn) {
-        // Имитация @ydbjs/query: каждая попытка — новый session/tx executor
-        // и новый сигнал попытки.
+        // Simulation of @ydbjs/query: each attempt is a new session/tx executor
+        // and a new attempt signal.
         let result: unknown;
         for (let attempt = 0; attempt < attempts; attempt += 1) {
           const ownSignal = attemptControllers[attempt].signal;
@@ -207,7 +207,7 @@ describe('runInTransaction(): options propagation to the SDK call (#98)', () => 
       signal: controller.signal,
     });
 
-    // Пользовательский сигнал уходит в SDK без изменений — он глобальный.
+    // The user signal goes to the SDK unchanged — it is global.
     expect(db.transactions[0].options.signal).toBe(controller.signal);
   });
 
@@ -225,9 +225,9 @@ describe('runInTransaction(): options propagation to the SDK call (#98)', () => 
       { timeout: 30 },
     );
 
-    // Таймаут НЕ попадает в SDK как общий дедлайн...
+    // The timeout does NOT reach the SDK as a shared deadline...
     expect(db.transactions[0].options.signal).toBeUndefined();
-    // ...а применяется к сигналу конкретной попытки.
+    // ...but is applied to the specific attempt's signal.
     expect(attemptSignal).toBeInstanceOf(AbortSignal);
     expect(attemptSignal?.aborted).toBe(true);
   }, 5000);
@@ -260,7 +260,7 @@ describe('timeout semantics across retries (#98)', () => {
       async (_trx, signal) => {
         received.push(signal!);
         if (received.length === 1) {
-          // Первая попытка «зависла» дольше таймаута.
+          // The first attempt "hung" longer than the timeout.
           await new Promise((resolve) => setTimeout(resolve, 90));
         }
         return Promise.resolve('ok');
@@ -269,12 +269,12 @@ describe('timeout semantics across retries (#98)', () => {
     );
 
     expect(received.length).toBe(2);
-    // Первая попытка упёрлась в таймаут...
+    // The first attempt hit the timeout...
     expect(received[0].aborted).toBe(true);
-    // ...но retry получил СВЕЖИЙ сигнал, а не уже истёкший дедлайн.
+    // ...but the retry got a FRESH signal, not the already-expired deadline.
     expect(received[1].aborted).toBe(false);
     expect(received[1]).not.toBe(received[0]);
-    // Таймаут не просочился в SDK как общий дедлайн операции.
+    // The timeout did not leak into the SDK as the operation's shared deadline.
     expect(db.transactions[0].options.signal).toBeUndefined();
   }, 5000);
 
@@ -288,20 +288,20 @@ describe('timeout semantics across retries (#98)', () => {
       async (_trx, signal) => {
         received.push(signal!);
         if (received.length === 1) {
-          // Глобальный дедлайн истекает, пока выполняется первая попытка.
+          // The global deadline expires while the first attempt is running.
           await new Promise((resolve) => setTimeout(resolve, 90));
         }
         return Promise.resolve('ok');
       },
-      // Полный дедлайн на всю операцию задаётся пользователем явно.
+      // The full operation-wide deadline is set by the user explicitly.
       { idempotent: true, signal: AbortSignal.timeout(30) },
     );
 
     expect(received.length).toBe(2);
-    // Оба сигнала прерваны: глобальный дедлайн распространяется на retry.
+    // Both signals are aborted: the global deadline propagates to retry.
     expect(received[0].aborted).toBe(true);
     expect(received[1].aborted).toBe(true);
-    // При этом сигнал SDK в опциях — именно пользовательский.
+    // The signal in the SDK options is exactly the user's.
     expect(db.transactions[0].options.signal).toBeDefined();
   }, 5000);
 });
@@ -317,7 +317,7 @@ describe('runInTransaction(): nested call detection (#98)', () => {
       }),
     ).rejects.toThrow(/Nested runInTransaction\(\) detected/);
 
-    // Вторая транзакция не была открыта.
+    // The second transaction was not opened.
     expect(db.count()).toBe(1);
   });
 
@@ -337,7 +337,7 @@ describe('runInTransaction(): nested call detection (#98)', () => {
     });
 
     expect(result).toBe('joined');
-    // Открыта ровно одна транзакция — внешняя.
+    // Exactly one transaction is opened — the outer one.
     expect(db.count()).toBe(1);
   });
 
@@ -350,13 +350,13 @@ describe('runInTransaction(): nested call detection (#98)', () => {
       (outerTrx, outerSignal) =>
         manager.runInTransaction(
           () => {
-            // Вложенный ambient-контекст указывает на ТУ ЖЕ транзакцию.
+            // The nested ambient context points to the SAME transaction.
             const active = getActiveTransaction();
             expect(active?.trx).toBe(outerTrx);
             expect(active?.signal).toBe(outerSignal);
             expect(active?.ambient).toBe(true);
-            // Операции без явного { trx } попадают в переиспользованную
-            // транзакцию, а не во внешний executor.
+            // Operations without an explicit { trx } go into the reused
+            // transaction, not the outer executor.
             expect(
               resolveOperationExecutor(undefined, db.executor, 'UserEntity'),
             ).toBe(outerTrx);
@@ -367,7 +367,7 @@ describe('runInTransaction(): nested call detection (#98)', () => {
       { ambient: false },
     );
 
-    // Новая БД-транзакция не открывалась.
+    // No new DB transaction was opened.
     expect(db.count()).toBe(1);
   }, 5000);
 
@@ -380,7 +380,7 @@ describe('runInTransaction(): nested call detection (#98)', () => {
       manager.runInTransaction(
         () => {
           const active = getActiveTransaction();
-          // Контекст внешний — без создания вложенного.
+          // The context is the outer one — no nested context is created.
           expect(active?.trx).toBe(outerTrx);
           expect(active?.ambient).toBe(true);
           return Promise.resolve();
@@ -399,8 +399,8 @@ describe('runInTransaction(): nested call detection (#98)', () => {
 
     let outerContextBeforeInner: ReturnType<typeof getActiveTransaction>;
     let trxExecutorSeenInside: unknown;
-    // При attemptsPerTransaction > 1 фейковый SDK повторяет ВЕСЬ колбэк,
-    // поэтому эталонный executor фиксируем на верхнем уровне той же попытки.
+    // With attemptsPerTransaction > 1 the fake SDK replays the WHOLE callback,
+    // so the reference executor is captured at the top level of the same attempt.
     let outerLevelTrx: unknown;
 
     await manager.runInTransaction(
@@ -416,12 +416,12 @@ describe('runInTransaction(): nested call detection (#98)', () => {
               },
               { reuse: true, ambient: true },
             );
-            // После завершения внутреннего вызова контекст восстановлен:
-            // снова активен ВНЕШНИЙ (не ambient-обёртка с тем же trx).
+            // After the inner call finishes, the context is restored:
+            // the OUTER (non-ambient wrapper with the same trx) is active again.
             const restored = getActiveTransaction();
             expect(restored?.trx).toBe(outerContextBeforeInner?.trx);
             expect(restored).toBe(outerContextBeforeInner);
-            // Транзакция всё ещё активна — внутренний вызов её не завершил.
+            // The transaction is still active — the inner call did not finish it.
             expect(db.count()).toBe(1);
             return Promise.resolve();
           },
@@ -431,7 +431,7 @@ describe('runInTransaction(): nested call detection (#98)', () => {
       { ambient: false },
     );
 
-    // Ровно одна транзакция и один executor попытки на все уровни reuse.
+    // Exactly one transaction and one attempt executor across all reuse levels.
     expect(db.count()).toBe(1);
     expect(trxExecutorSeenInside).toBe(outerLevelTrx);
     expect(getActiveTransaction()).toBeUndefined();
@@ -471,7 +471,7 @@ describe('nested detection and mixing with executor wrappers (#207)', () => {
   it('recognizes nested runInTransaction across different wrappers of the same logical DB', async () => {
     const db = makeFakeDb();
     const managerA = new YdbTransactionManager(db.executor);
-    // Вторая обёртка того же логического executor'а (логирование).
+    // A second wrapper of the same logical executor (logging).
     const managerB = new YdbTransactionManager(
       wrapExecutorWithLogging(db.executor, noopLogger),
     );
@@ -482,7 +482,7 @@ describe('nested detection and mixing with executor wrappers (#207)', () => {
       ),
     ).rejects.toThrow(/Nested runInTransaction\(\) detected/);
 
-    // Вторая независимая транзакция не открылась — вложенность распознана.
+    // No second independent transaction was opened — nesting is recognized.
     expect(db.count()).toBe(1);
   });
 
@@ -496,8 +496,8 @@ describe('nested detection and mixing with executor wrappers (#207)', () => {
     const result = await managerA.runInTransaction((outerTrx) =>
       managerB.runInTransaction(
         (innerTrx) => {
-          // reuse присоединяется к активной транзакции внешнего вызова —
-          // тот же trx, новая БД-транзакция не открывается.
+          // reuse joins the outer call's active transaction —
+          // the same trx, no new DB transaction is opened.
           expect(innerTrx).toBe(outerTrx);
           return Promise.resolve('joined');
         },
@@ -506,7 +506,7 @@ describe('nested detection and mixing with executor wrappers (#207)', () => {
     );
 
     expect(result).toBe('joined');
-    // Открыта ровно одна транзакция — внешняя.
+    // Exactly one transaction is opened — the outer one.
     expect(db.count()).toBe(1);
   });
 
@@ -517,8 +517,8 @@ describe('nested detection and mixing with executor wrappers (#207)', () => {
     await manager.runInTransaction(
       (trx) => {
         const wrappedTrx = wrapExecutorWithLogging(trx, noopLogger);
-        // Обёртка активной транзакции как явный { trx } при ambient —
-        // это та же логическая транзакция, ошибки смешивания быть не должно.
+        // A wrapper of the active transaction as an explicit { trx } under
+        // ambient — it is the same logical transaction, so no mixing error.
         expect(() =>
           resolveOperationExecutor(wrappedTrx, db.executor, 'UserEntity'),
         ).not.toThrow();
@@ -540,8 +540,8 @@ describe('nested detection and mixing with executor wrappers (#207)', () => {
         ).runInTransaction((otherTrx) =>
           Promise.resolve(wrapExecutorWithLogging(otherTrx, noopLogger)),
         );
-        // Посторонняя транзакция (хоть и обёрнутая) при активной ambient —
-        // смешивание, ошибка сохраняется.
+        // A foreign transaction (even wrapped) under an active ambient —
+        // mixing, the error is preserved.
         expect(() =>
           resolveOperationExecutor(other, db.executor, 'UserEntity'),
         ).toThrow(/mixing detected.*different transaction is active/s);
@@ -560,18 +560,18 @@ describe('identity registry (#217): private, non-mutable source of truth', () =>
     const executor = db.executor;
     const manager = new YdbTransactionManager(executor);
 
-    // Пытаемся «подделать» identity, записав произвольный символ в свойства
-    // executor'а, в т.ч. по прежнему глобальному ключу Symbol.for(...).
+    // Try to "forge" the identity by writing an arbitrary symbol into the
+    // executor's properties, including the old global Symbol.for(...) key.
     const forged = Symbol('forged');
     (executor as unknown as Record<PropertyKey, unknown>)[
       Symbol.for('ydb.transaction.id')
     ] = forged;
     (executor as unknown as Record<string, unknown>).anyOtherProp = forged;
 
-    // Реестр identity не читает свойства объекта — identity не изменился.
+    // The identity registry does not read object properties — identity unchanged.
     expect(getTransactionId(executor)).not.toBe(forged);
 
-    // Вложенная детекция по-прежнему работает по registry-identity.
+    // Nested detection still works via the registry identity.
     await expect(
       manager.runInTransaction(() =>
         manager.runInTransaction(() => Promise.resolve()),
@@ -604,7 +604,7 @@ describe('identity registry (#217): private, non-mutable source of truth', () =>
     const id = ensureExecutorIdentity(db.executor);
     expect(getTransactionId(db.executor)).toBe(id);
 
-    // Вложенная детекция на frozen-executor'е работает (никаких записей в объект).
+    // Nested detection works on a frozen executor (no writes into the object).
     await expect(
       manager.runInTransaction(() =>
         manager.runInTransaction(() => Promise.resolve()),
@@ -618,12 +618,12 @@ describe('identity registry (#217): private, non-mutable source of truth', () =>
 
     await manager.runInTransaction(
       (trx) => {
-        // Обёртка ТОЙ ЖЕ транзакции — не смешивание.
+        // A wrapper of the SAME transaction — not mixing.
         const wrapped = wrapExecutorWithLogging(trx, noopLogger);
         expect(() =>
           resolveOperationExecutor(wrapped, db.executor, 'UserEntity'),
         ).not.toThrow();
-        // Чужой executor — смешивание при активной ambient-транзакции.
+        // A foreign executor — mixing under an active ambient transaction.
         const stranger = makeFakeDb().executor;
         expect(() =>
           resolveOperationExecutor(stranger, db.executor, 'UserEntity'),
@@ -637,7 +637,7 @@ describe('identity registry (#217): private, non-mutable source of truth', () =>
 
 describe('ambient transaction context (#98)', () => {
   afterEach(() => {
-    // Сбрасываем глобальные настройки, чтобы не влиять на другие тесты файла.
+    // Reset the global settings so other tests in the file are not affected.
     configureTransactionContext({});
   });
 
@@ -686,11 +686,11 @@ describe('resolveOperationExecutor semantics via repository resolution (#98)', (
 
     await manager.runInTransaction(
       (trx) => {
-        // Совпадает с активной ambient — ок.
+        // Matches the active ambient — ok.
         expect(resolveOperationExecutor(trx, db.executor, 'UserEntity')).toBe(
           trx,
         );
-        // Посторонний trx при активной ambient-транзакции — ошибка смешивания.
+        // A foreign trx under an active ambient transaction — mixing error.
         expect(() =>
           resolveOperationExecutor(stranger, db.executor, 'UserEntity'),
         ).toThrow(/mixing detected.*different transaction is active/s);
@@ -706,8 +706,8 @@ describe('resolveOperationExecutor semantics via repository resolution (#98)', (
     const stranger = makeFakeDb().executor;
 
     await manager.runInTransaction(() => {
-      // Ambient выключен: явный { trx } — легитимный паттерн (обратная
-      // совместимость), никакой ошибки быть не должно.
+      // Ambient is off: an explicit { trx } is a legitimate pattern (backwards
+      // compatibility), no error should be raised.
       expect(
         resolveOperationExecutor(stranger, db.executor, 'UserEntity'),
       ).toBe(stranger);
@@ -735,10 +735,10 @@ describe('retry semantics are surfaced, not hidden (#98)', () => {
     );
 
     expect(result).toBe('done');
-    // Колбэк выполнен дважды: побочные эффекты повторяются при retry.
+    // The callback ran twice: side effects repeat on retry.
     expect(seen.length).toBe(2);
     expect(sideEffectCount).toBe(2);
-    // Каждая попытка получает СВОЙ executor транзакции и свой контекст.
+    // Each attempt gets ITS OWN transaction executor and context.
     expect(seen[0]).not.toBe(seen[1]);
   });
 
@@ -753,7 +753,7 @@ describe('retry semantics are surfaced, not hidden (#98)', () => {
     });
 
     expect(calls).toBe(1);
-    // Без явного флага менеджер не включает повторное выполнение колбэка.
+    // Without the explicit flag the manager does not enable callback replay.
     expect(db.transactions[0].options.idempotent).toBeUndefined();
   });
 });
@@ -820,8 +820,8 @@ describe('warnOutsideTransaction (#98) through the ORM logger (#206)', () => {
       '[ydb-orm] UserEntity: query executed outside any transaction ' +
         '(warnOutsideTransaction is enabled).',
     );
-    // Предупреждение не требует прямого console.warn: кастомный логгер
-    // получает сообщение, консоль не задействована.
+    // The warning does not require a direct console.warn: the custom logger
+    // receives the message and the console is not involved.
     expect(warnSpy).not.toHaveBeenCalled();
   });
 

--- a/src/transaction/transaction.manager.ts
+++ b/src/transaction/transaction.manager.ts
@@ -16,36 +16,36 @@ import {
   setExecutorIdentity,
 } from './transaction-context.js';
 
-/** Генерирует уникальный идентификатор транзакции. */
+/** Generates a unique transaction identifier. */
 function generateTransactionId(): symbol {
   return Symbol('transaction');
 }
 
 /**
- * Опции runInTransaction() (#98).
+ * Options for runInTransaction() (#98).
  *
- * Наследует опции исполнения YDB-транзакции (isolation/signal/timeout/
- * idempotent) и добавляет управление контекстом:
+ * Inherits the YDB transaction execution options (isolation/signal/timeout/
+ * idempotent) and adds context control:
  *
- * - reuse — при вложенном вызове переиспользовать уже активную транзакцию
- *   вместо ошибки. Транзакция остаётся под управлением внешнего вызова:
- * внутренний колбэк не коммитит и не откатывает её самостоятельно.
- * - ambient — принудительно пробросить эту транзакцию в ambient-контекст
- *   (операции без явного { trx } будут выполняться в ней), даже если
- *   ambient выключен глобально. Работает и при вложенном `{ reuse: true }`:
- *   создаётся вложенный контекст с транзакцией внешнего вызова (коммит/
- *   откат по-прежнему у внешнего вызова). Значение false НЕ отключает
- *   глобальный ambient — используйте для этого настройки модуля.
- * - retry — retry-политика ORM по типу ошибки (#27): `true` — дефолты
- *   (maxAttempts: 3, bounded backoff + jitter), объект — кастомная политика.
- *   Когда политика задана, владение повторами тела ПЕРЕХОДИТ от SDK к ORM:
- *   на каждую попытку политики приходится ровно одна попытка тела (внутренний
- *   цикл SDK гасится), максимум исполнений колбэка равен maxAttempts —
- *   попытки не перемножаются. Без политики поведение прежнее (#98): тело
- *   ретраит SDK по своим правилам (неограниченный бюджет). Контракт
- *   идемпотентности — на КОЛБЭК целиком (#98): пометки .idempotent()
- *   отдельных запросов внутри тела SDK игнорирует и на повтор колбэка
- *   не влияют.
+ * - reuse — on a nested call, reuse the already-active transaction instead of
+ *   throwing. The transaction stays under the control of the outer call: the
+ *   inner callback neither commits nor rolls it back on its own.
+ * - ambient — force this transaction into the ambient context (operations
+ *   without an explicit { trx } run inside it), even when ambient is disabled
+ *   globally. It also works with a nested `{ reuse: true }`: a nested context
+ *   is created carrying the outer call's transaction (commit/rollback still
+ *   belong to the outer call). A value of false does NOT disable the global
+ *   ambient — use the module settings for that.
+ * - retry — the ORM retry policy by error kind (#27): `true` — defaults
+ *   (maxAttempts: 3, bounded backoff + jitter), an object — a custom policy.
+ *   When a policy is set, ownership of retrying the body PASSES from the SDK
+ *   to the ORM: exactly one body attempt per policy attempt (the SDK's inner
+ *   loop is silenced), so the callback runs at most maxAttempts times —
+ *   attempts do not multiply. Without a policy the behavior is unchanged (#98):
+ *   the SDK retries the body by its own rules (unbounded budget). The
+ *   idempotency contract applies to the CALLBACK as a whole (#98): the SDK
+ *   ignores .idempotent() markings on individual queries inside the body and
+ *   they have no effect on a callback replay.
  */
 export interface RunInTransactionOptions extends YdbTransactionOptions {
   reuse?: boolean;
@@ -53,14 +53,14 @@ export interface RunInTransactionOptions extends YdbTransactionOptions {
   retry?: YdbRetryPolicyInput;
 }
 
-/** Допустимые уровни изоляции — для fail-fast валидации опций. */
+/** Allowed isolation levels — for fail-fast option validation. */
 const ISOLATION_LEVELS: readonly YdbIsolationLevel[] = [
   'serializableReadWrite',
   'snapshotReadOnly',
   'snapshotReadWrite',
 ];
 
-/** Ключи, допустимые в RunInTransactionOptions (защита от опечаток). */
+/** Keys allowed in RunInTransactionOptions (typo protection). */
 const ALLOWED_OPTION_KEYS = new Set([
   'isolation',
   'signal',
@@ -72,10 +72,11 @@ const ALLOWED_OPTION_KEYS = new Set([
 ]);
 
 /**
- * Маркер «внутренний ретрай SDK вытеснен политикой ORM» (#27): бросается
- * телом транзакции, когда SDK пытается начать попытку сверх лимита политики.
- * Для предиката повтора SDK это заведомо неповторяемая ошибка — цикл SDK
- * завершается; наружу пробрасывается исходная ошибка последней попытки.
+ * Marker for "SDK inner retry superseded by the ORM policy" (#27): thrown by
+ * the transaction body when the SDK tries to start an attempt beyond the
+ * policy limit. To the SDK retry predicate this is guaranteed non-retryable,
+ * so the SDK loop ends; the original error from the last attempt is
+ * propagated outward.
  */
 class SdkRetrySupersededError extends Error {
   constructor(readonly lastError: unknown) {
@@ -84,14 +85,14 @@ class SdkRetrySupersededError extends Error {
   }
 }
 
-/** Глубина обхода cause-цепочки при распаковке ошибки транзакции. */
+/** Depth of the cause-chain traversal when unwrapping a transaction error. */
 const MAX_CAUSE_DEPTH = 8;
 
 /**
- * Распаковывает ошибку execute(): SDK заворачивает неповторяемые ошибки
- * транзакции в Error('Transaction failed.', { cause }). Если в цепочке
- * найден маркер вытесненного ретрая — наружу идёт ИСХОДНАЯ ошибка
- * последней попытки (для классификации политикой), иначе ошибка как есть.
+ * Unwraps the execute() error: the SDK wraps non-retryable transaction errors
+ * in an Error('Transaction failed.', { cause }). If a superseded-retry marker
+ * is found in the chain, the ORIGINAL error of the last attempt is propagated
+ * outward (for policy classification); otherwise the error is returned as is.
  */
 function unwrapTransactionError(error: unknown): unknown {
   let current = error;
@@ -113,8 +114,9 @@ function unwrapTransactionError(error: unknown): unknown {
 }
 
 /**
- * Fail-fast валидация опций транзакции: неизвестный ключ или невалидное
- * значение — ошибка конфигурации сразу, а не тихо проигнорированная опция.
+ * Fail-fast validation of transaction options: an unknown key or an invalid
+ * value raises a configuration error immediately rather than silently
+ * ignoring the option.
  */
 export function validateRunInTransactionOptions(
   options?: RunInTransactionOptions,
@@ -189,7 +191,7 @@ export function validateRunInTransactionOptions(
     );
   }
 
-  // Политика не имеет смысла при reuse: повторами управляет внешний вызов.
+  // A policy is meaningless with reuse: the outer call owns retries.
   if (reuse && options.retry !== undefined) {
     throw new Error(
       'runInTransaction(): "retry" cannot be combined with "reuse: true" — ' +
@@ -199,57 +201,57 @@ export function validateRunInTransactionOptions(
 }
 
 /**
- * Менеджер транзакций (#98).
+ * Transaction manager (#98).
  *
- * Семантика повтора по умолчанию — как в @ydbjs/query: при `idempotent:
- * true` SDK может ПОВТОРНО выполнить весь колбэк при retryable-ошибках
- * (смерть сессии, сетевые сбои). Это значит, что побочные эффекты колбэка
- * и все lifecycle hooks сущностей могут выполниться больше одного раза —
- * колбэк должен быть идемпотентным или устойчивым к повтору.
+ * Default retry semantics match @ydbjs/query: with `idempotent: true` the SDK
+ * may RE-EXECUTE the whole callback on retryable errors (session death, network
+ * failures). This means the callback's side effects and all entity lifecycle
+ * hooks may run more than once — the callback must be idempotent or tolerant of
+ * replay.
  *
- * Приоритет слоёв повтора (#27, детерминированный):
- * - опция `retry` не задана — повторами тела владеет ТОЛЬКО SDK (как в #98);
- * - опция `retry` задана (`true` или объект политики) — владение переходит
- *   к политике ORM: ровно одна попытка тела на попытку политики (внутренний
- *   цикл SDK гасится), максимум исполнений колбэка = maxAttempts, между
- *   попытками bounded backoff + jitter, повторяются только статусы
- *   ABORTED/UNAVAILABLE/OVERLOADED. Требование идемпотентности колбэка —
- *   то же, что у idempotent-транзакций #98.
- * Смешивания слоёв нет: попытки не перемножаются ни в одной из конфигураций.
+ * Retry-layer priority (#27, deterministic):
+ * - no `retry` option — only the SDK owns body retries (as in #98);
+ * - `retry` set (`true` or a policy object) — ownership passes to the ORM
+ *   policy: exactly one body attempt per policy attempt (the SDK's inner loop
+ *   is silenced), the callback runs at most maxAttempts times, bounded backoff
+ *   + jitter between attempts, and only ABORTED/UNAVAILABLE/OVERLOADED statuses
+ *   are retried. The callback idempotency requirement is the same as for the
+ *   #98 idempotent transactions.
+ * There is no layer mixing: attempts never multiply in any configuration.
  */
 export class YdbTransactionManager {
   /**
-   * @param db executor БД.
-   * @param settings настройки транзакций конфигурации-владельца (#199);
-   *   если не заданы, используются процессно-глобальные настройки
-   *   (configureTransactionContext) — прежнее поведение.
+   * @param db the DB executor.
+   * @param settings transaction settings of the owning configuration (#199);
+   *   if not provided, the process-global settings
+   *   (configureTransactionContext) are used — the previous behavior.
    */
   constructor(
     private readonly db: YdbExecutor,
     private readonly settings?: YdbTransactionsSettings,
   ) {
-    // Стабильный identity для логического DB-executor'а (#207): разные обёртки
-    // одного и того же executor'а разделяют его, поэтому детекция вложенных
-    // транзакций сравнивает контексты по значению, а не по ссылке на объект.
+    // Stable identity for a logical DB executor (#207): different wrappers of
+    // the same executor share it, so nested-transaction detection compares
+    // contexts by value rather than by object reference.
     ensureExecutorIdentity(db);
   }
 
   /**
-   * Выполняет fn внутри транзакции YDB.
+   * Executes fn inside a YDB transaction.
    *
-   * Вложенные вызовы по умолчанию запрещены: если runInTransaction()
-   * вызывается, пока активна другая транзакция того же executor'а БД,
-   * бросается ошибка — молча открыть независимую транзакцию на другой
-   * сессии нельзя. Чтобы присоединиться к активной транзакции (коммитом и
-   * откатом управляет внешний вызов), передайте `{ reuse: true }`.
-   * Вложенность на ДРУГОМ executor'е БД не считается ошибкой: это независимые
-   * базы/сессии.
+   * Nested calls are forbidden by default: if runInTransaction() is called
+   * while another transaction of the same DB executor is active, an error is
+   * thrown — silently opening an independent transaction on another session is
+   * not allowed. To join the active transaction (commit/rollback owned by the
+   * outer call), pass `{ reuse: true }`. Nesting on a DIFFERENT DB executor is
+   * not an error: those are independent databases/sessions.
    *
-   * @param fn колбэк, получающий executor транзакции и сигнал отмены текущей
-   *   попытки. При idempotent-retry вызывается повторно — см. выше.
-   * @param options см. RunInTransactionOptions. Семантика отмены:
-   *   `signal` — глобальный (отменяет все попытки), `timeout` — на каждую
-   *   попытку (retry получает свежее окно; полный дедлайн —
+   * @param fn callback receiving the transaction executor and the cancellation
+   *   signal of the current attempt. On idempotent-retry it is invoked again —
+   *   see above.
+   * @param options see RunInTransactionOptions. Cancellation semantics:
+   *   `signal` is global (cancels all attempts), `timeout` is per attempt
+   *   (each retry gets a fresh window; the full deadline is
    *   `signal: AbortSignal.timeout(ms)`).
    */
   async runInTransaction<T>(
@@ -258,20 +260,20 @@ export class YdbTransactionManager {
   ): Promise<T> {
     validateRunInTransactionOptions(options);
 
-    // Детекция вложенности работает всегда (ambient включён или нет).
+    // Nesting detection always works (whether or not ambient is enabled).
     const active = getActiveTransaction();
-    // Сравниваем по identity-токену, а не по ссылке на executor (#207).
-    // active.db === this.db — ссылочное сравнение; разные обёртки одного
-    // логического DB-executor'а (логирование/retry) разделяют токен, поэтому
-    // проверка по значению распознаёт вложенную транзакцию того же DB.
+    // Compare by identity token, not by executor reference (#207).
+    // active.db === this.db is a reference comparison; different wrappers of
+    // one logical DB executor (logging/retry) share the token, so the
+    // by-value check recognizes a nested transaction of the same DB.
     if (active && getTransactionId(active.db) === getTransactionId(this.db)) {
       if (options?.reuse) {
-        // Переиспользуем активную транзакцию: коммит/откат остаются у
-        // внешнего вызова, новая БД-транзакция не открывается. Если на
-        // внутреннем вызове явно задан ambient: true, создаём вложенный
-        // ALS-контекст с ТЕМИ ЖЕ trx/db/signal, но ambient-флагом вызова:
-        // иначе per-call ambient: true игнорировался бы, когда внешняя
-        // транзакция открыта с ambient: false.
+        // Reuse the active transaction: commit/rollback stay with the outer
+        // call and a new DB transaction is not opened. If the inner call
+        // explicitly sets ambient: true, create a nested ALS context with the
+        // SAME trx/db/signal but the call's ambient flag: otherwise a
+        // per-call ambient: true would be ignored when the outer transaction
+        // was opened with ambient: false.
         if (options.ambient === true) {
           return runWithTransactionContext(
             createTransactionContext({
@@ -293,9 +295,9 @@ export class YdbTransactionManager {
       );
     }
 
-    // Ambient auto-join для операций БЕЗ явного { trx }: opt-in per-call,
-    // настройки конфигурации-владельца (#199), либо глобальные настройки
-    // процесса (configureTransactionContext) — в порядке приоритета.
+    // Ambient auto-join for operations WITHOUT an explicit { trx }: opt-in
+    // per call, the owning configuration's settings (#199), or the process
+    // global settings (configureTransactionContext) — in priority order.
     const settings = resolveTransactionSettings(
       this.settings
         ? {
@@ -307,22 +309,22 @@ export class YdbTransactionManager {
     );
     const ambient = options?.ambient ?? settings.ambient;
 
-    // Семантика таймаута (#98): timeout действует НА КАЖДУЮ попытку.
-    // При idempotent-retry SDK выполняет колбэк повторно с новой сессией —
-    // каждая попытка получает СВЕЖЕЕ окно таймаута, а не истёкший дедлайн
-    // первой попытки. Пользовательский signal при этом ГЛОБАЛЬНЫЙ: он
-    // передаётся в SDK как есть и отменяет операцию целиком (все попытки).
-    // Полный общий дедлайн задаётся явно: signal: AbortSignal.timeout(ms).
+    // Timeout semantics (#98): a timeout applies TO EACH ATTEMPT.
+    // On idempotent-retry the SDK re-executes the callback with a new session —
+    // each attempt gets a FRESH timeout window instead of the first attempt's
+    // expired deadline. The user signal, meanwhile, is GLOBAL: it is passed to
+    // the SDK as is and cancels the whole operation (all attempts). A full
+    // shared deadline is set explicitly: signal: AbortSignal.timeout(ms).
 
     const trxOptions = {
       isolation: options?.isolation,
       idempotent: options?.idempotent,
-      // Только пользовательский сигнал: таймаут не должен попадать сюда,
-      // иначе он стал бы общим дедлайном для всех попыток.
+      // Only the user signal: a timeout must not reach here, otherwise it
+      // would become a shared deadline for all attempts.
       signal: options?.signal,
     };
 
-    /** Сигнал конкретной попытки: сигнал SDK + свежий AbortSignal.timeout. */
+    /** Signal for a specific attempt: the SDK signal + a fresh AbortSignal.timeout. */
     const composeAttemptSignal = (sdkSignal?: AbortSignal) => {
       if (options?.timeout === undefined) return sdkSignal;
       const signals = [sdkSignal, AbortSignal.timeout(options.timeout)].filter(
@@ -332,18 +334,18 @@ export class YdbTransactionManager {
     };
 
     /**
-     * Тело execute(): создаёт контекст попытки и вызывает колбэк.
-     * Используется и легаси-путём, и под политикой (#27).
+     * The execute() body: creates the attempt context and invokes the callback.
+     * Used both by the legacy path and under a policy (#27).
      */
     const runAttemptBody = (
       trx: YdbExecutor,
       sdkSignal: AbortSignal | undefined,
     ) => {
       const attemptSignal = composeAttemptSignal(sdkSignal);
-      // Генерируем уникальный ID для этой транзакции и запоминаем его для
-      // trx-executor'а данной попытки в приватном реестре identity (#217).
+      // Generate a unique ID for this transaction and remember it on this
+      // attempt's trx executor in the private identity registry (#217).
       const transactionId = generateTransactionId();
-      // trx всегда объект/функция (WeakMap-ключ); защита для примитивных моков.
+      // trx is always an object/function (a WeakMap key); guard for primitive mocks.
       if (trx && (typeof trx === 'object' || typeof trx === 'function')) {
         setExecutorIdentity(trx, transactionId);
       }
@@ -359,12 +361,12 @@ export class YdbTransactionManager {
       );
     };
 
-    // Retry-политика (#27): без неё — прежнее поведение (#98), тело ретраит
-    // только SDK по своим правилам. С ней — владение повторами переходит к
-    // ORM: на одну попытку политики приходится ровно одна попытка тела
-    // (внутренний цикл SDK гасится маркером SdkRetrySupersededError — для
-    // его предиката это заведомо неповторяемая ошибка), поэтому попытки не
-    // перемножаются, а максимум исполнений колбэка равен maxAttempts.
+    // Retry policy (#27): without it — the previous behavior (#98), the SDK
+    // alone retries the body by its own rules. With it — retry ownership passes
+    // to the ORM: exactly one body attempt per policy attempt (the SDK's inner
+    // loop is silenced via the SdkRetrySupersededError marker — which is
+    // guaranteed non-retryable for its predicate), so attempts do not multiply
+    // and the callback runs at most maxAttempts times.
     const policy = resolveYdbRetryPolicy(options?.retry);
     if (!policy) {
       return this.db

--- a/src/transaction/transaction.retry.spec.ts
+++ b/src/transaction/transaction.retry.spec.ts
@@ -7,17 +7,17 @@ import type { YdbExecutor, YdbTransactionHandle } from '../core/interfaces.js';
 import type { YdbRetrySleepFn } from '../core/retry.js';
 
 /**
- * Интеграционные тесты retry-политики в runInTransaction() (#27):
- * политика реально применяется к исполнению транзакции, попытки НЕ
- * перемножаются с внутренним ретраем SDK, детерминированный приоритет
- * слоёв (политика задана — владеет повторами ORM; не задана — SDK).
+ * Integration tests for the retry policy in runInTransaction() (#27):
+ * the policy is really applied to transaction execution, attempts do NOT
+ * multiply with the SDK's internal retry, deterministic layer priority
+ * (policy set — the ORM owns retries; not set — the SDK).
  */
 
 function ydbErr(code: number): YDBError {
   return new YDBError(code, []);
 }
 
-/** Статусы, которые внутренний предикат SDK считает всегда-повторяемыми. */
+/** Statuses the SDK's inner predicate considers always-retryable. */
 const SDK_ALWAYS_RETRYABLE = new Set([
   Code.ABORTED,
   Code.UNAVAILABLE,
@@ -37,16 +37,16 @@ interface FakeDbResult {
 
 type BodyFn = (trx: YdbExecutor, signal?: AbortSignal) => Promise<unknown>;
 
-/** Сценарий попытки: успех (ok) либо ошибка (Error-совместимая). */
+/** Attempt outcome: success (ok) or an error (Error-compatible). */
 interface ScriptedOutcome {
   ok?: unknown;
   error?: Error;
 }
 
 /**
- * Простейшая фейковая БД: одна попытка тела на execute(), без внутреннего
- * ретрая (как если бы SDK его не имел). Колбэк пользователя не вызывается:
- * исход ошибки полностью определяется сценарием.
+ * Simplest fake DB: one body attempt per execute(), no internal retry (as if
+ * the SDK did not have one). The user callback is not invoked: the error
+ * source is fully determined by the script.
  */
 function makeSimpleDb(
   bodyScript: (invocation: number) => ScriptedOutcome,
@@ -70,10 +70,10 @@ function makeSimpleDb(
 }
 
 /**
- * Фейковая БД с ВНУТРЕННИМ retry-циклом SDK (@ydbjs/query):
- * тело вызывается повторно для всегда-повторяемых статусов,
- * бюджет неограничен; неповторяемые ошибки заворачиваются
- * в Error('Transaction failed.', { cause }) — как в реальном SDK.
+ * Fake DB with an internal SDK retry loop (@ydbjs/query):
+ * the body is re-invoked for always-retryable statuses,
+ * budget unbounded; non-retryable errors are wrapped
+ * in an Error('Transaction failed.', { cause }) — like the real SDK.
  */
 function makeSdkLikeDb(): FakeDbResult & {
   bodyInvocations: () => number;
@@ -98,7 +98,7 @@ function makeSdkLikeDb(): FakeDbResult & {
           if (!retryable) {
             throw new Error('Transaction failed.', { cause: error });
           }
-          // SDK повторяет: новая «сессия», тот же колбэк.
+          // SDK retries: a new "session", the same callback.
           return execute(fn);
         },
       );
@@ -122,8 +122,8 @@ function recordingSleep(): { sleep: YdbRetrySleepFn; delays: number[] } {
   return { sleep, delays };
 }
 
-describe('runInTransaction({ retry }): политика применяется к транзакции (#27)', () => {
-  it('транзитные ошибки ретраятся: три открытия транзакции, задержки политики', async () => {
+describe('runInTransaction({ retry }): policy applied to the transaction (#27)', () => {
+  it('transient errors retried: three transaction opens, policy delays', async () => {
     const { sleep, delays } = recordingSleep();
     const db = makeSimpleDb((n) =>
       n < 3 ? { error: ydbErr(Code.ABORTED) } : { ok: 'done' },
@@ -140,7 +140,7 @@ describe('runInTransaction({ retry }): политика применяется �
     expect(delays).toEqual([100, 200]);
   });
 
-  it('опции транзакции (isolation/idempotent/signal) пробрасываются как раньше', async () => {
+  it('transaction options (isolation/idempotent/signal) threaded through as before', async () => {
     const { sleep } = recordingSleep();
     const db = makeSimpleDb(() => ({ ok: 1 }));
     const manager = new YdbTransactionManager(db.executor);
@@ -160,7 +160,7 @@ describe('runInTransaction({ retry }): политика применяется �
     });
   });
 
-  it('детерминированная ошибка — одна попытка, исходная ошибка как есть', async () => {
+  it('deterministic error — one attempt, original error as-is', async () => {
     const { sleep } = recordingSleep();
     const boom = ydbErr(Code.BAD_REQUEST);
     const db = makeSimpleDb(() => ({ error: boom }));
@@ -174,7 +174,7 @@ describe('runInTransaction({ retry }): политика применяется �
     expect(db.bodyInvocations()).toBe(1);
   });
 
-  it('CommitError с транзитной причиной классифицируется и ретраится', async () => {
+  it('CommitError with a transient cause is classified and retried', async () => {
     const { sleep } = recordingSleep();
     let executes = 0;
     const executor = (() => ({})) as unknown as YdbExecutor;
@@ -183,7 +183,7 @@ describe('runInTransaction({ retry }): политика применяется �
         const execute = (): Promise<unknown> => {
           executes += 1;
           if (executes === 1) {
-            // Ошибка коммита: статус ABORTED в причине (как отдаёт SDK).
+            // Commit error: ABORTED status in the cause (as returned by the SDK).
             return Promise.reject(
               new CommitError(
                 'Transaction commit failed.',
@@ -205,10 +205,10 @@ describe('runInTransaction({ retry }): политика применяется �
     expect(executes).toBe(2);
   });
 
-  it('свежее окно timeout на каждую попытку политики', async () => {
+  it('a fresh timeout window on each policy attempt', async () => {
     const { sleep } = recordingSleep();
     const seenSignals: Array<AbortSignal | undefined> = [];
-    // SDK-подобная БД вызывает колбэк пользователя (гасится политикой).
+    // SDK-like DB invokes the user callback (silenced by the policy).
     const db = makeSdkLikeDb();
     const manager = new YdbTransactionManager(db.executor);
 
@@ -224,13 +224,13 @@ describe('runInTransaction({ retry }): политика применяется �
     );
 
     expect(seenSignals).toHaveLength(2);
-    // Каждая попытка получила СВЕЖЕЕ окно таймаута (новый инстанс сигнала):
+    // Each attempt got a FRESH timeout window (a new signal instance):
     expect(seenSignals[0]).not.toBe(seenSignals[1]);
     expect(seenSignals[0]?.aborted).toBe(false);
     expect(seenSignals[1]?.aborted).toBe(false);
   });
 
-  it('валидация: retry несовместим с reuse, невалидная форма отклоняется', async () => {
+  it('validation: retry incompatible with reuse, invalid form rejected', async () => {
     const db = makeSimpleDb(() => ({ ok: 1 }));
     const manager = new YdbTransactionManager(db.executor);
 
@@ -254,7 +254,7 @@ describe('runInTransaction({ retry }): политика применяется �
     ).rejects.toThrow(/maxAttempts/);
   });
 
-  it('отмена: отменённый сигнал политики запрещает обращения к БД', async () => {
+  it('cancellation: an aborted policy signal forbids DB access', async () => {
     const { sleep } = recordingSleep();
     const controller = new AbortController();
     controller.abort(new Error('cancelled'));
@@ -269,7 +269,7 @@ describe('runInTransaction({ retry }): политика применяется �
     expect(db.transactions).toHaveLength(0);
   });
 
-  it('отмена во время backoff останавливает повтор транзакции', async () => {
+  it('cancellation during backoff stops the transaction retry', async () => {
     const controller = new AbortController();
     const sleep: YdbRetrySleepFn = () => Promise.resolve();
     const db = makeSimpleDb((n) =>
@@ -294,11 +294,12 @@ describe('runInTransaction({ retry }): политика применяется �
   });
 });
 
-describe('runInTransaction({ retry }): умножение попыток исключено', () => {
-  it('внутренний цикл SDK гасится: ровно maxAttempts исполнений тела', async () => {
+describe('runInTransaction({ retry }): attempt multiplication excluded', () => {
+  it('sdk inner loop silenced: exactly maxAttempts body executions', async () => {
     const { sleep } = recordingSleep();
-    // Тело ПАДАЕТ всегда — без гашения внутреннего неограниченного цикла SDK
-    // операция никогда бы не завершилась; тест завершается = цикл погашен.
+    // The body ALWAYS fails — without silencing the SDK's unbounded inner loop
+    // the operation would never finish; the test completing means the loop was
+    // silenced.
     const alwaysAbort = ydbErr(Code.ABORTED);
     const db = makeSdkLikeDb();
     const manager = new YdbTransactionManager(db.executor);
@@ -310,17 +311,18 @@ describe('runInTransaction({ retry }): умножение попыток иск�
       }),
     ).rejects.toBe(alwaysAbort);
 
-    // Ровно по одной РЕАЛЬНОЙ попытке тела на попытку политики (+ вытесненные
-    // защитные вызовы, не доходящие до колбэка пользователя):
+    // Exactly one REAL body attempt per policy attempt (+ superseded
+    // protective invocations that never reach the user callback):
     expect(db.executes()).toBe(3);
-    // Реальных исполнений колбэка — ровно maxAttempts:
+    // Real callback executions — exactly maxAttempts:
     expect(db.bodyInvocations()).toBe(6);
   });
 
-  it('успех после транзитной неудачи: одна попытка тела на попытку политики', async () => {
+  it('success after a transient failure: one body attempt per policy attempt', async () => {
     const { sleep } = recordingSleep();
-    // Тело падает транзитно при первом вызове — внутренний предикат SDK
-    // захочет повторить, но защитный лимит политики передаёт управление ORM.
+    // The body fails transitively on the first call — the SDK's inner
+    // predicate would retry, but the policy's protective limit hands control
+    // to the ORM.
     const db = makeSdkLikeDb();
     const manager = new YdbTransactionManager(db.executor);
 
@@ -340,15 +342,15 @@ describe('runInTransaction({ retry }): умножение попыток иск�
       ),
     ).resolves.toBe('fine');
 
-    // Ровно две реальные попытки пользователя (неудача + успех после повтора
-    // политики), каждая — в СВОЕЙ транзакции: попытки не перемножились.
+    // Exactly two real user attempts (failure + success after a policy retry),
+    // each in ITS OWN transaction: attempts did not multiply.
     expect(userCalls).toBe(2);
     expect(db.executes()).toBe(2);
   });
 });
 
-describe('контракт #98 остаётся неизменным (#27)', () => {
-  it('без опции retry тело транзакции выполняется ровно один раз', async () => {
+describe('the #98 contract remains unchanged (#27)', () => {
+  it('without the retry option the transaction body runs exactly once', async () => {
     const db = makeSimpleDb((n) =>
       n === 1 ? { error: ydbErr(Code.ABORTED) } : { ok: 'nope' },
     );
@@ -357,16 +359,16 @@ describe('контракт #98 остаётся неизменным (#27)', () 
     await expect(
       manager.runInTransaction(() => Promise.resolve('x')),
     ).rejects.toBeInstanceOf(YDBError);
-    // Ни скрытого ORM-ретрая, ни требований к пометкам запросов:
-    // повторами тела владеет только SDK (#98).
+    // Neither any hidden ORM retry nor any requirement of query markings:
+    // only the SDK owns body retries (#98).
     expect(db.bodyInvocations()).toBe(1);
     expect(db.transactions).toHaveLength(1);
   });
 
-  it('retry транзакции ретраит колбэк как целое — пометки отдельных запросов не требуются', async () => {
+  it('transaction retry retries the callback as a whole — no per-query markings needed', async () => {
     const { sleep } = recordingSleep();
-    // Внутри тела никакие .idempotent() не вызываются: контракт
-    // идемпотентности относится к КОЛБЭКУ целиком (#98), а не к запросам.
+    // No .idempotent() is called inside the body: the idempotency contract
+    // applies to the CALLBACK as a whole (#98), not to individual queries.
     const db = makeSdkLikeDb();
     const manager = new YdbTransactionManager(db.executor);
 

--- a/src/validation/validation-error.ts
+++ b/src/validation/validation-error.ts
@@ -4,9 +4,9 @@ import type {
 } from './ydb-validate.interface.js';
 
 /**
- * Приводит результат провайдера валидации к структурному виду.
- * Строки (legacy-провайдеры до #95) теряют property/constraint —
- * сохраняются только в message.
+ * Converts validation provider result to structured form.
+ * Strings (legacy providers before #95) lose property/constraint —
+ * only message is preserved.
  */
 export function normalizeValidationIssues(
   issues: YdbValidationIssue[],
@@ -25,9 +25,9 @@ function formatIssue(issue: YdbValidationErrorItem): string {
 }
 
 /**
- * Ошибка валидации сущности перед записью (#95).
- * Сохраняет структурированный список нарушений в `errors` —
- * исходное property/constraint/value не схлопываются в строку.
+ * Entity validation error before write (#95).
+ * Preserves structured list of violations in `errors` —
+ * original property/constraint/value are not collapsed into a string.
  */
 export class YdbEntityValidationError extends Error {
   readonly entityName: string;

--- a/src/validation/ydb-validate.interface.ts
+++ b/src/validation/ydb-validate.interface.ts
@@ -1,30 +1,30 @@
 /**
- * Структурированная ошибка валидации одного свойства сущности.
- * Сохраняет property/constraint для машинной обработки (например,
- * маппинга в HTTP 400) — в отличие от плоского списка строк (#95).
+ * Structured validation error for a single entity property.
+ * Preserves property/constraint for machine processing (e.g.,
+ * mapping to HTTP 400) — unlike a flat string list (#95).
  */
 export interface YdbValidationErrorItem {
-  /** Имя свойства сущности, не прошедшего валидацию (пусто — если провайдер не сообщает). */
+  /** Name of the entity property that failed validation (empty if the provider does not report it). */
   property: string;
-  /** Тип нарушения: ключ constraint (например, 'isNotEmpty', 'minLength'). */
+  /** Violation type: the constraint key (e.g. 'isNotEmpty', 'minLength'). */
   constraint: string;
-  /** Человекочитаемое сообщение об ошибке. */
+  /** Human-readable error message. */
   message: string;
-  /** Значение свойства на момент валидации (контекст; не попадает в message). */
+  /** Value of the property at validation time (context; not included in message). */
   value?: unknown;
 }
 
 /**
- * Элемент результата провайдера валидации.
- * Строка — legacy-формат (обратная совместимость с провайдерами до #95),
- * объект — структурированный формат.
+ * Validation provider result item.
+ * String — legacy format (backward compatibility with providers before #95),
+ * object — structured format.
  */
 export type YdbValidationIssue = string | YdbValidationErrorItem;
 
 export interface YdbValidationProvider {
   /**
-   * Валидирует сущность и возвращает список нарушений.
-   * Пустой массив — сущность валидна.
+   * Validates an entity and returns a list of violations.
+   * Empty array — entity is valid.
    */
   validate(entity: any): Promise<YdbValidationIssue[]>;
 }
@@ -32,12 +32,12 @@ export interface YdbValidationProvider {
 export interface YdbValidationOptions {
   groups?: string[];
   /**
-   * Пропускать проверку отсутствующих (undefined/null) свойств.
+   * Skip validation of missing (undefined/null) properties.
    *
-   * По умолчанию `false` — безопасный явный дефолт (#95): при save()
-   * нового объекта @IsNotEmpty/@IsDefined на незаполненных полях
-   * не проходят валидацию. `true` восстанавливает поведение до #95
-   * (раньше это значение было жёстко зашито).
+   * Defaults to `false` — safe explicit default (#95): on save()
+   * of a new object, @IsNotEmpty/@IsDefined on unfilled fields
+   * will fail validation. `true` restores pre-#95 behavior
+   * (this value was previously hardcoded).
    */
   skipMissingProperties?: boolean;
 }

--- a/src/validation/ydb-validate.provider.ts
+++ b/src/validation/ydb-validate.provider.ts
@@ -6,22 +6,27 @@ import type {
 } from './ydb-validate.interface.js';
 
 /**
- * Безопасный явный дефолт (#95): отсутствующие свойства валидируются.
- * Раньше здесь было жёстко зашито true — @IsNotEmpty/@IsDefined на
- * незаполненных полях молча проходили валидацию при save() нового объекта.
+ * Safe explicit default (#95): missing properties are validated.
+ * Previously this was hardcoded to true — @IsNotEmpty/@IsDefined on
+ * unfilled fields silently passed validation on save() of a new object.
  */
 const DEFAULT_SKIP_MISSING_PROPERTIES = false;
 
-/** Минимальный структурный срез ValidationError из class-validator. */
+/** Minimal structural slice of ValidationError from class-validator. */
 interface ClassValidatorErrorLike {
   property?: string;
   value?: unknown;
   constraints?: Record<string, string>;
   children?: ClassValidatorErrorLike[];
-  /** У настоящей ValidationError есть toString() с человекочитаемым текстом. */
+  /** Real ValidationError has a human-readable toString(). */
   toString?: () => string;
 }
 
+/**
+ * `YdbValidationProvider` backed by `class-validator` (optional peer
+ * dependency). Translates class-validator's `ValidationError` tree into
+ * the structured `YdbValidationErrorItem[]` format.
+ */
 export class ClassValidatorProvider implements YdbValidationProvider {
   private readonly groups?: string[];
   private readonly skipMissingProperties: boolean;
@@ -33,7 +38,7 @@ export class ClassValidatorProvider implements YdbValidationProvider {
   }
 
   async validate(entity: any): Promise<YdbValidationErrorItem[]> {
-    // class-validator — опциональный peer dependency
+    // class-validator is an optional peer dependency
     const mod = await loadOptionalPeer<{
       validate: (
         object: object,
@@ -56,8 +61,8 @@ export class ClassValidatorProvider implements YdbValidationProvider {
 }
 
 /**
- * Разворачивает дерево ValidationError в плоский список структурированных
- * ошибок: property (вложенность — через точку), constraint, message, value.
+ * Flattens a ValidationError tree into a flat list of structured
+ * errors: property (nesting via dot), constraint, message, value.
  */
 function collectIssues(
   errors: ClassValidatorErrorLike[],
@@ -90,7 +95,7 @@ function collectIssues(
       continue;
     }
 
-    // Ни constraints, ни children: аномальный формат ошибки — не теряем её
+    // Neither constraints nor children: anomalous error format — don't drop it
     if (!constraints) {
       out.push({
         property,
@@ -102,7 +107,7 @@ function collectIssues(
   }
 }
 
-/** Безопасная сериализация аномальной ошибки без constraints. */
+/** Safe serialization of an anomalous error without constraints. */
 function describeUnknownError(error: ClassValidatorErrorLike): string {
   const text = error.toString?.();
   if (typeof text === 'string') return text;


### PR DESCRIPTION
Translate all Russian source comments in `src/` to English and add missing JSDoc to public exports. No runtime behavior, public API signatures, or test assertions changed; user-facing string literals (CLI help text, error messages, fixture values) are untouched.